### PR TITLE
Make mongo an extra dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ services:
   - mongodb
 
 before_script:
-  - sleep 15  # mongo takes time to start
+  - sleep 15 # mongo takes time to start
   - mongo mydb_test --eval 'db.createUser({user:"travis",pwd:"test",roles:["readWrite"]});'
 
 before_install:
@@ -44,8 +44,9 @@ install:
   - pip install --upgrade wheel
   - pip install $IPYTHON
   - pip install --only-binary=numpy,scipy numpy==$NUMPY_VERSION scipy
-  - python setup.py install
-  - pip install pytest>=3.6 pytest-cov pep8 pytest-pep8
+  - pip install .[MongoTrials]
+  - pip install pytest>=3.6
+  - pip install pytest-cov pep8 pytest-pep8
   - pip install wrapt
 script:
   - ./run_tests.sh

--- a/hyperopt/mongoexp.py
+++ b/hyperopt/mongoexp.py
@@ -107,10 +107,14 @@ import urllib.parse
 import warnings
 
 import numpy
-import pymongo
-import gridfs
-from bson import SON
+try:
+    import pymongo
+    import gridfs
+    _has_mongo = True
+except:
+    _has_mongo = False
 
+from bson import SON
 from .base import JOB_STATES
 from .base import (JOB_STATE_NEW, JOB_STATE_RUNNING, JOB_STATE_DONE,
                    JOB_STATE_ERROR)
@@ -330,6 +334,10 @@ class MongoJobs(object):
             XXX: No idea what this is for, seems unimportant.
 
         """
+        if not _has_mongo:
+            raise Exception("MongoJobs cannot import pymongo classes.  Make sure that pymongo "
+                            "is available in your environment.  E.g., try running 'import pymongo'")
+
         self.db = db
         self.jobs = jobs
         self.gfs = gfs
@@ -663,6 +671,10 @@ class MongoTrials(Trials):
 
     def __init__(self, arg, exp_key=None, cmd=None, workdir=None,
                  refresh=True):
+        if not _has_mongo:
+            raise Exception("MongoTrials cannot import pymongo classes.  Make sure that pymongo "
+                            "is available in your environment.  E.g., try running 'import pymongo'")
+
         if isinstance(arg, MongoJobs):
             self.handle = arg
         else:

--- a/setup.py
+++ b/setup.py
@@ -147,8 +147,8 @@ setuptools.setup(
     keywords='Bayesian optimization hyperparameter model selection',
     package_data=package_data,
     include_package_data=True,
-    install_requires=['numpy', 'scipy', 'pymongo', 'six', 'networkx==2.2', 'future', 'tqdm', 'cloudpickle'],
-    extras_require={'SparkTrials':'pyspark'},
+    install_requires=['numpy', 'scipy', 'six', 'networkx==2.2', 'future', 'tqdm', 'cloudpickle', 'bson'],
+    extras_require={'SparkTrials':'pyspark', 'MongoTrials': 'pymongo'},
     tests_require=['nose'],
     zip_safe=False
 )


### PR DESCRIPTION
`pymongo` should be a dependency only for those, who want to use MongoTrials.

Note that I also had to change how `hyperopt` is installed in the CI:

* `pip install .[MongoTrials]` because we want to specify installation of `pymongo`, so that tests for `mongoexp` run correctly
* `pip install pytest>=3.6 pytest-cov pep8 pytest-pep8` was causing CI errors for Python 2.7 and 3.6, so I split it into two separate installs - first `pytest` and then the rest.

See also #353