### PR TITLE
Convert output of fmin to same dtypes in space

### DIFF
--- a/hyperopt/fmin.py
+++ b/hyperopt/fmin.py
@@ -423,7 +423,16 @@ def fmin(fn, space, algo, max_evals, trials=None, rstate=None,
     if return_argmin:
         if len(trials.trials) == 0:
             raise Exception("There are no evaluation tasks, cannot return argmin of task losses.")
-        return trials.argmin
+        # Make sure the arguments are returned with the correct type
+        out_dict = dict()
+        for arg_idx, arg_val in trials.argmin.items():
+            try:
+                if space[arg_idx].name in ["int", "float"]:
+                    arg_val = eval(space[arg_idx].name + "(arg_val)")
+            except KeyError:
+                print(arg_idx + " not found in space.")
+            out_dict[arg_idx] = arg_val
+        return out_dict
     elif len(trials) > 0:
         # Only if there are some succesfull trail runs, return the best point in the evaluation space
         return space_eval(space, trials.argmin)


### PR DESCRIPTION
When training a Gradient Boosting Regression model (from sklearn) on training data like this:

```
space = {
        "max_depth": scope.int(hp.quniform("max_depth", 1, 10, 1)),
        "n_estimators": scope.int(hp.quniform("n_estimators", 1, 111, 10)),
        "subsample": hp.uniform("subsample", 0.01, 1),
    }
    f_min_obj = partial(cv_wrapper, X_input=X_tr, y_input=y_tr)
    best = fmin(fn=f_min_obj, space=space, algo=tpe.suggest, max_evals=50)
```

The dictionary returned by `fmin` will have all its parameters as floats, if I try to train the model with the best parameters using: `model = GradientBoostingRegressor(**best).fit(X_tr, y_tr)`, it crashes since `max_depth` and `n_estimators` should be `int`.

The solution is a bit hacky, since I'm declaring `out_dict`, however, I was not able to change `trials.argmin` on my machine. Any comments on how to make this better are more than welcome.