### PR TITLE
Add SparkTrials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ coverage.xml
 # IDE
 .idea/
 
+# MacOS
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,25 +7,25 @@ cache:
     - $HOME/.cache/spark-versions
 
 env:
-   global:
-      - HYPEROPT_FMIN_SEED=3
-      - SPARK_VERSION=2.4.3
-      - SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.6"
-      - SPARK_BUILD_URL="https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/${SPARK_BUILD}.tgz"
-      - SPARK_HOME=$HOME/.cache/spark-versions/${SPARK_BUILD}
-      - RUN_ONLY_LIGHT_TESTS=True
-      - NUMPY_VERSION=1.14.3
+  global:
+    - HYPEROPT_FMIN_SEED=3
+    - SPARK_VERSION=2.4.4
+    - SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
+    - SPARK_BUILD_URL="https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/${SPARK_BUILD}.tgz"
+    - SPARK_HOME=$HOME/.cache/spark-versions/${SPARK_BUILD}
+    - RUN_ONLY_LIGHT_TESTS=True
+    - NUMPY_VERSION=1.14.3
 matrix:
-   include:
-      - python: 2.7
-        env:
-          - IPYTHON="ipython[all]==5.4.1"
-      - python: 3.5
-        env:
-          - IPYTHON=ipython[all]
-      - python: 3.6
-        env:
-          - IPYTHON=ipython[all]
+  include:
+    - python: 2.7
+      env:
+        - IPYTHON="ipython[all]==5.4.1"
+    - python: 3.5
+      env:
+        - IPYTHON=ipython[all]
+    - python: 3.6
+      env:
+        - IPYTHON=ipython[all]
 
 services:
   - mongodb
@@ -35,7 +35,7 @@ before_script:
   - mongo mydb_test --eval 'db.createUser({user:"travis",pwd:"test",roles:["readWrite"]});'
 
 before_install:
- - ./download_spark_dependencies.sh
+  - ./download_spark_dependencies.sh
 
 install:
   - sudo apt-get remove ipython

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,31 @@
 dist: trusty
+
 language: python
 
+cache:
+  directories:
+    - $HOME/.cache/spark-versions
+
+env:
+   global:
+      - HYPEROPT_FMIN_SEED=3
+      - SPARK_VERSION=2.4.3
+      - SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.6"
+      - SPARK_BUILD_URL="https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/${SPARK_BUILD}.tgz"
+      - SPARK_HOME=$HOME/.cache/spark-versions/${SPARK_BUILD}
+      - RUN_ONLY_LIGHT_TESTS=True
+      - NUMPY_VERSION=1.14.3
 matrix:
    include:
       - python: 2.7
         env:
-          - IPYTHON="ipython[all]==5.4.1" HYPEROPT_FMIN_SEED=3
+          - IPYTHON="ipython[all]==5.4.1"
       - python: 3.5
         env:
-          - IPYTHON=ipython[all] HYPEROPT_FMIN_SEED=3
+          - IPYTHON=ipython[all]
+      - python: 3.6
+        env:
+          - IPYTHON=ipython[all]
 
 services:
   - mongodb
@@ -17,16 +34,20 @@ before_script:
   - sleep 15  # mongo takes time to start
   - mongo mydb_test --eval 'db.createUser({user:"travis",pwd:"test",roles:["readWrite"]});'
 
+before_install:
+ - ./download_spark_dependencies.sh
+
 install:
   - sudo apt-get remove ipython
   - pip install --upgrade pip
   - pip install --upgrade setuptools
   - pip install --upgrade wheel
   - pip install $IPYTHON
-  - pip install --only-binary=numpy,scipy numpy scipy
+  - pip install --only-binary=numpy,scipy numpy==$NUMPY_VERSION scipy
   - python setup.py install
   - pip install pytest>=3.6 pytest-cov pep8 pytest-pep8
+  - pip install wrapt
 script:
-  - nosetests
+  - ./run_tests.sh
 after_success:
   - coveralls

