### PR TITLE
Fix BSON import issue

### DIFF
--- a/hyperopt/mongoexp.py
+++ b/hyperopt/mongoexp.py
@@ -110,11 +110,11 @@ import numpy
 try:
     import pymongo
     import gridfs
+    from bson import SON
     _has_mongo = True
 except:
     _has_mongo = False
 
-from bson import SON
 from .base import JOB_STATES
 from .base import (JOB_STATE_NEW, JOB_STATE_RUNNING, JOB_STATE_DONE,
                    JOB_STATE_ERROR)

--- a/setup.py
+++ b/setup.py
@@ -147,9 +147,9 @@ setuptools.setup(
     keywords='Bayesian optimization hyperparameter model selection',
     package_data=package_data,
     include_package_data=True,
-    install_requires=['numpy', 'scipy', 'six', 'networkx==2.2', 'future', 'tqdm', 'cloudpickle', 'bson'],
+    install_requires=['numpy', 'scipy', 'six', 'networkx==2.2', 'future', 'tqdm', 'cloudpickle'],
     extras_require={
-        'SparkTrials':'pyspark', 
+        'SparkTrials':'pyspark',
         'MongoTrials': 'pymongo',
         'ATPE': ['lightgbm', 'scikit-learn']},
     tests_require=['nose'],


### PR DESCRIPTION
A package `bson` has been added to the `setup.py` in commit 4dae46c4724d4796c6a83f146e8f336013ad9bdf,
because `pymongo` has been removed. The package is however not compatible
with the `bson` package from `pymongo` and has been causing
`ImportError`s.

Therefore we add all the imports of `bson` to a guarded block.
It should be safe to do so, because any code that needs the `bson`
package is also dependent on `pymongo`.

Issues: #541 and #547 