### PR TITLE
removed obsolete import and references to old versions of scipy from rdist.py

### DIFF
--- a/hyperopt/rdists.py
+++ b/hyperopt/rdists.py
@@ -6,18 +6,6 @@ import numpy as np
 import numpy.random as mtrand
 import scipy.stats
 from scipy.stats import rv_continuous, rv_discrete
-from scipy.stats.distributions import rv_generic
-
-
-class uniform_gen(scipy.stats.distributions.uniform_gen):
-    # -- included for completeness
-    pass
-
-
-class norm_gen(scipy.stats.distributions.norm_gen):
-    # -- included for completeness
-    pass
-
 
 class loguniform_gen(rv_continuous):
     """ Stats for Y = e^X where X ~ U(low, high).


### PR DESCRIPTION
See issue [#235](a href=https://github.com/hyperopt/hyperopt/issues/235)