### PR TITLE
small fix for example of saving dot file

### DIFF
--- a/hyperopt/graphviz.py
+++ b/hyperopt/graphviz.py
@@ -25,7 +25,7 @@ def dot_hyperparameters(expr):
     in an ancestral sampling process.
 
     E.g.:
-    >>> open('foo.dot', 'wb').write(dot_hyperparameters(search_space()))
+    >>> open('foo.dot', 'w').write(dot_hyperparameters(search_space()))
 
     Then later from the shell, type e.g.
     dot -Tpng foo.dot > foo.png && eog foo.png


### PR DESCRIPTION
The example has a small bug:
`>>> open('foo.dot', 'wb').write(dot_hyperparameters(search_space()))`
The mode should not be 'wb' since it is a string that gets written.
This is right:
`>>> open('foo.dot', 'w').write(dot_hyperparameters(search_space()))`