### PR TITLE
Meaningful exception for all optimization trials failed

### DIFF
--- a/hyperopt/base.py
+++ b/hyperopt/base.py
@@ -44,8 +44,8 @@ except ImportError:
 from . import pyll
 from .pyll.stochastic import recursive_set_rng_kwarg
 
-from .exceptions import (
-    DuplicateLabel, InvalidTrial, InvalidResultStatus, InvalidLoss)
+from .exceptions import (DuplicateLabel, InvalidTrial, InvalidResultStatus,
+                         InvalidLoss, AllTrialsFailed)
 from .utils import pmin_sampled
 from .utils import use_obj_for_literal_in_memo
 from .vectorize import VectorizeHelper
@@ -580,6 +580,8 @@ class Trials(object):
         """
         candidates = [t for t in self.trials
                       if t['result']['status'] == STATUS_OK]
+        if not candidates:
+            raise AllTrialsFailed
         losses = [float(t['result']['loss']) for t in candidates]
         assert not np.any(np.isnan(losses))
         best = np.argmin(losses)

--- a/hyperopt/exceptions.py
+++ b/hyperopt/exceptions.py
@@ -31,4 +31,8 @@ class InvalidLoss(ValueError):
         ValueError.__init__(self)
         self.result = result
 
+
+class AllTrialsFailed(Exception):
+    """All optimization steps have finished with status base.STATUS_FAIL"""
+
 # -- flake8 doesn't like blank last line


### PR DESCRIPTION
When all optimization trials fail with status `base.STATUS_FAIL`, the code fails with "ValueError: attempt to get argmin of an empty sequence". This PR replaces the error with more meaningful exception, that is easier to catch and recognize.

**Example:**
```python
def objective(x):
    return {'status': STATUS_FAIL}

trials = Trials()
best = fmin(objective,
    space=hp.uniform('x', -10, 10),
    algo=tpe.suggest,
    max_evals=100,
    trials=trials)
```