### PR TITLE
Fix missing isatty() method of DummyTqdmFile

### DIFF
--- a/hyperopt/std_out_err_redirect_tqdm.py
+++ b/hyperopt/std_out_err_redirect_tqdm.py
@@ -21,6 +21,10 @@ class DummyTqdmFile(object):
     def flush(self):
         return getattr(self.file, "flush", lambda: None)()
 
+    def isatty(self):
+        return getattr(self.file, "isatty", lambda: False)()
+
+
 @contextlib.contextmanager
 def std_out_err_redirect_tqdm():
     orig_out_err = sys.stdout, sys.stderr


### PR DESCRIPTION
When using hyperopt and calling `sys.stdout.isatty()`, it will fail with an AttributeError. This adds the missing method to `DummyTqdmFile`.