### PR TITLE
Replace pickle with dill

### DIFF
--- a/hyperopt/fmin.py
+++ b/hyperopt/fmin.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from future import standard_library
 from builtins import str
 from builtins import object
-import dill
 
 import functools
 import logging
@@ -19,6 +18,13 @@ from . import base
 
 standard_library.install_aliases()
 logger = logging.getLogger(__name__)
+
+
+try:
+    import dill as pickler
+except Exception as e:
+    logger.info('Failed to load dill, try installing dill via "pip install dill" for enhanced pickling support.')
+    import six.moves.cPickle as pickler
 
 
 def fmin_pass_expr_memo_ctrl(f):
@@ -73,9 +79,9 @@ class FMinIter(object):
         if self.async:
             if 'FMinIter_Domain' in trials.attachments:
                 logger.warn('over-writing old domain trials attachment')
-            msg = dill.dumps(domain)
+            msg = pickler.dumps(domain)
             # -- sanity check for unpickling
-            dill.loads(msg)
+            pickler.loads(msg)
             trials.attachments['FMinIter_Domain'] = msg
 
     def serial_evaluate(self, N=-1):

--- a/hyperopt/fmin.py
+++ b/hyperopt/fmin.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from future import standard_library
 from builtins import str
 from builtins import object
-import six.moves.cPickle as pickle
+import dill
 
 import functools
 import logging
@@ -73,10 +73,9 @@ class FMinIter(object):
         if self.async:
             if 'FMinIter_Domain' in trials.attachments:
                 logger.warn('over-writing old domain trials attachment')
-            msg = pickle.dumps(
-                domain, protocol=self.pickle_protocol)
+            msg = dill.dumps(domain)
             # -- sanity check for unpickling
-            pickle.loads(msg)
+            dill.loads(msg)
             trials.attachments['FMinIter_Domain'] = msg
 
     def serial_evaluate(self, N=-1):

