### PR TITLE
Dependencies should be install by `pip install hyperopt`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -140,11 +140,11 @@ setuptools.setup(
     keywords = 'Bayesian optimization hyperparameter model selection',
     package_data = package_data,
     include_package_data = True,
-    install_requires = reversed([
+    install_requires = list(reversed([
         'numpy',
         'scipy',
         'nose',
         'pymongo',
-        'networkx']),
+        'networkx'])),
     **extra
 )


### PR DESCRIPTION
I had the same problem as issue #245 

The issue was that install_requires needs a list, not an iterator as returned by `reversed`