### PR TITLE
Also add `truediv` to `pyll.Apply`.

### DIFF
--- a/hyperopt/pyll/base.py
+++ b/hyperopt/pyll/base.py
@@ -483,6 +483,12 @@ class Apply(object):
     def __rdiv__(self, other):
         return scope.div(other, self)
 
+    def __truediv__(self, other):
+        return scope.truediv(self, other)
+
+    def __rtruediv__(self, other):
+        return scope.truediv(other, self)
+
     def __floordiv__(self, other):
         return scope.floordiv(self, other)
 
@@ -955,7 +961,8 @@ scope.define_pure(operator.mul)
 try:
     scope.define_pure(operator.div)
 except AttributeError:
-    scope.define_pure(operator.truediv)
+    pass  # No more operator.div in Python3, but truediv also exists since Python2.2
+scope.define_pure(operator.truediv)
 scope.define_pure(operator.floordiv)
 scope.define_pure(operator.neg)
 scope.define_pure(operator.eq)


### PR DESCRIPTION
Looks like #225 wasn't the whole story, sorry! While trying the more advanced examples from the documentation using a state like:

```python
space = hp.choice('a',
    [
        ('case 1', 1 + hp.lognormal('c1', 0, 1)),
        ('case 2', hp.uniform('c2', -10, 10))
    ])
```

I encountered this error:

```
[...]
/home.local/lucas/sci-env3.4/lib/python3.4/site-packages/hyperopt-0.0.3.dev-py3.4.egg/hyperopt/tpe.py in ap_categorical_sampler(obs, prior_weight, upper, size, rng, LF)
    578     # -- add in some prior pseudocounts
    579     pseudocounts = counts + prior_weight
--> 580     return scope.categorical(pseudocounts / scope.sum(pseudocounts),
    581             upper=upper, size=size, rng=rng)
    582 

TypeError: unsupported operand type(s) for /: 'Apply' and 'Apply'
```

That's because python3 completely removed `div` and only uses `floordiv` and `truediv`. This PR implements the necessary changes. I also gave a cursory read to `tpe.py`, `rand.py` and `anneal.py` and all files of `pyll`: all uses of the `/` operator *seem* to be true divisions. But I'm just starting to use `hyperopt` so I might still be missing more things.

Additionally, since python2 also supports `truediv` since 2.2, it was a mistake (though not a regression) to only add `truediv` in the python3 case in my previous PR. I also fixed that.