### PR TITLE
update mongoexp.py to more recent pymongo

### DIFF
--- a/hyperopt/mongoexp.py
+++ b/hyperopt/mongoexp.py
@@ -447,7 +447,7 @@ class MongoJobs(object):
     def refresh(self, doc):
         self.update(doc, dict(refresh_time=coarse_utcnow()))
 
-    def update(self, doc, dct, collection=None):
+    def update(self, doc, dct, collection=None, do_sanity_checks=True):
         """Return union of doc and dct, after making sure that dct has been
         added to doc in `collection`.
 
@@ -491,7 +491,7 @@ class MongoJobs(object):
         # update doc in-place to match what happened on the server side
         doc.update(dct)
 
-        if True:
+        if do_sanity_checks:
             server_doc = collection.find_one(
                     dict(_id=doc['_id'], version=doc['version']))
             if server_doc is None:


### PR DESCRIPTION
Merge after #166

PyMongo has deprecated the "safe" kwarg to several calls, in favour of a new mechanism `write_concern`. This patch brings mongoexp into line with this new API.