--- a/hyperopt/main.py
+++ b/hyperopt/main.py
@@ -5,12 +5,12 @@ Entry point for bin/* scripts
 """
 from __future__ import absolute_import
 from future import standard_library
-import six.moves.cPickle as pickle
 import logging
 import os
 from . import utils
 from .base import SerialExperiment
 import sys
+import dill
 
 standard_library.install_aliases()
 logger = logging.getLogger(__name__)
@@ -71,7 +71,7 @@ def main_search():
         if not options.load:
             raise IOError()
         handle = open(options.load, 'rb')
-        self = pickle.load(handle)
+        self = dill.load(handle)
         handle.close()
     except IOError:
         bandit = utils.get_obj(bandit_json, argfile=options.bandit_argfile)
@@ -84,7 +84,7 @@ def main_search():
         self.run(int(options.steps))
     finally:
         if options.save:
-            pickle.dump(self, open(options.save, 'wb'))
+            dill.dump(self, open(options.save, 'wb'))
 
 
 def main(cmd, fn_pos=1):

--- a/hyperopt/main.py
+++ b/hyperopt/main.py
@@ -10,10 +10,16 @@ import os
 from . import utils
 from .base import SerialExperiment
 import sys
-import dill
 
 standard_library.install_aliases()
 logger = logging.getLogger(__name__)
+
+
+try:
+    import dill as pickler
+except Exception as e:
+    logger.info('Failed to load dill, try installing dill via "pip install dill" for enhanced pickling support.')
+    import six.moves.cPickle as pickler
 
 __authors__ = "James Bergstra"
 __license__ = "3-clause BSD License"
@@ -71,7 +77,7 @@ def main_search():
         if not options.load:
             raise IOError()
         handle = open(options.load, 'rb')
-        self = dill.load(handle)
+        self = pickler.load(handle)
         handle.close()
     except IOError:
         bandit = utils.get_obj(bandit_json, argfile=options.bandit_argfile)
@@ -84,7 +90,7 @@ def main_search():
         self.run(int(options.steps))
     finally:
         if options.save:
-            dill.dump(self, open(options.save, 'wb'))
+            pickler.dump(self, open(options.save, 'wb'))
 
 
 def main(cmd, fn_pos=1):

--- a/hyperopt/mongoexp.py
+++ b/hyperopt/mongoexp.py
@@ -93,7 +93,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 from future import standard_library
 import copy
-import six.moves.cPickle as pickle
 # import hashlib
 import logging
 import optparse
@@ -128,6 +127,7 @@ from .utils import working_dir, temp_dir
 import six
 from six.moves import map
 from six.moves import range
+import dill
 
 __authors__ = ["James Bergstra", "Dan Yamins"]
 __license__ = "3-clause BSD License"
@@ -741,7 +741,7 @@ class MongoTrials(Trials):
                                               str(numpy.random.randint(1e8)) + '.pkl')
                     logger.error('HYPEROPT REFRESH ERROR: writing error file to %s' % reportpath)
                     _file = open(reportpath, 'w')
-                    pickle.dump({'db_data': db_data,
+                    dill.dump({'db_data': db_data,
                                  'existing_data': existing_data},
                                 _file)
                     _file.close()
@@ -1040,9 +1040,9 @@ class MongoWorker(object):
             cmd_protocol = cmd[0]
             try:
                 if cmd_protocol == 'cpickled fn':
-                    worker_fn = pickle.loads(cmd[1])
+                    worker_fn = dill.loads(cmd[1])
                 elif cmd_protocol == 'call evaluate':
-                    bandit = pickle.loads(cmd[1])
+                    bandit = dill.loads(cmd[1])
                     worker_fn = bandit.evaluate
                 elif cmd_protocol == 'token_load':
                     cmd_toks = cmd[1].split('.')
@@ -1054,14 +1054,14 @@ class MongoWorker(object):
                 elif cmd_protocol == 'driver_attachment':
                     # name = 'driver_attachment_%s' % job['exp_key']
                     blob = ctrl.trials.attachments[cmd[1]]
-                    bandit_name, bandit_args, bandit_kwargs = pickle.loads(blob)
+                    bandit_name, bandit_args, bandit_kwargs = dill.loads(blob)
                     worker_fn = json_call(bandit_name,
                                           args=bandit_args,
                                           kwargs=bandit_kwargs).evaluate
                 elif cmd_protocol == 'domain_attachment':
                     blob = ctrl.trials.attachments[cmd[1]]
                     try:
-                        domain = pickle.loads(blob)
+                        domain = dill.loads(blob)
                     except BaseException as e:
                         logger.info(
                             'Error while unpickling. Try installing dill via "pip install dill" for enhanced pickling support.')

--- a/hyperopt/mongoexp.py
+++ b/hyperopt/mongoexp.py
@@ -1064,7 +1064,7 @@ class MongoWorker(object):
                         domain = dill.loads(blob)
                     except BaseException as e:
                         logger.info(
-                            'Error while unpickling. Try installing dill via "pip install dill" for enhanced pickling support.')
+                            'Error while unpickling.')
                         raise
                     worker_fn = domain.evaluate
                 else:

--- a/hyperopt/utils.py
+++ b/hyperopt/utils.py
@@ -8,12 +8,12 @@ from past.utils import old_div
 import datetime
 import numpy as np
 import logging
-import six.moves.cPickle as pickle
 import os
 import shutil
 import numpy
 from . import pyll
 from contextlib import contextmanager
+import dill
 
 standard_library.install_aliases()
 logger = logging.getLogger(__name__)
@@ -85,7 +85,7 @@ def get_obj(f, argfile=None, argstr=None, args=(), kwargs=None):
     if argfile is not None:
         argstr = open(argfile).read()
     if argstr is not None:
-        argd = pickle.loads(argstr)
+        argd = dill.loads(argstr)
     else:
         argd = {}
     args = args + argd.get('args', ())

--- a/hyperopt/utils.py
+++ b/hyperopt/utils.py
@@ -13,10 +13,15 @@ import shutil
 import numpy
 from . import pyll
 from contextlib import contextmanager
-import dill
 
 standard_library.install_aliases()
 logger = logging.getLogger(__name__)
+
+try:
+    import dill as pickler
+except Exception as e:
+    logger.info('Failed to load dill, try installing dill via "pip install dill" for enhanced pickling support.')
+    import six.moves.cPickle as pickler
 
 
 def import_tokens(tokens):
@@ -85,7 +90,7 @@ def get_obj(f, argfile=None, argstr=None, args=(), kwargs=None):
     if argfile is not None:
         argstr = open(argfile).read()
     if argstr is not None:
-        argd = dill.loads(argstr)
+        argd = pickler.loads(argstr)
     else:
         argd = {}
     args = args + argd.get('args', ())

--- a/setup.py
+++ b/setup.py
@@ -144,6 +144,6 @@ setuptools.setup(
     keywords='Bayesian optimization hyperparameter model selection',
     package_data=package_data,
     include_package_data=True,
-    install_requires=['numpy', 'scipy', 'nose', 'pymongo', 'six', 'networkx', 'future'],
+    install_requires=['numpy', 'scipy', 'nose', 'pymongo', 'six', 'dill', 'networkx', 'future'],
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -144,6 +144,9 @@ setuptools.setup(
     keywords='Bayesian optimization hyperparameter model selection',
     package_data=package_data,
     include_package_data=True,
-    install_requires=['numpy', 'scipy', 'nose', 'pymongo', 'six', 'dill', 'networkx', 'future'],
+    install_requires=['numpy', 'scipy', 'nose', 'pymongo', 'six', 'networkx', 'future'],
+    extras_require={
+        'dill': 'dill'
+    },
     zip_safe=False
 )


### PR DESCRIPTION
Dill is better at pickling (among other things) functions than pickle

Pickle is bad at pickling functions. In fact in order to pickle a function one is forced to resolve to some hack (e.g. creating a class with a `__call__` property), whereas dill can pickle the function effortlessly.

This PR makes it much less tedious to write objective functions to pass into mongoExp.
