### PR TITLE
Python 3.4 Compatibility

### DIFF
--- a/hyperopt/base.py
+++ b/hyperopt/base.py
@@ -621,8 +621,8 @@ class Trials(object):
         # -- Stop-gap implementation!
         #    fmin should have been a Trials method in the first place
         #    but for now it's still sitting in another file.
-        import fmin as fmin_module
-        return fmin_module.fmin(
+        from .fmin import fmin
+        return fmin(
             fn, space, algo, max_evals,
             trials=self,
             rstate=rstate,

--- a/hyperopt/base.py
+++ b/hyperopt/base.py
@@ -145,7 +145,7 @@ def SONify(arg, memo=None):
         else:
             add_arg_to_raise = False
             raise TypeError('SONify', arg)
-    except Exception, e:
+    except Exception as e:
         if add_arg_to_raise:
             e.args = e.args + (arg,)
         raise

--- a/hyperopt/pyll/base.py
+++ b/hyperopt/pyll/base.py
@@ -738,7 +738,10 @@ def clone_merge(expr, memo=None, merge_literals=False):
     # -- args are somewhat slow to construct, so cache them out front
     #    XXX node.arg does not always work (builtins, weird co_flags)
     node_args = [(node.pos_args, node.named_args) for node in nodes]
-    del node
+    try:
+        del node
+    except:
+        pass
     for ii, node_ii in enumerate(nodes):
         if node_ii in memo:
             continue

--- a/hyperopt/rdists.py
+++ b/hyperopt/rdists.py
@@ -6,7 +6,6 @@ import numpy as np
 import numpy.random as mtrand
 import scipy.stats
 from scipy.stats import rv_continuous, rv_discrete
-from scipy.stats.distributions import rv_generic
 
 
 class uniform_gen(scipy.stats.distributions.uniform_gen):


### PR DESCRIPTION
A few more Python 3.4 fixes. Mentioned some in #225. 

I see some test failure and errors, many look like they may be related to the mongodb I have installed. 

The integer division tests in `pyll/tests/test_base.py` fail though and maybe a few others that are python 3 related.
