### PR TITLE
bugfix handling result type checking had SerialExperiment class

### DIFF
--- a/hyperopt/experiments.py
+++ b/hyperopt/experiments.py
@@ -28,7 +28,7 @@ class SerialExperiment(base.Experiment):
         for n in xrange(N):
             trial = algo.suggest(self.trials, self.results, 1)[0]
             result = bandit.evaluate(trial, base.Ctrl())
-            if not isinstance(result, (dict, base.SON)):
+            if not (hasattr(result, 'keys') and hasattr(result, 'values')):
                 raise TypeError('result should be dict-like', result)
             logger.debug('trial: %s' % str(trial))
             logger.debug('result: %s' % str(result))


### PR DESCRIPTION
previously, SerialExperiment checks for hyperopt.base.SON -- but that had two problems:

1) it was now causing a bug due to the fact that base no longer imports SON directly ... so things were crashing (test not passing &c)

2) I think the check for "dict-like" you should look for attributes like values, keys &c... not isinstance() a particular class. 

@jaberg -- let me know what you think.
