### PR TITLE
Catch ValueError exceptions in addition to AttributeErrors in use_obj…

### DIFF
--- a/hyperopt/utils.py
+++ b/hyperopt/utils.py
@@ -168,7 +168,7 @@ def use_obj_for_literal_in_memo(expr, obj, lit, memo):
         try:
             if node.obj == lit:
                 memo[node] = obj
-        except AttributeError:
+        except (AttributeError, ValueError) as e:
             # -- non-literal nodes don't have node.obj
             pass
     return memo


### PR DESCRIPTION
…_for_literal_in_memo

Some complex datatypes (passed in as parameters to fmin) cannot be compared with == and we get an error such as: 
if node.obj == lit:
   ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
If we catch ValueErrors in addition to AttributeErrors, it resolves this problem.