### PR TITLE
Fix test failure on python 2.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *,cover
+
+# IDE
+.idea/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,6 @@ install:
   - python setup.py install
   - pip install pytest>=3.6 pytest-cov pep8 pytest-pep8
 script:
-  - python -m pytest
+  - nosetests
 after_success:
   - coveralls


### PR DESCRIPTION
The travis runtime for python 2.7 cannot install pytest>=3.6.0 version, so failure happens.

I change it into `nosetests`. and it works fine.