### PR TITLE
Function for adding custom starting points to be evaluated for fmin()

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/hyperopt/tests/test_tools.py
+++ b/hyperopt/tests/test_tools.py
@@ -1,16 +1,19 @@
+import unittest
+
 from hyperopt import fmin, tpe, hp
 from hyperopt.tools import generate_trials_to_calculate
-import unittest
+
 
 class TestGenerateTrialsToCalculate(unittest.TestCase):
     def test_generate_trials_to_calculate(self):
         points = [{'x': 0.0, 'y': 0.0}, {'x': 1.0, 'y': 1.0}]
         trials = generate_trials_to_calculate(points)
-        best = fmin(fn=lambda space: space['x']**2 + space['y']**2,
+        best = fmin(fn=lambda space: space['x'] ** 2 + space['y'] ** 2,
                     space={'x': hp.uniform('x', -10, 10),
                            'y': hp.uniform('y', -10, 10)},
                     algo=tpe.suggest,
                     max_evals=10,
                     trials=trials,
                     )
-        assert best['x'] == 0.0 and best['y'] == 0.0
+        assert best['x'] == 0.0
+        assert best['y'] == 0.0

--- a/hyperopt/tests/test_tools.py
+++ b/hyperopt/tests/test_tools.py
@@ -1,0 +1,16 @@
+from hyperopt import fmin, tpe, hp
+from hyperopt.tools import generate_trials_to_calculate
+import unittest
+
+class TestGenerateTrialsToCalculate(unittest.TestCase):
+    def test_generate_trials_to_calculate(self):
+        points = [{'x': 0.0, 'y': 0.0}, {'x': 1.0, 'y': 1.0}]
+        trials = generate_trials_to_calculate(points)
+        best = fmin(fn=lambda space: space['x']**2 + space['y']**2,
+                    space={'x': hp.uniform('x', -10, 10),
+                           'y': hp.uniform('y', -10, 10)},
+                    algo=tpe.suggest,
+                    max_evals=10,
+                    trials=trials,
+                    )
+        assert best['x'] == 0.0 and best['y'] == 0.0

--- a/hyperopt/tools.py
+++ b/hyperopt/tools.py
@@ -1,0 +1,45 @@
+from hyperopt.base import Trials, JOB_STATE_NEW
+
+def _generate_trial(tid, space):
+    variables = space.keys()
+    idxs = dict([(v, [tid]) for v in variables])
+    vals = dict([(k, [v]) for k, v in space.items()])
+    return {'state': JOB_STATE_NEW,
+           'tid': tid,
+           'spec': None,
+           'result': {'status': 'new'},
+           'misc': {'tid': tid,
+                    'cmd': ('domain_attachment',
+                            'FMinIter_Domain'),
+                    'workdir': None,
+                    'idxs': idxs,
+                    'vals': vals},
+           'exp_key': None,
+           'owner': None,
+           'version': 0,
+           'book_time': None,
+           'refresh_time': None,
+           }
+
+def generate_trials_to_calculate(points):
+    """
+    :param points: List of points to be inserted in trials object in form of
+                    dictionary with variable names as keys and variable values
+                     as dict values. Example code:
+
+    points = [{'x': 0.0, 'y': 0.0}, {'x': 1.0, 'y': 1.0}]
+    trials = generate_trials_to_calculate(points)
+    best = fmin(fn=lambda space: space['x']**2 + space['y']**2,
+                space={'x': hp.uniform('x', -10, 10),
+                       'y': hp.uniform('y', -10, 10)},
+                algo=tpe.suggest,
+                max_evals=10,
+                trials=trials,
+                )
+    :return: object of class base.Trials() with points which will be calculated
+                before optimisation start if passed to fmin().
+    """
+    trials = Trials()
+    new_trials = [_generate_trial(tid, x) for tid, x in enumerate(points)]
+    trials.insert_trial_docs(new_trials)
+    return trials

--- a/hyperopt/tools.py
+++ b/hyperopt/tools.py
@@ -1,25 +1,27 @@
 from hyperopt.base import Trials, JOB_STATE_NEW
 
+
 def _generate_trial(tid, space):
     variables = space.keys()
-    idxs = dict([(v, [tid]) for v in variables])
-    vals = dict([(k, [v]) for k, v in space.items()])
+    idxs = {v: [tid] for v in variables}
+    vals = {k: [v] for k, v in space.items()}
     return {'state': JOB_STATE_NEW,
-           'tid': tid,
-           'spec': None,
-           'result': {'status': 'new'},
-           'misc': {'tid': tid,
-                    'cmd': ('domain_attachment',
-                            'FMinIter_Domain'),
-                    'workdir': None,
-                    'idxs': idxs,
-                    'vals': vals},
-           'exp_key': None,
-           'owner': None,
-           'version': 0,
-           'book_time': None,
-           'refresh_time': None,
-           }
+            'tid': tid,
+            'spec': None,
+            'result': {'status': 'new'},
+            'misc': {'tid': tid,
+                     'cmd': ('domain_attachment',
+                             'FMinIter_Domain'),
+                     'workdir': None,
+                     'idxs': idxs,
+                     'vals': vals},
+            'exp_key': None,
+            'owner': None,
+            'version': 0,
+            'book_time': None,
+            'refresh_time': None,
+            }
+
 
 def generate_trials_to_calculate(points):
     """


### PR DESCRIPTION
My pull request implements requests from issues #401 #395 . I have written a function to prepare Trials() object with custom hyperparameter points to evaluate at the beginning of the optimisation with fmin().

This function is the most non-invasive way to implement this idea but I can modify fmin() itself if you prefer this way.