### PR TITLE
support uniformint

### DIFF
--- a/hyperopt/hp.py
+++ b/hyperopt/hp.py
@@ -8,7 +8,9 @@ from pyll_utils import hp_randint as randint
 from pyll_utils import hp_pchoice as pchoice
 
 from pyll_utils import hp_uniform as uniform
+from pyll_utils import hp_uniformint as uniformint
 from pyll_utils import hp_quniform as quniform
+from pyll_utils import hp_quniformint as quniformint
 from pyll_utils import hp_loguniform as loguniform
 from pyll_utils import hp_qloguniform as qloguniform
 

--- a/hyperopt/pyll_utils.py
+++ b/hyperopt/pyll_utils.py
@@ -75,9 +75,8 @@ def hp_uniform(label, *args, **kwargs):
 
 @validate_label
 def hp_uniformint(label, *args, **kwargs):
-    return scope.int(
-            scope.hyperopt_param(label,
-                scope.uniform(*args, **kwargs)))
+    args += (1.0,)
+    return scope.int(hp_quniform(label, *args, **kwargs))
 
 
 @validate_label

--- a/hyperopt/pyll_utils.py
+++ b/hyperopt/pyll_utils.py
@@ -68,8 +68,22 @@ def hp_uniform(label, *args, **kwargs):
 
 
 @validate_label
+def hp_uniformint(label, *args, **kwargs):
+    return scope.int(
+            scope.hyperopt_param(label,
+                scope.uniform(*args, **kwargs)))
+
+
+@validate_label
 def hp_quniform(label, *args, **kwargs):
     return scope.float(
+            scope.hyperopt_param(label,
+                scope.quniform(*args, **kwargs)))
+
+
+@validate_label
+def hp_quniformint(label, *args, **kwargs):
+    return scope.int(
             scope.hyperopt_param(label,
                 scope.quniform(*args, **kwargs)))
 

--- a/hyperopt/tests/test_pyll_utils.py
+++ b/hyperopt/tests/test_pyll_utils.py
@@ -67,3 +67,13 @@ def test_remove_allpaths():
     assert aconds == set([(True,)]), aconds
     assert zconds == set([(True,)]), zconds
 
+
+def test_remove_allpaths_int():
+    z = hp.uniformint('z', 0, 10)
+    a = hp.choice('a', [ z + 1, z - 1])
+    hps = {}
+    expr_to_config(a, (True,), hps)
+    aconds = hps['a']['conditions']
+    zconds = hps['z']['conditions']
+    assert aconds == set([(True,)]), aconds
+    assert zconds == set([(True,)]), zconds


### PR DESCRIPTION
This PR is suggestion for supporting `uniformint` and `quniformint`
for integer hyper parameter such as `max_depth` of XGB.
(See #253 )

I know same function is achievable by using `hp.choice`, this PR can be declined.
