### PR TITLE
Update timer if no jobs found by mongo worker.

### DIFF
--- a/hyperopt/mongoexp.py
+++ b/hyperopt/mongoexp.py
@@ -1025,6 +1025,8 @@ class MongoWorker(object):
                         * (float(self.poll_interval) - 1.0))
                 logger.info('no job found, sleeping for %.1fs' % interval)
                 time.sleep(interval)
+                # reset timer
+                start_time = time.time()
 
         logger.debug('job found: %s' % str(job))
 


### PR DESCRIPTION
I noticed that keeping a mongo-worker running without submitting a job for a long time causes timeouts in `run_one()`. I think the cause is this logic:

``` python
       start_time = time.time()
        mj = self.mj
        while job is None:
            if (reserve_timeout
                    and (time.time() - start_time) > reserve_timeout):
                raise ReserveTimeout()
            job = mj.reserve(host_id, exp_key=self.exp_key)
            if not job:
                interval = (1 +
                        numpy.random.rand()
                        * (float(self.poll_interval) - 1.0))
                logger.info('no job found, sleeping for %.1fs' % interval)
                time.sleep(interval)
```

Essentially if there are no jobs submitted the timer just keeps on running until it times out. This PR resets the timer if no job is found to changes this behavior.
