### PR TITLE
add future package to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -144,6 +144,6 @@ setuptools.setup(
     keywords='Bayesian optimization hyperparameter model selection',
     package_data=package_data,
     include_package_data=True,
-    install_requires=['numpy', 'scipy', 'nose', 'pymongo', 'six', 'networkx'],
+    install_requires=['numpy', 'scipy', 'nose', 'pymongo', 'six', 'networkx', 'future'],
     zip_safe=False
 )


### PR DESCRIPTION
Little patch to add `future` for python 2.x, closes #273 