--- a/download_spark_dependencies.sh
+++ b/download_spark_dependencies.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+echo "Downloading Spark if necessary"
+echo "Spark version = $SPARK_VERSION"
+echo "Spark build = $SPARK_BUILD"
+echo "Spark build URL = $SPARK_BUILD_URL"
+
+sparkVersionsDir="$HOME/.cache/spark-versions"
+mkdir -p "$sparkVersionsDir"
+SPARK_BUILD_DIR="$sparkVersionsDir/$SPARK_BUILD"
+
+if [[ -d "$SPARK_BUILD_DIR" ]]; then
+    echo "Skipping download - found Spark dir $SPARK_BUILD_DIR"
+else
+    echo "Missing $SPARK_BUILD_DIR, downloading archive"
+    filename="$HOME/.cache/spark-versions/$SPARK_BUILD.tgz"
+
+    if ! [[ -d "$SPARK_BUILD_DIR" ]]; then
+            echo "Downloading $SPARK_BUILD_URL ..."
+            wget "$SPARK_BUILD_URL" -O $filename
+            echo "[Debug] Following should list a valid spark binary"
+            ls -larth $HOME/.cache/spark-versions/*
+            tar -xzf $filename --directory $HOME/.cache/spark-versions > /dev/null
+    fi
+
+    echo "Content of $SPARK_BUILD_DIR:"
+    ls -la "$SPARK_BUILD_DIR"
+fi
+

--- a/hyperopt/__init__.py
+++ b/hyperopt/__init__.py
@@ -36,4 +36,7 @@ from . import tpe
 from . import mix
 from . import anneal
 
+# -- spark extension
+from .spark import SparkTrials
+
 __version__ = '0.2'

--- a/hyperopt/base.py
+++ b/hyperopt/base.py
@@ -93,6 +93,10 @@ JOB_STATES = [
     JOB_STATE_DONE,
     JOB_STATE_ERROR,
     JOB_STATE_CANCEL]
+JOB_VALID_STATES = {
+    JOB_STATE_NEW,
+    JOB_STATE_RUNNING,
+    JOB_STATE_DONE}
 
 
 TRIAL_KEYS = [
@@ -334,15 +338,14 @@ class Trials(object):
 
     def refresh(self):
         # In MongoTrials, this method fetches from database
-        valid_states = [JOB_STATE_NEW, JOB_STATE_RUNNING, JOB_STATE_DONE]
         if self._exp_key is None:
             self._trials = [
                 tt for tt in self._dynamic_trials
-                if tt['state'] in valid_states]
+                if tt['state'] in JOB_VALID_STATES]
         else:
             self._trials = [tt
                             for tt in self._dynamic_trials
-                            if (tt['state'] in valid_states and tt['exp_key'] == self._exp_key)]
+                            if (tt['state'] in JOB_VALID_STATES and tt['exp_key'] == self._exp_key)]
         self._ids.update([tt['tid'] for tt in self._trials])
 
     @property

--- a/hyperopt/fmin.py
+++ b/hyperopt/fmin.py
@@ -23,9 +23,9 @@ logger = logging.getLogger(__name__)
 
 
 try:
-    import dill as pickler
+    import cloudpickle as pickler
 except Exception as e:
-    logger.info('Failed to load dill, try installing dill via "pip install dill" for enhanced pickling support.')
+    logger.info('Failed to load cloudpickle, try installing cloudpickle via "pip install cloudpickle" for enhanced pickling support.')
     import six.moves.cPickle as pickler
 
 
@@ -159,6 +159,16 @@ class FMinIter(object):
                     break
         self.trials.refresh()
 
+    @property
+    def is_cancelled(self):
+        """
+        Indicates whether this fmin run has been cancelled.  SparkTrials supports cancellation.
+        """
+        if hasattr(self.trials, "_fmin_cancelled"):
+            if self.trials._fmin_cancelled:
+                return True
+        return False
+
     def block_until_done(self):
         already_printed = False
         if self.asynchronous:
@@ -199,7 +209,8 @@ class FMinIter(object):
                       ) as pbar:
                 while n_queued < N:
                     qlen = get_queue_len()
-                    while qlen < self.max_queue_len and n_queued < N:
+                    while qlen < self.max_queue_len and n_queued < N and \
+                            not self.is_cancelled:
                         n_to_enqueue = min(self.max_queue_len - qlen, N - n_queued)
                         new_ids = trials.new_trial_ids(n_to_enqueue)
                         self.trials.refresh()
@@ -219,6 +230,9 @@ class FMinIter(object):
                             stopped = True
                             break
 
+                    if self.is_cancelled:
+                        break
+
                     if self.asynchronous:
                         # -- wait for workers to fill in the trials
                         time.sleep(self.poll_interval_secs)
@@ -237,7 +251,7 @@ class FMinIter(object):
 
                     if stopped:
                         break
-        
+
         if block_until_done:
             self.block_until_done()
             self.trials.refresh()
@@ -350,10 +364,10 @@ def fmin(fn, space, algo, max_evals, trials=None, rstate=None,
         Elements of this list must be in a form of a dictionary with variable
         names as keys and variable values as dict values. Example
         points_to_evaluate value is [{'x': 0.0, 'y': 0.0}, {'x': 1.0, 'y': 2.0}]
-        
+
     max_queue_len : integer, default 1
-        Sets the queue length generated in the dictionary or trials. Increasing this 
-        value helps to slightly speed up parallel simulatulations which sometimes lag 
+        Sets the queue length generated in the dictionary or trials. Increasing this
+        value helps to slightly speed up parallel simulatulations which sometimes lag
         on suggesting a new trial.
 
     show_progressbar : bool, default True
@@ -407,6 +421,8 @@ def fmin(fn, space, algo, max_evals, trials=None, rstate=None,
     rval.catch_eval_exceptions = catch_eval_exceptions
     rval.exhaust()
     if return_argmin:
+        if len(trials.trials) == 0:
+            raise Exception("There are no evaluation tasks, cannot return argmin of task losses.")
         return trials.argmin
     elif len(trials) > 0:
         # Only if there are some succesfull trail runs, return the best point in the evaluation space

--- a/hyperopt/main.py
+++ b/hyperopt/main.py
@@ -16,9 +16,9 @@ logger = logging.getLogger(__name__)
 
 
 try:
-    import dill as pickler
+    import cloudpickle as pickler
 except Exception as e:
-    logger.info('Failed to load dill, try installing dill via "pip install dill" for enhanced pickling support.')
+    logger.info('Failed to load cloudpickle, try installing cloudpickle via "pip install cloudpickle" for enhanced pickling support.')
     import six.moves.cPickle as pickler
 
 __authors__ = "James Bergstra"

--- a/hyperopt/mongoexp.py
+++ b/hyperopt/mongoexp.py
@@ -136,9 +136,9 @@ standard_library.install_aliases()
 logger = logging.getLogger(__name__)
 
 try:
-    import dill as pickler
+    import cloudpickle as pickler
 except Exception as e:
-    logger.info('Failed to load dill, try installing dill via "pip install dill" for enhanced pickling support.')
+    logger.info('Failed to load cloudpickle, try installing cloudpickle via "pip install cloudpickle" for enhanced pickling support.')
     import six.moves.cPickle as pickler
 
 

--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -1,0 +1,415 @@
+from __future__ import print_function
+import numbers
+import threading
+import time
+import timeit
+
+import cloudpickle
+
+from hyperopt import base, fmin, Trials
+from hyperopt.utils import coarse_utcnow, _get_logger, _get_random_id
+from pyspark.sql import SparkSession
+
+
+logger = _get_logger('hyperopt-spark')
+
+
+class SparkTrials(Trials):
+    """
+    Implementation of hyperopt.Trials supporting
+    distributed execution using Apache Spark clusters.
+    This requires fmin to be run on a Spark cluster.
+
+    Plugging SparkTrials into hyperopt.fmin() allows hyperopt
+    to send model training and evaluation tasks to Spark workers,
+    parallelizing hyperparameter search.
+    Each trial (set of hyperparameter values) is handled within
+    a single Spark task; i.e., each model will be fit and evaluated
+    on a single worker machine.  Trials are run asynchronously.
+
+    See hyperopt.Trials docs for general information about Trials.
+
+    The fields we store in our trial docs match the base Trials class.  The fields include:
+     - 'tid': trial ID
+     - 'state': JOB_STATE_DONE, JOB_STATE_ERROR, etc.
+     - 'result': evaluation result for completed trial run
+     - 'refresh_time': timestamp for last status update
+     - 'misc': includes:
+        - 'error': (error type, error message)
+     - 'book_time': timestamp for trial run start
+    """
+
+    asynchronous = True
+
+    # Hard cap on the number of concurrent hyperopt tasks (Spark jobs) to run. Set at 128.
+    MAX_CONCURRENT_JOBS_ALLOWED = 128
+
+    def __init__(self, parallelism=None, timeout=None, spark_session=None):
+        """
+        :param parallelism: Maximum number of parallel trials to run,
+                            i.e., maximum number of concurrent Spark tasks.
+                            If set to None or and invalid value, this will be set to the number of
+                            executors in your Spark cluster.
+                            Hard cap at `MAX_CONCURRENT_JOBS_ALLOWED`.
+                            Default: None (= number of Spark executors).
+        :param timeout: Maximum time (in seconds) which fmin is allowed to take.
+                        If this timeout is hit, then fmin will cancel running and proposed trials.
+                        It will retain all completed trial runs and return the best result found
+                        so far.
+        :param spark_session: A SparkSession object. If None is passed, SparkTrials will attempt
+                              to use an existing SparkSession or create a new one. SparkSession is
+                              the entry point for various facilities provided by Spark. For more
+                              information, visit the documentation for PySpark.
+        """
+        super(SparkTrials, self).__init__(exp_key=None, refresh=False)
+        self._spark_context = SparkSession.builder.getOrCreate().sparkContext if spark_session is None \
+                                  else spark_session.sparkContext
+        # The feature to support controlling jobGroupIds is in SPARK-22340
+        self._spark_supports_job_cancelling = hasattr(self._spark_context.parallelize([1]),
+                                                      "collectWithJobGroup")
+        # maxNumConcurrentTasks() is a package private API
+        max_num_concurrent_tasks = self._spark_context._jsc.sc().maxNumConcurrentTasks()
+        self.parallelism = self._decide_parallelism(max_num_concurrent_tasks, parallelism)
+        self.user_specified_parallelism = parallelism
+
+        if timeout is not None and (not isinstance(timeout, numbers.Number) or timeout <= 0):
+            raise Exception("timeout argument should be None or a positive value.")
+        if not self._spark_supports_job_cancelling and timeout is not None:
+            logger.warning(
+                "SparkTrials was constructed with a timeout specified, but this Apache "
+                "Spark version does not support job group-based cancellation. The timeout will be "
+                "respected when starting new Spark jobs, but SparkTrials will not be able to "
+                "cancel running Spark jobs which exceed the timeout.")
+
+        self.timeout = timeout
+        self._fmin_cancelled = False
+        self._fmin_cancelled_reason = None
+        self.refresh()
+
+    @staticmethod
+    def _decide_parallelism(max_num_concurrent_tasks, parallelism):
+        """
+        Given the user-set value of parallelism, return the value SparkTrials will actually use.
+        See the docstring for `parallelism` in the constructor for expected behavior.
+        """
+        if max_num_concurrent_tasks == 0:
+            raise Exception("There are no available spark executors.  "
+                            "Add workers to your Spark cluster to use SparkTrials.")
+        if parallelism is None:
+            parallelism = max_num_concurrent_tasks
+        elif parallelism <= 0:
+            logger.warning("User-specified parallelism was invalid value ({p}), so parallelism will"
+                           " be set to max_num_concurrent_tasks ({c})."
+                           .format(p=parallelism, c=max_num_concurrent_tasks))
+            parallelism = max_num_concurrent_tasks
+        elif parallelism > max_num_concurrent_tasks:
+            logger.warning("User-specified parallelism ({p}) is greater than "
+                           "max_num_concurrent_tasks ({c}), so parallelism will be set to "
+                           "max_num_concurrent_tasks."
+                           .format(p=parallelism, c=max_num_concurrent_tasks))
+            parallelism = max_num_concurrent_tasks
+        if parallelism > SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED:
+            logger.warning("Parallelism ({p}) is being decreased to the hard cap of "
+                           "SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED ({c})"
+                           .format(p=parallelism, c=SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED))
+            parallelism = SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED
+        return parallelism
+
+    def count_successful_trials(self):
+        """
+        Returns the current number of trials which ran successfully
+        """
+        return self.count_by_state_unsynced(base.JOB_STATE_DONE)
+
+    def count_failed_trials(self):
+        """
+        Returns the current number of trial runs which failed
+        """
+        return self.count_by_state_unsynced(base.JOB_STATE_ERROR)
+
+    def count_cancelled_trials(self):
+        """
+        Returns the current number of cancelled trial runs.
+        This covers trials which are cancelled from exceeding the timeout.
+        """
+        return self.count_by_state_unsynced(base.JOB_STATE_CANCEL)
+
+    def count_total_trials(self):
+        """
+        Returns the current number of all successful, failed, and cancelled trial runs
+        """
+        total_states = [base.JOB_STATE_DONE, base.JOB_STATE_ERROR, base.JOB_STATE_CANCEL]
+        return self.count_by_state_unsynced(total_states)
+
+    def delete_all(self):
+        """
+        Reset the Trials to init state
+        """
+        super(SparkTrials, self).delete_all()
+        self._fmin_cancelled = False
+        self._fmin_cancelled_reason = None
+
+    def trial_attachments(self, trial):
+        raise NotImplementedError("SparkTrials does not support trial attachments.")
+
+    def fmin(self, fn, space, algo, max_evals,
+             max_queue_len,
+             rstate,
+             verbose,
+             pass_expr_memo_ctrl,
+             catch_eval_exceptions,
+             return_argmin,
+             show_progressbar,
+             ):
+        """
+        This should not be called directly but is called via :func:`hyperopt.fmin`
+        Refer to :func:`hyperopt.fmin` for docs on each argument
+        """
+
+        assert not pass_expr_memo_ctrl, "SparkTrials does not support `pass_expr_memo_ctrl`"
+        assert not catch_eval_exceptions, "SparkTrials does not support `catch_eval_exceptions`"
+
+        state = _SparkFMinState(self._spark_context, fn, space, self)
+
+        # Will launch a dispatcher thread which runs each trial task as one spark job.
+        state.launch_dispatcher()
+
+        try:
+            res = fmin(fn, space, algo, max_evals,
+                       max_queue_len=max_queue_len,
+                       trials=self,
+                       allow_trials_fmin=False,  # -- prevent recursion
+                       rstate=rstate,
+                       pass_expr_memo_ctrl=None,  # not support
+                       catch_eval_exceptions=catch_eval_exceptions,
+                       verbose=verbose,
+                       return_argmin=return_argmin,
+                       points_to_evaluate=None,  # not support
+                       show_progressbar=show_progressbar)
+        except BaseException as e:
+            logger.debug("fmin thread exits with an exception raised.")
+            raise e
+        else:
+            logger.debug("fmin thread exits normally.")
+            return res
+        finally:
+            state.wait_for_all_threads()
+
+            logger.info("Total Trials: {t}: {s} succeeded, {f} failed, {c} cancelled.".format(
+                t=self.count_total_trials(),
+                s=self.count_successful_trials(),
+                f=self.count_failed_trials(),
+                c=self.count_cancelled_trials()
+            ))
+
+
+class _SparkFMinState:
+    """
+    Class for managing threads which run concurrent Spark jobs.
+
+    This maintains a primary dispatcher thread, plus 1 thread per Hyperopt trial.
+    Each trial's thread runs 1 Spark job with 1 task.
+    """
+
+    def __init__(self,
+                 spark_context,
+                 eval_function,
+                 space,
+                 trials):
+        self.spark_context = spark_context
+        self.eval_function = eval_function
+        self.space = space
+        self.trials = trials
+        self._fmin_done = False
+        self._dispatcher_thread = None
+        self._task_threads = set()
+
+        if self.trials._spark_supports_job_cancelling:
+            self._job_group_id = spark_context.getLocalProperty("spark.jobGroup.id")
+            self._job_desc = spark_context.getLocalProperty("spark.job.description")
+            interrupt_on_cancel = spark_context.getLocalProperty("spark.job.interruptOnCancel")
+            if interrupt_on_cancel is None:
+                self._job_interrupt_on_cancel = False
+            else:
+                self._job_interrupt_on_cancel = "true" == interrupt_on_cancel.lower()
+            # In certain Spark deployments, the local property "spark.jobGroup.id" value is None,
+            # so we create one to use for SparkTrials.
+            if self._job_group_id is None:
+                self._job_group_id = "Hyperopt_SparkTrials_" + _get_random_id()
+            if self._job_desc is None:
+                self._job_desc = "Trial evaluation jobs launched by hyperopt fmin"
+            logger.debug("Job group id: {g}, job desc: {d}, job interrupt on cancel: {i}"
+                         .format(g=self._job_group_id,
+                                 d=self._job_desc,
+                                 i=self._job_interrupt_on_cancel))
+
+    def running_trial_count(self):
+        return self.trials.count_by_state_unsynced(base.JOB_STATE_RUNNING)
+
+    @staticmethod
+    def _begin_trial_run(trial):
+        trial['state'] = base.JOB_STATE_RUNNING
+        now = coarse_utcnow()
+        trial['book_time'] = now
+        trial['refresh_time'] = now
+        logger.debug("trial task {tid} started".format(tid=trial['tid']))
+
+    def _finish_trial_run(self, is_success, is_cancelled, trial, data):
+        """
+        Call this method when a trial evaluation finishes. It will save results to the trial object
+        and update task counters.
+        :param is_success: whether the trial succeeded
+        :param is_cancelled: whether the trial was cancelled
+        :param data: If the trial succeeded, this is the return value from the trial task function.
+                     Otherwise, this is the exception raised when running the trial task.
+        """
+        if is_cancelled:
+            logger.debug("trial task {tid} cancelled, exception is {e}"
+                         .format(tid=trial['tid'], e=str(data)))
+            self._write_cancellation_back(trial, e=data)
+        elif is_success:
+            logger.debug("trial task {tid} succeeded, result is {r}"
+                         .format(tid=trial['tid'], r=data))
+            self._write_result_back(trial, result=data)
+        else:
+            logger.debug("trial task {tid} failed, exception is {e}"
+                         .format(tid=trial['tid'], e=str(data)))
+            self._write_exception_back(trial, e=data)
+
+    def launch_dispatcher(self):
+        def run_dispatcher():
+            start_time = timeit.default_timer()
+            while not self._fmin_done:
+                new_tasks = self._poll_new_tasks()
+
+                for trial in new_tasks:
+                    self._run_trial_async(trial)
+
+                elapsed_time = timeit.default_timer() - start_time
+
+                # In the future, timeout checking logic could be moved to `fmin`.
+                # For now, timeouts are specific to SparkTrials.
+                # When a timeout happens:
+                #  - Set `trials._fmin_cancelled` flag to be True.
+                #  - FMinIter checks this flag and exits if it is set to True.
+                if self.trials.timeout is not None and elapsed_time > self.trials.timeout and\
+                        not self.trials._fmin_cancelled:
+                    self.trials._fmin_cancelled = True
+                    self.trials._fmin_cancelled_reason = "fmin run timeout"
+                    self._cancel_running_trials()
+                    logger.warning("fmin cancelled because of " + self.trials._fmin_cancelled_reason)
+                time.sleep(1)
+
+            if self.trials._fmin_cancelled:
+                # Because cancelling fmin triggered, warn that the dispatcher won't launch
+                # more trial tasks.
+                logger.warning("fmin is cancelled, so new trials will not be launched.")
+
+            logger.debug("dispatcher thread exits normally.")
+
+        self._dispatcher_thread = threading.Thread(target=run_dispatcher)
+        self._dispatcher_thread.setDaemon(True)
+        self._dispatcher_thread.start()
+
+    @staticmethod
+    def _get_spec_from_trial(trial):
+        return base.spec_from_misc(trial['misc'])
+
+    @staticmethod
+    def _write_result_back(trial, result):
+        trial['state'] = base.JOB_STATE_DONE
+        trial['result'] = result
+        trial['refresh_time'] = coarse_utcnow()
+
+    @staticmethod
+    def _write_exception_back(trial, e):
+        trial['state'] = base.JOB_STATE_ERROR
+        trial['misc']['error'] = (str(type(e)), str(e))
+        trial['refresh_time'] = coarse_utcnow()
+
+    @staticmethod
+    def _write_cancellation_back(trial, e):
+        trial['state'] = base.JOB_STATE_CANCEL
+        trial['misc']['error'] = (str(type(e)), str(e))
+        trial['refresh_time'] = coarse_utcnow()
+
+    def _run_trial_async(self, trial):
+        def run_task_thread():
+            # TODO: use broadcast for `domain` object
+            domain = base.Domain(self.eval_function, self.space, pass_expr_memo_ctrl=None)
+            ser_domain = cloudpickle.dumps(domain)
+            params = self._get_spec_from_trial(trial)
+
+            def run_task_on_executor(_):
+                domain = cloudpickle.loads(ser_domain)
+                result = domain.evaluate(params, ctrl=None, attach_attachments=False)
+                yield result
+            try:
+                worker_rdd = self.spark_context.parallelize([0], 1)
+                if self.trials._spark_supports_job_cancelling:
+                    result = worker_rdd.mapPartitions(run_task_on_executor).collectWithJobGroup(
+                        self._job_group_id, self._job_desc, self._job_interrupt_on_cancel
+                    )[0]
+                else:
+                    result = worker_rdd.mapPartitions(run_task_on_executor).collect()[0]
+            except BaseException as e:
+                # I recommend to catch all exceptions here, it can make the program more robust.
+                # There're several possible reasons lead to raising exception here.
+                # so I use `except BaseException` here.
+                #
+                # If cancelled flag is set, it represent we need to cancel all running tasks,
+                # Otherwise it represent the task failed.
+                self._finish_trial_run(is_success=False, is_cancelled=self.trials._fmin_cancelled,
+                                       trial=trial, data=e)
+                logger.debug("trial {tid} task thread catches an exception and writes the "
+                             "info back correctly."
+                             .format(tid=trial['tid']))
+            else:
+                self._finish_trial_run(is_success=True, is_cancelled=self.trials._fmin_cancelled,
+                                       trial=trial, data=result)
+                logger.debug("trial {tid} task thread exits normally and writes results "
+                             "back correctly."
+                             .format(tid=trial['tid']))
+
+        task_thread = threading.Thread(target=run_task_thread)
+        task_thread.setDaemon(True)
+        task_thread.start()
+        self._task_threads.add(task_thread)
+
+    def _poll_new_tasks(self):
+        new_task_list = []
+        # Make a copy of trials by slicing
+        for trial in self.trials.trials[:]:
+            if trial['state'] == base.JOB_STATE_NEW:
+                # check parallelism limit
+                if self.running_trial_count() >= self.trials.parallelism:
+                    break
+                new_task_list.append(trial)
+                self._begin_trial_run(trial)
+        return new_task_list
+
+    def _cancel_running_trials(self):
+        if self.trials._spark_supports_job_cancelling:
+            logger.debug("Cancelling all running jobs in job group {g}"
+                         .format(g=self._job_group_id))
+            self.spark_context.cancelJobGroup(self._job_group_id)
+            # Make a copy of trials by slicing
+            for trial in self.trials.trials[:]:
+                if trial['state'] in [base.JOB_STATE_NEW, base.JOB_STATE_RUNNING]:
+                    trial['state'] = base.JOB_STATE_CANCEL
+        else:
+            logger.info("Because the current Apache PySpark version does not support "
+                        "cancelling jobs by job group ID, SparkTrials will block until all of "
+                        "its running Spark jobs finish.")
+
+    def wait_for_all_threads(self):
+        """
+        Wait for the dispatcher and worker threads to finish.
+        :param cancel_running_trials: If true, try to cancel all running trials.
+        """
+        self._fmin_done = True
+        self._dispatcher_thread.join()
+        self._dispatcher_thread = None
+        for task_thread in self._task_threads:
+            task_thread.join()
+        self._task_threads.clear()

--- a/hyperopt/tests/test_anneal.py
+++ b/hyperopt/tests/test_anneal.py
@@ -8,6 +8,7 @@ from hyperopt import anneal
 from hyperopt import rand
 from hyperopt import Trials, fmin
 
+
 try:
     import matplotlib.pyplot as plt
 except ImportError:

--- a/hyperopt/tests/test_fmin.py
+++ b/hyperopt/tests/test_fmin.py
@@ -21,8 +21,7 @@ def test_quadratic1_rand():
     assert abs(argmin['x'] - 3.0) < .25
 
 
-def test_quadratic1_tpe():
-    trials = Trials()
+def test_quadratic1_tpe(trials=Trials()):
 
     argmin = fmin(
         fn=lambda x: (x - 3) ** 2,

--- a/hyperopt/tests/test_ipy.py
+++ b/hyperopt/tests/test_ipy.py
@@ -29,7 +29,7 @@ def test0():
     except IOError:
         raise SkipTest()
 
-    client[:].use_dill()
+    client[:].use_cloudpickle()
     trials = IPythonTrials(client, 'log')
 
     def simple_objective(args):
@@ -56,7 +56,7 @@ def test_fmin_fn():
     except IOError:
         raise SkipTest()
 
-    client[:].use_dill()
+    client[:].use_cloudpickle()
 
     trials = IPythonTrials(client, 'log')
     assert not trials._testing_fmin_was_called

--- a/hyperopt/tests/test_spark.py
+++ b/hyperopt/tests/test_spark.py
@@ -1,0 +1,434 @@
+import contextlib
+import logging
+import unittest
+import tempfile
+import time
+import shutil
+
+from six import StringIO
+
+from pyspark.sql import SparkSession
+
+from hyperopt import anneal, base, fmin, hp
+from hyperopt import SparkTrials
+
+from .test_fmin import test_quadratic1_tpe
+
+
+@contextlib.contextmanager
+def patch_logger(name, level=logging.INFO):
+    """patch logger and give an output"""
+    io_out = StringIO()
+    log = logging.getLogger(name)
+    log.setLevel(level)
+    log.handlers = []
+    handler = logging.StreamHandler(io_out)
+    log.addHandler(handler)
+    try:
+        yield io_out
+    finally:
+        log.removeHandler(handler)
+
+
+class TestTempDir(object):
+    @classmethod
+    def make_tempdir(cls, dir="/tmp"):
+        """
+        :param dir: Root directory in which to create the temp directory
+        """
+        cls.tempdir = tempfile.mkdtemp(prefix="hyperopt_tests_", dir=dir)
+
+    @classmethod
+    def remove_tempdir(cls):
+        shutil.rmtree(cls.tempdir)
+
+
+class ISparkContext(object):
+
+    NUM_SPARK_EXECUTORS = 4
+
+    @classmethod
+    def setup_spark(cls):
+        cls._spark = SparkSession.builder\
+            .master('local[{n}]'.format(n=ISparkContext.NUM_SPARK_EXECUTORS))\
+            .appName(cls.__name__)\
+            .getOrCreate()
+        cls._sc = cls._spark.sparkContext
+        cls.checkpointDir = tempfile.mkdtemp()
+        cls._sc.setCheckpointDir(cls.checkpointDir)
+        # Small tests run much faster with spark.sql.shuffle.partitions=4
+        cls._spark.conf.set("spark.sql.shuffle.partitions", "4")
+
+    @classmethod
+    def teardown_spark(cls):
+        cls._spark.stop()
+        cls._sc = None
+        shutil.rmtree(cls.checkpointDir)
+
+    @property
+    def spark(self):
+        return self._spark
+
+    @property
+    def sc(self):
+        return self._sc
+
+
+class TestSparkContext(unittest.TestCase, ISparkContext):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.setup_spark()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.teardown_spark()
+
+    def test_spark_context(self):
+        rdd1 = self.sc.parallelize(range(10), 10)
+        rdd2 = rdd1.map(lambda x: x + 1)
+        sum2 = rdd2.sum()
+        assert sum2 == 55
+
+
+def fn_succeed_within_range(x):
+    """
+    Test function to test the handling failures for `fmin`. When run `fmin` with `max_evals=8`,
+    it has 7 successful trial runs and 1 failed run.
+    :param x:
+    :return: 1 when -3 < x < 3, and RuntimeError otherwise
+    """
+    if -3 < x < 3:
+        return 1
+    else:
+        raise RuntimeError
+
+
+class FMinTestCase(unittest.TestCase, ISparkContext):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.setup_spark()
+        cls._sc.setLogLevel('OFF')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.teardown_spark()
+
+    def sparkSupportsJobCancelling(self):
+        return hasattr(self.sc.parallelize([1]), "collectWithJobGroup")
+
+    def check_run_status(self, spark_trials, output, num_total, num_success, num_failure):
+        self.assertEqual(spark_trials.count_total_trials(), num_total,
+                         "Wrong number of total trial runs: Expected {e} but got {r}."
+                         .format(e=num_total, r=spark_trials.count_total_trials()))
+        self.assertEqual(spark_trials.count_successful_trials(), num_success,
+                         "Wrong number of successful trial runs: Expected {e} but got {r}."
+                         .format(e=num_success, r=spark_trials.count_successful_trials()))
+        self.assertEqual(spark_trials.count_failed_trials(), num_failure,
+                         "Wrong number of failed trial runs: Expected {e} but got {r}."
+                         .format(e=num_failure, r=spark_trials.count_failed_trials()))
+        log_output = output.getvalue().strip()
+        self.assertIn("Total Trials: "+str(num_total), log_output,
+                      """Logging "Total Trials: {num}" missing from the log: {log}"""
+                      .format(num=str(num_total), log=log_output))
+        self.assertIn(str(num_success)+" succeeded", log_output,
+                      """Logging "{num} succeeded " missing from the log: {log}"""
+                      .format(num=str(num_success), log=log_output))
+        self.assertIn(str(num_failure)+" failed", log_output,
+                      """ Logging "{num} failed " missing from the log: {log}"""
+                      .format(num=str(num_failure), log=log_output))
+
+    def assert_task_succeeded(self, log_output, task):
+        self.assertIn(
+            "trial {} task thread exits normally".format(task),
+            log_output,
+            """Debug info "trial {task} task thread exits normally" missing from log:
+             {log_output}"""
+            .format(task=task, log_output=log_output))
+
+    def assert_task_failed(self, log_output, task):
+        self.assertIn(
+            "trial {} task thread catches an exception"
+            .format(task),
+            log_output,
+            """Debug info "trial {task} task thread catches an exception" missing from log:
+             {log_output}"""
+            .format(task=task, log_output=log_output))
+
+    def test_quadratic1_tpe(self):
+        # TODO: Speed this up or remove it since it is slow (1 minute on laptop)
+        spark_trials = SparkTrials(parallelism=4)
+        test_quadratic1_tpe(spark_trials)
+
+    def test_trial_run_info(self):
+        spark_trials = SparkTrials(parallelism=4)
+
+        with patch_logger('hyperopt-spark') as output:
+            fmin(
+                fn=fn_succeed_within_range,
+                space=hp.uniform('x', -5, 5),
+                algo=anneal.suggest,
+                max_evals=8,
+                return_argmin=False,
+                trials=spark_trials)
+            self.check_run_status(spark_trials, output, num_total=8, num_success=7, num_failure=1)
+
+        expected_result = {'loss': 1.0, 'status': 'ok'}
+        for trial in spark_trials._dynamic_trials:
+            if trial['state'] == base.JOB_STATE_DONE:
+                self.assertEqual(trial['result'], expected_result,
+                                 "Wrong result has been saved: Expected {e} but got {r}."
+                                 .format(e=expected_result, r=trial['result']))
+            elif trial['state'] == base.JOB_STATE_ERROR:
+                err_message = trial['misc']['error'][1]
+                self.assertIn("RuntimeError", err_message,
+                              "Missing {e} in {r}."
+                              .format(e="RuntimeError", r=err_message))
+
+        num_success = spark_trials.count_by_state_unsynced(base.JOB_STATE_DONE)
+        self.assertEqual(num_success, 7,
+                         "Wrong number of successful trial runs: Expected {e} but got {r}."
+                         .format(e=7, r=num_success))
+        num_failure = spark_trials.count_by_state_unsynced(base.JOB_STATE_ERROR)
+        self.assertEqual(num_failure, 1,
+                         "Wrong number of failed trial runs: Expected {e} but got {r}."
+                         .format(e=1, r=num_failure))
+
+    def test_accepting_sparksession(self):
+        spark_trials = SparkTrials(parallelism=2,
+                                   spark_session=SparkSession.builder.getOrCreate())
+
+        fmin(
+            fn=lambda x: x + 1,
+            space=hp.uniform('x', 5, 8),
+            algo=anneal.suggest,
+            max_evals=2,
+            trials=spark_trials)
+
+    def test_parallelism_arg(self):
+        # Computing max_num_concurrent_tasks
+        max_num_concurrent_tasks = self.sc._jsc.sc().maxNumConcurrentTasks()
+        self.assertEqual(max_num_concurrent_tasks, ISparkContext.NUM_SPARK_EXECUTORS,
+                         "max_num_concurrent_tasks ({c}) did not equal "
+                         "ISparkContext.NUM_SPARK_EXECUTORS ({e})"
+                         .format(c=max_num_concurrent_tasks, e=ISparkContext.NUM_SPARK_EXECUTORS))
+
+        max_num_concurrent_tasks = 4
+        # Given invalidly small parallelism
+        with patch_logger('hyperopt-spark') as output:
+            parallelism = SparkTrials._decide_parallelism(max_num_concurrent_tasks, -1)
+            self.assertEqual(parallelism, max_num_concurrent_tasks,
+                             "Failed to default parallelism ({p}) to max_num_concurrent_tasks"
+                             " ({e})".format(p=parallelism, e=max_num_concurrent_tasks))
+            log_output = output.getvalue().strip()
+            self.assertIn(
+                "invalid value (-1)",
+                log_output,
+                """Invalid parallelism value -1 missing from log: {log_output}"""
+                .format(log_output=log_output))
+            self.assertIn(
+                "max_num_concurrent_tasks ({c})".format(c=max_num_concurrent_tasks),
+                log_output,
+                """max_num_concurrent_tasks value missing from log: {log_output}"""
+                .format(log_output=log_output))
+
+        # Given invalidly large parallelism
+        with patch_logger('hyperopt-spark') as output:
+            parallelism = SparkTrials._decide_parallelism(max_num_concurrent_tasks,
+                                                     max_num_concurrent_tasks+1)
+            self.assertEqual(parallelism,
+                             max_num_concurrent_tasks,
+                             "Failed to limit parallelism ({p}) to max_num_concurrent_tasks"
+                             " ({e})".format(p=parallelism, e=max_num_concurrent_tasks))
+            log_output = output.getvalue().strip()
+            self.assertIn(
+                "parallelism ({p}) is greater".format(p=max_num_concurrent_tasks+1),
+                log_output,
+                """User-specified parallelism ({p}) missing from log: {log_output}"""
+                .format(p=max_num_concurrent_tasks+1, log_output=log_output))
+            self.assertIn(
+                "max_num_concurrent_tasks ({c})".format(c=max_num_concurrent_tasks),
+                log_output,
+                """max_num_concurrent_tasks value missing from log: {log_output}"""
+                .format(log_output=log_output))
+
+        # Given valid parallelism
+        parallelism = SparkTrials._decide_parallelism(max_num_concurrent_tasks, None)
+        self.assertEqual(parallelism,
+                         max_num_concurrent_tasks,
+                         "The default parallelism ({p}) did not equal max_num_concurrent_tasks"
+                         " ({e})".format(p=parallelism, e=max_num_concurrent_tasks))
+
+        # Given invalid parallelism relative to hard cap
+        with patch_logger('hyperopt-spark') as output:
+            parallelism = SparkTrials._decide_parallelism(
+                max_num_concurrent_tasks=SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED+1,
+                parallelism=None)
+            self.assertEqual(
+                parallelism,
+                SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED,
+                "Failed to limit parallelism ({p}) to MAX_CONCURRENT_JOBS_ALLOWED ({e})"
+                .format(p=parallelism, e=SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED))
+            log_output = output.getvalue().strip()
+            self.assertIn(
+                "SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED ({c})"
+                .format(c=SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED),
+                log_output,
+                """MAX_CONCURRENT_JOBS_ALLOWED value missing from log: {log_output}"""
+                .format(log_output=log_output))
+
+    def test_all_successful_trials(self):
+        spark_trials = SparkTrials(parallelism=1)
+        with patch_logger('hyperopt-spark', logging.DEBUG) as output:
+            fmin(
+                fn=fn_succeed_within_range,
+                space=hp.uniform('x', -1, 1),
+                algo=anneal.suggest,
+                max_evals=1,
+                trials=spark_trials)
+            log_output = output.getvalue().strip()
+
+            self.assertEqual(spark_trials.count_successful_trials(), 1)
+            self.assertIn(
+                "fmin thread exits normally",
+                log_output,
+                """Debug info "fmin thread exits normally" missing from log: {log_output}"""
+                .format(log_output=log_output))
+            self.assert_task_succeeded(log_output, 0)
+
+    def test_all_failed_trials(self):
+        spark_trials = SparkTrials(parallelism=1)
+        with patch_logger('hyperopt-spark', logging.DEBUG) as output:
+            fmin(
+                fn=fn_succeed_within_range,
+                space=hp.uniform('x', 5, 10),
+                algo=anneal.suggest,
+                max_evals=1,
+                trials=spark_trials,
+                return_argmin=False)
+            log_output = output.getvalue().strip()
+
+            self.assertEqual(spark_trials.count_failed_trials(), 1)
+            self.assert_task_failed(log_output, 0)
+
+        spark_trials = SparkTrials(parallelism=4)
+        # Here return_argmin is True (by default) and an exception should be thrown:w
+        with self.assertRaisesRegexp(Exception, "There are no evaluation tasks"):
+            fmin(
+                fn=fn_succeed_within_range,
+                space=hp.uniform('x', 5, 8),
+                algo=anneal.suggest,
+                max_evals=2,
+                trials=spark_trials)
+
+    def test_timeout_without_job_cancellation(self):
+        timeout = 4
+        spark_trials = SparkTrials(parallelism=1, timeout=timeout)
+        spark_trials._spark_supports_job_cancelling = False
+
+        def fn(x):
+            time.sleep(0.5)
+            return x
+
+        with patch_logger('hyperopt-spark', logging.DEBUG) as output:
+            fmin(
+                fn=fn,
+                space=hp.uniform('x', -1, 1),
+                algo=anneal.suggest,
+                max_evals=10,
+                trials=spark_trials,
+                max_queue_len=1,
+                show_progressbar=False,
+                return_argmin=False)
+            log_output = output.getvalue().strip()
+
+            self.assertTrue(spark_trials._fmin_cancelled)
+            self.assertEqual(spark_trials._fmin_cancelled_reason, "fmin run timeout")
+            self.assertGreater(spark_trials.count_successful_trials(), 0)
+            self.assertGreater(spark_trials.count_cancelled_trials(), 0)
+            self.assertIn(
+                "fmin is cancelled, so new trials will not be launched",
+                log_output,
+                """ "fmin is cancelled, so new trials will not be launched" missing from log:
+                {log_output}"""
+                .format(log_output=log_output))
+            self.assertIn(
+                "SparkTrials will block",
+                log_output,
+                """ "SparkTrials will block" missing from log: {log_output}"""
+                .format(log_output=log_output))
+            self.assert_task_succeeded(log_output, 0)
+
+    def test_timeout_with_job_cancellation(self):
+        if not self.sparkSupportsJobCancelling():
+            print("Skipping timeout test since this Apache PySpark version does not support "
+                  "cancelling jobs by job group ID.")
+            return
+
+        timeout = 2
+        spark_trials = SparkTrials(parallelism=4, timeout=timeout)
+
+        def fn(x):
+            if x < 0:
+                time.sleep(timeout + 20)
+                raise Exception("Task should have been cancelled")
+            else:
+                time.sleep(1)
+            return x
+
+        # Test 1 cancelled trial.  Examine logs.
+        with patch_logger('hyperopt-spark', logging.DEBUG) as output:
+            fmin(
+                fn=fn,
+                space=hp.uniform('x', -2, 0),
+                algo=anneal.suggest,
+                max_evals=1,
+                trials=spark_trials,
+                max_queue_len=1,
+                show_progressbar=False,
+                return_argmin=False)
+            log_output = output.getvalue().strip()
+
+            self.assertTrue(spark_trials._fmin_cancelled)
+            self.assertEqual(spark_trials._fmin_cancelled_reason, "fmin run timeout")
+            self.assertEqual(spark_trials.count_cancelled_trials(), 1)
+            self.assertIn(
+                "Cancelling all running jobs",
+                log_output,
+                """ "Cancelling all running jobs" missing from log: {log_output}"""
+                .format(log_output=log_output))
+            self.assertIn("trial task 0 cancelled",
+                          log_output,
+                          """ "trial task 0 cancelled" missing from log: {log_output}"""
+                          .format(log_output=log_output))
+            self.assertNotIn("Task should have been cancelled",
+                             log_output,
+                             """ "Task should have been cancelled" should not in log:
+                              {log_output}""".format(log_output=log_output))
+            self.assert_task_failed(log_output, 0)
+
+        # Test mix of successful and cancelled trials.
+        spark_trials = SparkTrials(parallelism=4, timeout=4)
+        fmin(
+            fn=fn,
+            space=hp.uniform('x', -0.25, 5),
+            algo=anneal.suggest,
+            max_evals=6,
+            trials=spark_trials,
+            max_queue_len=1,
+            show_progressbar=False,
+            return_argmin=True)
+
+        time.sleep(2)
+        self.assertTrue(spark_trials._fmin_cancelled)
+        self.assertEqual(spark_trials._fmin_cancelled_reason, "fmin run timeout")
+
+        # There are 2 finished trials, 1 cancelled running trial and 1 cancelled
+        # new trial. We do not need to check the new trial since it is not started yet.
+        self.assertGreaterEqual(
+            spark_trials.count_successful_trials(), 1,
+            "Expected at least 1 successful trial but found none.")
+        self.assertGreaterEqual(
+            spark_trials.count_cancelled_trials(), 1,
+            "Expected at least 1 cancelled trial but found none.")

--- a/hyperopt/tests/test_utils.py
+++ b/hyperopt/tests/test_utils.py
@@ -4,6 +4,7 @@ import numpy as np
 from nose.tools import raises, eq_
 import shutil
 import os
+from hyperopt import Trials
 from hyperopt.utils import fast_isin
 from hyperopt.utils import get_most_recent_inds
 from hyperopt.utils import temp_dir, working_dir, get_closest_dir, path_split_all

--- a/hyperopt/utils.py
+++ b/hyperopt/utils.py
@@ -10,17 +10,39 @@ import numpy as np
 import logging
 import os
 import shutil
+import sys
+import uuid
 import numpy
 from . import pyll
 from contextlib import contextmanager
 
 standard_library.install_aliases()
-logger = logging.getLogger(__name__)
+
+
+def _get_random_id():
+    """
+    Generates a random ID.
+    """
+    return uuid.uuid4().hex[-12:]
+
+
+def _get_logger(name):
+    """ Gets a logger by name, or creates and configures it for the first time. """
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.INFO)
+    # If the logger is configured, skip the configure
+    if not logger.handlers and not logging.getLogger().handlers:
+        handler = logging.StreamHandler(sys.stderr)
+        logger.addHandler(handler)
+    return logger
+
+
+logger = _get_logger(__name__)
 
 try:
-    import dill as pickler
+    import cloudpickle as pickler
 except Exception as e:
-    logger.info('Failed to load dill, try installing dill via "pip install dill" for enhanced pickling support.')
+    logger.info('Failed to load cloudpickle, try installing cloudpickle via "pip install cloudpickle" for enhanced pickling support.')
     import six.moves.cPickle as pickler
 
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# Return on any failure
+set -e
+
+# if (got > 1 argument OR ( got 1 argument AND that argument does not exist)) then
+# print usage and exit.
+if [[ $# -gt 1 || ($# = 1 && ! -e $1) ]]; then
+echo "run_tests.sh [target]"
+echo ""
+echo "Run python tests for this package."
+echo "  target -- either a test file or directory [default tests]"
+if [[ ($# = 1 && ! -e $1) ]]; then
+echo
+echo "ERROR: Could not find $1"
+fi
+exit 1
+fi
+
+# assumes run from the package base directory
+if [ -z "$SPARK_HOME" ]; then
+echo 'You need to set $SPARK_HOME to run these tests.' >&2
+exit 1
+fi
+
+# Honor the choice of python driver
+if [ -z "$PYSPARK_PYTHON" ]; then
+PYSPARK_PYTHON=`which python`
+fi
+# Override the python driver version as well to make sure we are in sync in the tests.
+export PYSPARK_DRIVER_PYTHON=$PYSPARK_PYTHON
+python_major=$($PYSPARK_PYTHON -c 'import sys; print(".".join(map(str, sys.version_info[:1])))')
+
+echo $PYSPARK_PYTHON
+
+LIBS=""
+for lib in "$SPARK_HOME/python/lib"/*zip ; do
+LIBS=$LIBS:$lib
+done
+
+# The current directory of the script.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+export PYTHONPATH=$PYTHONPATH:$SPARK_HOME/python:$LIBS:hyperopt
+
+# This will be used when starting pyspark.
+export PYSPARK_SUBMIT_ARGS="--driver-memory 4g --executor-memory 4g pyspark-shell"
+
+# Run test suites
+
+if [ -f "$1" ]; then
+noseOptionsArr="$1"
+else
+if [ -d "$1" ]; then
+targetDir=$1
+else
+targetDir=$DIR/hyperopt/tests
+fi
+# add all python files in the test dir recursively
+echo "============= Searching for tests in: $targetDir ============="
+noseOptionsArr="$(find "$targetDir" -type f | grep "\.py" | grep -v "\.pyc" | grep -v "\.py~" | grep -v "__init__.py")"
+fi
+
+for noseOptions in $noseOptionsArr
+do
+echo "============= Running the tests in: $noseOptions ============="
+$PYSPARK_DRIVER_PYTHON \
+-m "nose" \
+--nologcapture \
+-v --exe "$noseOptions"
+
+done
+
+# nosetests

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,15 +1,27 @@
 #!/usr/bin/env bash
 
+use_spark=true
+while :; do
+case $1 in
+--no-spark)
+use_spark=false
+;;
+*) break
+esac
+shift
+done
+
 # Return on any failure
 set -e
 
 # if (got > 1 argument OR ( got 1 argument AND that argument does not exist)) then
 # print usage and exit.
 if [[ $# -gt 1 || ($# = 1 && ! -e $1) ]]; then
-echo "run_tests.sh [target]"
+echo "run_tests.sh [--no-spark] [target]"
 echo ""
 echo "Run python tests for this package."
-echo "  target -- either a test file or directory [default tests]"
+echo "  --no-spark : flag to tell this script to skip Apache Spark-related tests"
+echo "  target : either a test file or directory [default: tests]"
 if [[ ($# = 1 && ! -e $1) ]]; then
 echo
 echo "ERROR: Could not find $1"
@@ -17,6 +29,13 @@ fi
 exit 1
 fi
 
+if [[ ("$use_spark" = false) && ($1 == *test_spark.py) ]] ; then
+echo
+echo "ERROR: Cannot run $1 with --no-spark flag"
+exit 1
+fi
+
+if [[ "$use_spark" = true ]]; then
 # assumes run from the package base directory
 if [ -z "$SPARK_HOME" ]; then
 echo 'You need to set $SPARK_HOME to run these tests.' >&2
@@ -29,7 +48,6 @@ PYSPARK_PYTHON=`which python`
 fi
 # Override the python driver version as well to make sure we are in sync in the tests.
 export PYSPARK_DRIVER_PYTHON=$PYSPARK_PYTHON
-python_major=$($PYSPARK_PYTHON -c 'import sys; print(".".join(map(str, sys.version_info[:1])))')
 
 echo $PYSPARK_PYTHON
 
@@ -38,13 +56,14 @@ for lib in "$SPARK_HOME/python/lib"/*zip ; do
 LIBS=$LIBS:$lib
 done
 
-# The current directory of the script.
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
 export PYTHONPATH=$PYTHONPATH:$SPARK_HOME/python:$LIBS:hyperopt
 
 # This will be used when starting pyspark.
 export PYSPARK_SUBMIT_ARGS="--driver-memory 4g --executor-memory 4g pyspark-shell"
+fi
+
+# The current directory of the script.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Run test suites
 
@@ -63,12 +82,21 @@ fi
 
 for noseOptions in $noseOptionsArr
 do
+if [[ ("$use_spark" = false) && ($noseOptions == *test_spark.py) ]] ; then
+continue
+fi
 echo "============= Running the tests in: $noseOptions ============="
+if [[ "$use_spark" = true ]]; then
 $PYSPARK_DRIVER_PYTHON \
 -m "nose" \
 --nologcapture \
 -v --exe "$noseOptions"
-
+else
+python \
+-m "nose" \
+--nologcapture \
+-v --exe "$noseOptions"
+fi
 done
 
 # nosetests

--- a/setup.py
+++ b/setup.py
@@ -148,6 +148,7 @@ setuptools.setup(
     package_data=package_data,
     include_package_data=True,
     install_requires=['numpy', 'scipy', 'pymongo', 'six', 'networkx==2.2', 'future', 'tqdm', 'cloudpickle'],
+    extras_require={'SparkTrials':'pyspark'},
     tests_require=['nose'],
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -147,10 +147,7 @@ setuptools.setup(
     keywords='Bayesian optimization hyperparameter model selection',
     package_data=package_data,
     include_package_data=True,
-    install_requires=['numpy', 'scipy', 'pymongo', 'six', 'networkx==2.2', 'future', 'tqdm'],
-    extras_require={
-        'dill': 'dill'
-    },
+    install_requires=['numpy', 'scipy', 'pymongo', 'six', 'networkx==2.2', 'future', 'tqdm', 'cloudpickle'],
     tests_require=['nose'],
     zip_safe=False
 )

--- a/unit-test.md
+++ b/unit-test.md
@@ -1,19 +1,28 @@
 Running unit tests
 ==============
 
-To run the  unit tests, run the `run-tests.sh` script.  You will need to set these environment variables:
+To run the unit tests, run the `run-tests.sh` script.  You will need to set these environment variables:
 
-- `SPARK_HOME`: your local copy of Apache Spark. Look at download_spark_dependencies.sh for more details.
+- `SPARK_HOME`: your local copy of Apache Spark. Look at `.travis.yml` and `download_spark_dependencies.sh` for details on how to download Apache Spark.
 - `HYPEROPT_FMIN_SEED`: the random seed. You need to get its value from `.travis.yml`.
 
 For example:
 
 ```bash
-hyperopt$ HYPEROPT_FMIN_SEED=3 SPARK_HOME=/usr/local/lib/spark-2.4.0-bin-hadoop2.7 ./run_tests.sh
+hyperopt$ HYPEROPT_FMIN_SEED=3 SPARK_HOME=/usr/local/lib/spark-2.4.4-bin-hadoop2.7 ./run_tests.sh
 ```
 
 To run the unit test for one file, you can add the file name as the parameter, e.g:
 ```bash
-hyperopt$ HYPEROPT_FMIN_SEED=3 SPARK_HOME=/usr/local/lib/spark-2.4.0-bin-hadoop2.7 ./run_tests.sh hyperopt/tests/test_spark.py
+hyperopt$ HYPEROPT_FMIN_SEED=3 SPARK_HOME=/usr/local/lib/spark-2.4.4-bin-hadoop2.7 ./run_tests.sh hyperopt/tests/test_spark.py
 ```
 
+To run all unit tests except `test_spark.py`, add the `--no-spark` flag, e.g:
+```bash
+hyperopt$ HYPEROPT_FMIN_SEED=3 ./run_tests.sh --no-spark
+```
+
+To run the unit test for one file other than `test_spark.py`, add the file name as the parameter after the `--no-spark` flag, e.g:
+```bash
+hyperopt$ HYPEROPT_FMIN_SEED=3 ./run_tests.sh --no-spark test_base.py
+```

--- a/unit-test.md
+++ b/unit-test.md
@@ -1,0 +1,19 @@
+Running unit tests
+==============
+
+To run the  unit tests, run the `run-tests.sh` script.  You will need to set these environment variables:
+
+- `SPARK_HOME`: your local copy of Apache Spark. Look at download_spark_dependencies.sh for more details.
+- `HYPEROPT_FMIN_SEED`: the random seed. You need to get its value from `.travis.yml`.
+
+For example:
+
+```bash
+hyperopt$ HYPEROPT_FMIN_SEED=3 SPARK_HOME=/usr/local/lib/spark-2.4.0-bin-hadoop2.7 ./run_tests.sh
+```
+
+To run the unit test for one file, you can add the file name as the parameter, e.g:
+```bash
+hyperopt$ HYPEROPT_FMIN_SEED=3 SPARK_HOME=/usr/local/lib/spark-2.4.0-bin-hadoop2.7 ./run_tests.sh hyperopt/tests/test_spark.py
+```
+


### PR DESCRIPTION
This PR integrates hyperopt with Apache Spark clusters.  The goal is to provide users a scalable distributed hyperopt implementation under the hood.  This is limited to hyperopt tasks which can run on a single machine, e.g., for scikit-learn.

A `SparkTrials` type is added to distribute trial runs across a Spark cluster. It uses concurrent Spark jobs for running asynchronous hyperopt tasks on Spark executors.

This PR is based on this [design doc](https://docs.google.com/document/d/1R-qMVOYxaLw3HdqMiTADQDZ5z7uInMR-x42HFCXu2-s/edit), which was discussed with @maxpumperla in #414.  Contributors include @WeichenXu123, @lu-wang-dl, @jkbradley, and the author.
