### PR TITLE
Support python3

### DIFF
--- a/hyperopt/pyll/base.py
+++ b/hyperopt/pyll/base.py
@@ -952,7 +952,10 @@ scope.define_pure(operator.getitem)
 scope.define_pure(operator.add)
 scope.define_pure(operator.sub)
 scope.define_pure(operator.mul)
-scope.define_pure(operator.div)
+try:
+    scope.define_pure(operator.div)
+except AttributeError:
+    scope.define_pure(operator.truediv)
 scope.define_pure(operator.floordiv)
 scope.define_pure(operator.neg)
 scope.define_pure(operator.eq)

--- a/hyperopt/pyll/tests/test_base.py
+++ b/hyperopt/pyll/tests/test_base.py
@@ -8,20 +8,20 @@ from hyperopt.pyll import base
 
 def test_literal_pprint():
     l = Literal(5)
-    print str(l)
+    print(str(l))
     assert str(l) == '0 Literal{5}'
 
 
 def test_literal_apply():
     l0 = Literal([1, 2, 3])
-    print str(l0)
+    print(str(l0))
     assert str(l0) == '0 Literal{[1, 2, 3]}'
 
 
 def test_literal_unpacking():
     l0 = Literal([1, 2, 3])
     a, b, c = l0
-    print a
+    print(a)
     assert c.name == 'getitem'
     assert c.pos_args[0] is l0
     assert isinstance(c.pos_args[1], Literal)
@@ -116,7 +116,7 @@ def test_dfs():
     d = {'a': 9, 'b': dd, 'y': dd, 'z': dd + 1}
     ad = as_apply(d)
     order = dfs(ad)
-    print [str(o) for o in order]
+    print([str(o) for o in order])
     assert order[0]._obj == 9
     assert order[1]._obj == 11
     assert order[2]._obj == 12
@@ -196,7 +196,7 @@ def test_bincount():
     try:
         test_f(base._bincount_slow)
         test_f(base.bincount)
-    except TypeError, e:
+    except TypeError as e:
         if 'function takes at most 2 arguments' in str(e):
             raise SkipTest()
         raise
@@ -223,19 +223,19 @@ def test_recursion():
                 p0 > 1,
                 1,
                 p0 * apply('Fact', p0 - 1))))
-    print scope.Fact(3)
-    #print rec_eval(scope.Fact(3))
+    print(scope.Fact(3))
+    #print( rec_eval(scope.Fact(3)))
     assert rec_eval(scope.Fact(3)) == 6
 
 
 def test_partial():
     add2 = scope.partial('add', 2)
-    print add2
+    print(add2)
     assert len(str(add2).split('\n')) == 3
 
     # add2 evaluates to a scope method
     thing = rec_eval(add2)
-    print thing
+    print(thing)
     assert 'SymbolTableEntry' in str(thing)
 
     # add2() evaluates to a failure because it's only a partial application
@@ -243,7 +243,7 @@ def test_partial():
 
     # add2(3) evaluates to 5 because we've filled in all the blanks
     thing = rec_eval(add2(3))
-    print thing
+    print(thing)
     assert thing == 5
 
 

--- a/hyperopt/pyll/tests/test_stochastic.py
+++ b/hyperopt/pyll/tests/test_stochastic.py
@@ -7,7 +7,7 @@ def test_recursive_set_rng_kwarg():
     a = as_apply([uniform(0, 1), uniform(2, 3)])
     rng = np.random.RandomState(234)
     recursive_set_rng_kwarg(a, rng)
-    print a
+    print(a)
     val_a = rec_eval(a)
     assert 0 < val_a[0] < 1
     assert 2 < val_a[1] < 3
@@ -29,8 +29,8 @@ def test_lnorm():
                  low=.1 / np.sqrt(10.),
                  high=10 * np.sqrt(10))
              }})
-    print lnorm
-    print 'len', len(str(lnorm))
+    print(lnorm)
+    print('len', len(str(lnorm)))
     # not sure what to assert
     # ... this is too fagile
     # assert len(str(lnorm)) == 980
@@ -38,7 +38,7 @@ def test_lnorm():
 
 def test_sample_deterministic():
     aa = as_apply([0, 1])
-    print aa
+    print(aa)
     dd = sample(aa, np.random.RandomState(3))
     assert dd == (0, 1)
 
@@ -62,7 +62,7 @@ def test_sample():
                 u = u,
                 n = scope.normal(5, 0.1),
                 l = [0, 1, scope.one_of(2, 3), u]))
-    print aa
+    print(aa)
     dd = sample(aa, np.random.RandomState(3))
     assert 0 < dd['u'] < 1
     assert 4 < dd['n'] < 6

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@
 import logging
 import os
 import re
+import sys
 
 # ----- overrides -----
 
@@ -70,7 +71,7 @@ def find_subdirectories(package):
     This will include resources (non-submodules) and submodules
     """
     try:
-        subdirectories = os.walk(package_to_path(package)).next()[1]
+        subdirectories = next(os.walk(package_to_path(package)))[1]
     except StopIteration:
         subdirectories = []
     return subdirectories
@@ -120,6 +121,10 @@ if package_data is None: package_data = find_package_data(packages)
 
 if scripts is None: scripts = find_scripts()
 
+extra = {}
+if sys.version_info >= (3,):
+    extra['use_2to3'] = True
+
 setuptools.setup(
     name = package_name,
     version = '0.0.3.dev',
@@ -142,6 +147,8 @@ setuptools.setup(
         'Operating System :: POSIX',
         'Operating System :: Unix',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
         'Topic :: Scientific/Engineering',
         'Topic :: Software Development',
     ],
@@ -156,4 +163,5 @@ setuptools.setup(
         'nose',
         'pymongo',
         'networkx']),
+    **extra
 )


### PR DESCRIPTION
It passes `nosetest hyperopt`, but I wasn't able to run `nosetest hyperopt` in py2 since I don't have a py2-scipy environment available.

One thing to note is that I had to fix the incompatibilities in `pyll` by hand because I couldn't figure out how to make `setup.py` also run `2to3` on additional packages.