### PR TITLE
adding anneal pchoice tests

### DIFF
--- a/hyperopt/tests/test_pchoice.py
+++ b/hyperopt/tests/test_pchoice.py
@@ -2,7 +2,7 @@ from functools import partial
 import numpy as np
 import unittest
 from sklearn import datasets
-from hyperopt import hp, Trials, fmin, tpe, rand
+from hyperopt import hp, Trials, fmin, tpe, anneal, rand
 import hyperopt.pyll.stochastic
 
 
@@ -128,6 +128,19 @@ class TestSimpleFMin(unittest.TestCase):
         print counts
         assert counts[3] > N * .6
 
+    def test_anneal(self):
+        N = 100
+        fmin(self.objective,
+            space=self.space,
+            trials=self.trials,
+            algo=partial(anneal.suggest),
+            max_evals=N)
+
+        a_vals = [t['misc']['vals']['a'][0] for t in self.trials.trials]
+        counts = np.bincount(a_vals)
+        print counts
+        assert counts[3] > N * .6
+
 def test_bug1_rand():
     space = hp.choice('preprocess_choice', [
         {'pwhiten': hp.pchoice('whiten_randomPCA',
@@ -148,5 +161,16 @@ def test_bug1_tpe():
     best = fmin(fn=lambda x: 1,
                 space=space,
                 algo=tpe.suggest,
+                max_evals=50)
+
+def test_bug1_anneal():
+    space = hp.choice('preprocess_choice', [
+        {'pwhiten': hp.pchoice('whiten_randomPCA',
+                               [(.3, False), (.7, True)])},
+        {'palgo': False},
+        {'pthree': 7}])
+    best = fmin(fn=lambda x: 1,
+                space=space,
+                algo=anneal.suggest,
                 max_evals=50)
 


### PR DESCRIPTION
Currently anneal fails when there is a pchoice nested inside a choice. Adding a test for both the nested and non-nested cases.
