### PR TITLE
Update toposort to work with networkx 2.0

### DIFF
--- a/hyperopt/pyll/base.py
+++ b/hyperopt/pyll/base.py
@@ -703,7 +703,7 @@ def dfs(aa, seq=None, seqset=None):
 
 def toposort(expr):
     """
-    Return apply nodes of `expr` sub-tree in topological order.
+    Return apply nodes of `expr` sub-tree as a list in topological order.
 
     Raises networkx.NetworkXUnfeasible if subtree contains cycle.
 
@@ -711,7 +711,7 @@ def toposort(expr):
     G = nx.DiGraph()
     for node in dfs(expr):
         G.add_edges_from([(n_in, node) for n_in in node.inputs()])
-    order = nx.topological_sort(G)
+    order = list(nx.topological_sort(G))
     assert order[-1] == expr
     return order
 


### PR DESCRIPTION
Fixes #318 - networkx have changed their interface to return a generator rather than a list, so the assertion was failing when it indexed the list. Create a list before returning - this keeps the toposort interface consistent. Also documented that toposort returns a list.