### PR TITLE
Change fmin to return the best parameter values if return_argmin is False

### DIFF
--- a/hyperopt/fmin.py
+++ b/hyperopt/fmin.py
@@ -362,13 +362,11 @@ def fmin(fn, space, algo, max_evals, trials=None, rstate=None,
     Returns
     -------
 
-    argmin : None or dictionary
-        If `return_argmin` is False, this function returns nothing.
-        Otherwise, it returns `trials.argmin`.  This argmin can be converted
-        to a point in the configuration space by calling
-        `hyperopt.space_eval(space, best_vals)`.
-
-
+    argmin : dictionary
+        If return_argmin is True returns `trials.argmin` which is a dictionary.  Otherwise
+        this function  returns the result of `hyperopt.space_eval(space, trails.argmin)` if there
+        were succesfull trails. This object shares the same structure as the space passed.
+        If there were no succesfull trails, it returns None.
     """
     if rstate is None:
         env_rseed = os.environ.get('HYPEROPT_FMIN_SEED', '')
@@ -409,6 +407,11 @@ def fmin(fn, space, algo, max_evals, trials=None, rstate=None,
     rval.exhaust()
     if return_argmin:
         return trials.argmin
+    elif len(trials) > 0:
+        # Only if there are some succesfull trail runs, return the best point in the evaluation space
+        return space_eval(space, trials.argmin)
+    else:
+        return None
 
 
 def space_eval(space, hp_assignment):

--- a/hyperopt/tests/test_fmin.py
+++ b/hyperopt/tests/test_fmin.py
@@ -110,6 +110,35 @@ def test_set_fmin_rstate():
     assert argmin_seed0 != argmin_seed1
 
 
+def test_fmin_return_argmin():
+    fn = lambda x: x
+    space = hp.choice('x', [100, 5, 10])
+
+    # With return_argmin=False it should return the
+    # best parameter values
+    best_parameter = fmin(
+        fn=fn,
+        space=space,
+        max_evals=10,
+        algo=rand.suggest,
+        return_argmin=False,
+        rstate=np.random.RandomState(0)
+    )
+    assert best_parameter == 5
+
+    # With return_argmin=True it should return the
+    # optimal point in ths sample space
+    best_args = fmin(
+        fn=fn,
+        space=space,
+        max_evals=10,
+        algo=rand.suggest,
+        return_argmin=True,
+        rstate=np.random.RandomState(0)
+    )
+    assert best_args['x'] == 1
+
+
 class TestFmin(unittest.TestCase):
 
     class SomeError(Exception):


### PR DESCRIPTION
This PR adds support for returning the actual values that led to the optimal solution instead of the optimal arguments of the space. This is done by making `fmin` return the result of `hyperopt.space_eval` instead of `None` when the `return_argmin` argument to `fmin` is set to `False`.

This resolves #412, #431, #458.