### PR TITLE
Small bugfix to get tutorial examples to run

### DIFF
--- a/hyperopt/ht_dist2.py
+++ b/hyperopt/ht_dist2.py
@@ -176,7 +176,7 @@ class rdist(SON):
         """
         # -- if rng is an int, use it as a seed
         try:
-            rng = numpy.RandomState(int(rng))
+            rng = numpy.random.RandomState(int(rng))
         except TypeError:
             pass
         prior = bless(copy.deepcopy(self))

--- a/hyperopt/theano_bandit_algos.py
+++ b/hyperopt/theano_bandit_algos.py
@@ -275,4 +275,3 @@ class TheanoRandom(TheanoBanditAlgo):
                     rvals[:len(rvals)/2],
                     rvals[len(rvals)/2:]))
 
-from theano_gm import GM_BanditAlgo, AdaptiveParzenGM


### PR DESCRIPTION
To get the tutorial examples to work, I had to make the following small two tweaks:
1. The numpy.RandomSeed -> numpy.random.RandomSeed is trivial, I think.
2. I removed the import line at the end of theano_bandit_algos.py:
   from theano_gm import GM_BanditAlgo, AdaptiveParzenGM

I'm not sure why it's there. Basically if it's there and I try to unpickle 'experiments.pkl' I get a complaint about not being able to import GM_BanditAlgo. 

I think it's a circular dependency issue. In ipython, running %run theano_gm.py first then %theano_bandit_algos.py second works fine. But not vice-versa.

Note that theano_gm.py does a: "from theano_bandit_algos import TheanoBanditAlgo" on line 32
but theano_bandit_algos imports from theano_gm.py on its last line.
