### PR TITLE
do not log the MongoDB password in plain text

### DIFF
--- a/hyperopt/mongoexp.py
+++ b/hyperopt/mongoexp.py
@@ -222,7 +222,8 @@ def parse_url(url, pwfile=None):
             password = None
     else:
         password = tmp.password
-    logger.info('PASS ***')
+    if password is not None:
+        logger.info('PASS ***')
     port = int(float(tmp.port))  # port has to be casted explicitly here.
 
     return (protocol, tmp.username, password, tmp.hostname, port, dbname, collection, authdbname)

--- a/hyperopt/mongoexp.py
+++ b/hyperopt/mongoexp.py
@@ -222,7 +222,7 @@ def parse_url(url, pwfile=None):
             password = None
     else:
         password = tmp.password
-    logger.info('PASS %s' % password)
+    logger.info('PASS ***')
     port = int(float(tmp.port))  # port has to be casted explicitly here.
 
     return (protocol, tmp.username, password, tmp.hostname, port, dbname, collection, authdbname)


### PR DESCRIPTION
I think from a security point of view it makes sense to not log the password in plain text.