### PR TITLE
Change ModuleNotFoundError to ImportError to work in Python < 3.6

### DIFF
--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -12,7 +12,7 @@ from hyperopt.utils import coarse_utcnow, _get_logger, _get_random_id
 try:
     from pyspark.sql import SparkSession
     _have_spark = True
-except ModuleNotFoundError as e:
+except ImportError as e:
     _have_spark = False
 
 logger = _get_logger('hyperopt-spark')


### PR DESCRIPTION
There is no ModuleNotFoundError in Python2. This caused NameError in py<3

ModuleNotFoundError inherits from ImportError so changing the exception should work for both Py2 and Py3
