### PR TITLE
Fix module not callable error

### DIFF
--- a/hyperopt/base.py
+++ b/hyperopt/base.py
@@ -622,7 +622,7 @@ class Trials(object):
         #    fmin should have been a Trials method in the first place
         #    but for now it's still sitting in another file.
         import fmin as fmin_module
-        return fmin_module(
+        return fmin_module.fmin(
             fn, space, algo, max_evals,
             trials=self,
             rstate=rstate,


### PR DESCRIPTION
The current version contains a bug that will trigger a "module not callable" error when line 625 in base.py is called. Unfortunately, this bug seems to be incorporated into several releases of hyperopt on anaconda.org too. This has prevented packages such as hyperopt-sklearn from running properly.

This PR is also related to PR #244, from which we can see that the older version of the code was correct. So the bug was only recently introduced.