### PR TITLE
hyperopt facelift with black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
+# not used at the moment
 repos:
 -   repo: https://github.com/ambv/black
     rev: stable
     hooks:
     - id: black
-#      args: [--check]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,4 @@ repos:
     rev: stable
     hooks:
     - id: black
+      args: [--check]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
-# not used at the moment
 repos:
 -   repo: https://github.com/ambv/black
     rev: stable
     hooks:
     - id: black
+      args: [--check]

--- a/README.md
+++ b/README.md
@@ -60,13 +60,7 @@ git clone https://github.com/jaberg/hyperopt.git
 cd hyperopt && python setup.py develop &&  pip install -e '.[MongoTrials, SparkTrials, ATPE]'
 ```
 
-Then install the pre-commit hook as
-```
-pre-commit install
-```
-
-so that black is automatically run (and failing if required) every time you 
-commit
+We recommend to use `black` to format your code before submitting a PR
 
 ## Algorithms
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ Currently three algorithms are implemented in hyperopt:
 
 Hyperopt has been designed to accommodate Bayesian optimization algorithms based on Gaussian processes and regression trees, but these are not currently implemented.
 
-All algorithms can be run either serially, or in parallel by communicating via [MongoDB](https://mongodb.com).
+All algorithms can be parallelized in two ways, using:
+
+- [Apache Spark](https://spark.apache.org/)
+- [MongoDB](https://mongodb.com)
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Hyperopt is a Python library for serial and parallel optimization over awkward
 search spaces, which may include real-valued, discrete, and conditional
 dimensions.
 
+## Requirements
+
+python 3.6+
+
 ## Getting started
 
 Install hyperopt from PyPI
@@ -40,12 +44,12 @@ space = hp.choice('a',
     ])
 
 # minimize the objective over the space
-from hyperopt import fmin, tpe
+from hyperopt import fmin, tpe, space_eval
 best = fmin(objective, space, algo=tpe.suggest, max_evals=100)
 
-print best
+print(best)
 # -> {'a': 1, 'c2': 0.01420615366247227}
-print hyperopt.space_eval(space, best)
+print(space_eval(space, best))
 # -> ('case 2', 0.01420615366247227}
 ```
 
@@ -55,6 +59,14 @@ If you're a developer, clone this repository and install from source:
 git clone https://github.com/jaberg/hyperopt.git
 cd hyperopt && python setup.py develop &&  pip install -e '.[MongoTrials, SparkTrials, ATPE]'
 ```
+
+Then install the pre-commit hook as
+```
+pre-commit install
+```
+
+so that black is automatically run (and failing if required) every time you 
+commit
 
 ## Algorithms
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ git clone https://github.com/hyperopt/hyperopt.git
 cd hyperopt && python setup.py develop &&  pip install -e '.[MongoTrials, SparkTrials, ATPE, dev]'
 ```
 
-Note that dev dependencies require black, using python 3.6+ under the hood.
+Note that dev dependencies require `black`, using python 3.6+ under the hood.
 
 We recommend to use `black` to format your code before submitting a PR. You can use it 
 with a pre-commit hook as follows:
@@ -65,7 +65,7 @@ with a pre-commit hook as follows:
 pre-commit install
 ```
 
-Then, once you commit ensure than git hooks are activated (Pycharm for example have the 
+Then, once you commit ensure that git hooks are activated (Pycharm for example has the 
 option to omit them). This will run black automatically on all files you modified, 
 failing if there are any files requiring to be blacked.
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,21 @@ If you're a developer, clone this repository and install from source:
 
 ```bash
 git clone https://github.com/hyperopt/hyperopt.git
-cd hyperopt && python setup.py develop &&  pip install -e '.[MongoTrials, SparkTrials, ATPE]'
+cd hyperopt && python setup.py develop &&  pip install -e '.[MongoTrials, SparkTrials, ATPE, dev]'
 ```
 
-We recommend to use `black` to format your code before submitting a PR
+Note that dev dependencies require black, using python 3.6+ under the hood.
+
+We recommend to use `black` to format your code before submitting a PR. You can use it 
+with a pre-commit hook as follows:
+
+```
+pre-commit install
+```
+
+Then, once you commit ensure than git hooks are activated (Pycharm for example have the 
+option to omit them). This will run black automatically on all files you modified, 
+failing if there are any files requiring to be blacked.
 
 ## Algorithms
 

--- a/distribute_setup.py
+++ b/distribute_setup.py
@@ -36,24 +36,29 @@ try:
         args = (sys.executable,) + args
         return subprocess.call(args) == 0
 
+
 except ImportError:
     # will be used for python 2.3
     def _python_cmd(*args):
         args = (sys.executable,) + args
         # quoting arguments if windows
-        if sys.platform == 'win32':
+        if sys.platform == "win32":
+
             def quote(arg):
-                if ' ' in arg:
+                if " " in arg:
                     return '"%s"' % arg
                 return arg
+
             args = [quote(arg) for arg in args]
         return os.spawnl(os.P_WAIT, sys.executable, *args) == 0
+
 
 DEFAULT_VERSION = "0.6.38"
 DEFAULT_URL = "http://pypi.python.org/packages/source/d/distribute/"
 SETUPTOOLS_FAKED_VERSION = "0.6c11"
 
-SETUPTOOLS_PKG_INFO = """\
+SETUPTOOLS_PKG_INFO = (
+    """\
 Metadata-Version: 1.0
 Name: setuptools
 Version: %s
@@ -63,13 +68,15 @@ Author: xxx
 Author-email: xxx
 License: xxx
 Description: xxx
-""" % SETUPTOOLS_FAKED_VERSION
+"""
+    % SETUPTOOLS_FAKED_VERSION
+)
 
 
 def _install(tarball, install_args=()):
     # extracting the tarball
     tmpdir = tempfile.mkdtemp()
-    log.warn('Extracting in %s', tmpdir)
+    log.warn("Extracting in %s", tmpdir)
     old_wd = os.getcwd()
     try:
         os.chdir(tmpdir)
@@ -80,13 +87,13 @@ def _install(tarball, install_args=()):
         # going in the directory
         subdir = os.path.join(tmpdir, os.listdir(tmpdir)[0])
         os.chdir(subdir)
-        log.warn('Now working in %s', subdir)
+        log.warn("Now working in %s", subdir)
 
         # installing
-        log.warn('Installing Distribute')
-        if not _python_cmd('setup.py', 'install', *install_args):
-            log.warn('Something went wrong during the installation.')
-            log.warn('See the error message above.')
+        log.warn("Installing Distribute")
+        if not _python_cmd("setup.py", "install", *install_args):
+            log.warn("Something went wrong during the installation.")
+            log.warn("See the error message above.")
             # exitcode will be 2
             return 2
     finally:
@@ -97,7 +104,7 @@ def _install(tarball, install_args=()):
 def _build_egg(egg, tarball, to_dir):
     # extracting the tarball
     tmpdir = tempfile.mkdtemp()
-    log.warn('Extracting in %s', tmpdir)
+    log.warn("Extracting in %s", tmpdir)
     old_wd = os.getcwd()
     try:
         os.chdir(tmpdir)
@@ -108,11 +115,11 @@ def _build_egg(egg, tarball, to_dir):
         # going in the directory
         subdir = os.path.join(tmpdir, os.listdir(tmpdir)[0])
         os.chdir(subdir)
-        log.warn('Now working in %s', subdir)
+        log.warn("Now working in %s", subdir)
 
         # building an egg
-        log.warn('Building a Distribute egg in %s', to_dir)
-        _python_cmd('setup.py', '-q', 'bdist_egg', '--dist-dir', to_dir)
+        log.warn("Building a Distribute egg in %s", to_dir)
+        _python_cmd("setup.py", "-q", "bdist_egg", "--dist-dir", to_dir)
 
     finally:
         os.chdir(old_wd)
@@ -120,31 +127,39 @@ def _build_egg(egg, tarball, to_dir):
     # returning the result
     log.warn(egg)
     if not os.path.exists(egg):
-        raise IOError('Could not build the egg.')
+        raise IOError("Could not build the egg.")
 
 
 def _do_download(version, download_base, to_dir, download_delay):
-    egg = os.path.join(to_dir, 'distribute-%s-py%d.%d.egg'
-                       % (version, sys.version_info[0], sys.version_info[1]))
+    egg = os.path.join(
+        to_dir,
+        "distribute-%s-py%d.%d.egg"
+        % (version, sys.version_info[0], sys.version_info[1]),
+    )
     if not os.path.exists(egg):
-        tarball = download_setuptools(version, download_base,
-                                      to_dir, download_delay)
+        tarball = download_setuptools(version, download_base, to_dir, download_delay)
         _build_egg(egg, tarball, to_dir)
     sys.path.insert(0, egg)
     import setuptools
+
     setuptools.bootstrap_install_from = egg
 
 
-def use_setuptools(version=DEFAULT_VERSION, download_base=DEFAULT_URL,
-                   to_dir=os.curdir, download_delay=15, no_fake=True):
+def use_setuptools(
+    version=DEFAULT_VERSION,
+    download_base=DEFAULT_URL,
+    to_dir=os.curdir,
+    download_delay=15,
+    no_fake=True,
+):
     # making sure we use the absolute path
     to_dir = os.path.abspath(to_dir)
-    was_imported = 'pkg_resources' in sys.modules or \
-        'setuptools' in sys.modules
+    was_imported = "pkg_resources" in sys.modules or "setuptools" in sys.modules
     try:
         try:
             import pkg_resources
-            if not hasattr(pkg_resources, '_distribute'):
+
+            if not hasattr(pkg_resources, "_distribute"):
                 if not no_fake:
                     _fake_setuptools()
                 raise ImportError
@@ -157,26 +172,26 @@ def use_setuptools(version=DEFAULT_VERSION, download_base=DEFAULT_URL,
             e = sys.exc_info()[1]
             if was_imported:
                 sys.stderr.write(
-                "The required version of distribute (>=%s) is not available,\n"
-                "and can't be installed while this script is running. Please\n"
-                "install a more recent version first, using\n"
-                "'easy_install -U distribute'."
-                "\n\n(Currently using %r)\n" % (version, e.args[0]))
+                    "The required version of distribute (>=%s) is not available,\n"
+                    "and can't be installed while this script is running. Please\n"
+                    "install a more recent version first, using\n"
+                    "'easy_install -U distribute'."
+                    "\n\n(Currently using %r)\n" % (version, e.args[0])
+                )
                 sys.exit(2)
             else:
-                del pkg_resources, sys.modules['pkg_resources']    # reload ok
-                return _do_download(version, download_base, to_dir,
-                                    download_delay)
+                del pkg_resources, sys.modules["pkg_resources"]  # reload ok
+                return _do_download(version, download_base, to_dir, download_delay)
         except pkg_resources.DistributionNotFound:
-            return _do_download(version, download_base, to_dir,
-                                download_delay)
+            return _do_download(version, download_base, to_dir, download_delay)
     finally:
         if not no_fake:
             _create_fake_setuptools_pkg_info(to_dir)
 
 
-def download_setuptools(version=DEFAULT_VERSION, download_base=DEFAULT_URL,
-                        to_dir=os.curdir, delay=15):
+def download_setuptools(
+    version=DEFAULT_VERSION, download_base=DEFAULT_URL, to_dir=os.curdir, delay=15
+):
     """Download distribute from a specified location and return its filename
 
     `version` should be a valid distribute version number that is available
@@ -216,9 +231,12 @@ def _no_sandbox(function):
     def __no_sandbox(*args, **kw):
         try:
             from setuptools.sandbox import DirectorySandbox
-            if not hasattr(DirectorySandbox, '_old'):
+
+            if not hasattr(DirectorySandbox, "_old"):
+
                 def violation(*args):
                     pass
+
                 DirectorySandbox._old = DirectorySandbox._violation
                 DirectorySandbox._violation = violation
                 patched = True
@@ -244,16 +262,17 @@ def _patch_file(path, content):
     f.close()
     if existing_content == content:
         # already patched
-        log.warn('Already patched.')
+        log.warn("Already patched.")
         return False
-    log.warn('Patching...')
+    log.warn("Patching...")
     _rename_path(path)
-    f = open(path, 'w')
+    f = open(path, "w")
     try:
         f.write(content)
     finally:
         f.close()
     return True
+
 
 _patch_file = _no_sandbox(_patch_file)
 
@@ -266,26 +285,26 @@ def _same_content(path, content):
 
 
 def _rename_path(path):
-    new_name = path + '.OLD.%s' % time.time()
-    log.warn('Renaming %s to %s', path, new_name)
+    new_name = path + ".OLD.%s" % time.time()
+    log.warn("Renaming %s to %s", path, new_name)
     os.rename(path, new_name)
     return new_name
 
 
 def _remove_flat_installation(placeholder):
     if not os.path.isdir(placeholder):
-        log.warn('Unkown installation at %s', placeholder)
+        log.warn("Unkown installation at %s", placeholder)
         return False
     found = False
     for file in os.listdir(placeholder):
-        if fnmatch.fnmatch(file, 'setuptools*.egg-info'):
+        if fnmatch.fnmatch(file, "setuptools*.egg-info"):
             found = True
             break
     if not found:
-        log.warn('Could not locate setuptools*.egg-info')
+        log.warn("Could not locate setuptools*.egg-info")
         return
 
-    log.warn('Moving elements out of the way...')
+    log.warn("Moving elements out of the way...")
     pkg_info = os.path.join(placeholder, file)
     if os.path.isdir(pkg_info):
         patched = _patch_egg_dir(pkg_info)
@@ -293,42 +312,44 @@ def _remove_flat_installation(placeholder):
         patched = _patch_file(pkg_info, SETUPTOOLS_PKG_INFO)
 
     if not patched:
-        log.warn('%s already patched.', pkg_info)
+        log.warn("%s already patched.", pkg_info)
         return False
     # now let's move the files out of the way
-    for element in ('setuptools', 'pkg_resources.py', 'site.py'):
+    for element in ("setuptools", "pkg_resources.py", "site.py"):
         element = os.path.join(placeholder, element)
         if os.path.exists(element):
             _rename_path(element)
         else:
-            log.warn('Could not find the %s element of the '
-                     'Setuptools distribution', element)
+            log.warn(
+                "Could not find the %s element of the " "Setuptools distribution",
+                element,
+            )
     return True
+
 
 _remove_flat_installation = _no_sandbox(_remove_flat_installation)
 
 
 def _after_install(dist):
-    log.warn('After install bootstrap.')
-    placeholder = dist.get_command_obj('install').install_purelib
+    log.warn("After install bootstrap.")
+    placeholder = dist.get_command_obj("install").install_purelib
     _create_fake_setuptools_pkg_info(placeholder)
 
 
 def _create_fake_setuptools_pkg_info(placeholder):
     if not placeholder or not os.path.exists(placeholder):
-        log.warn('Could not find the install location')
+        log.warn("Could not find the install location")
         return
-    pyver = '%s.%s' % (sys.version_info[0], sys.version_info[1])
-    setuptools_file = 'setuptools-%s-py%s.egg-info' % \
-            (SETUPTOOLS_FAKED_VERSION, pyver)
+    pyver = "%s.%s" % (sys.version_info[0], sys.version_info[1])
+    setuptools_file = "setuptools-%s-py%s.egg-info" % (SETUPTOOLS_FAKED_VERSION, pyver)
     pkg_info = os.path.join(placeholder, setuptools_file)
     if os.path.exists(pkg_info):
-        log.warn('%s already exists', pkg_info)
+        log.warn("%s already exists", pkg_info)
         return
 
-    log.warn('Creating %s', pkg_info)
+    log.warn("Creating %s", pkg_info)
     try:
-        f = open(pkg_info, 'w')
+        f = open(pkg_info, "w")
     except EnvironmentError:
         log.warn("Don't have permissions to write %s, skipping", pkg_info)
         return
@@ -337,126 +358,125 @@ def _create_fake_setuptools_pkg_info(placeholder):
     finally:
         f.close()
 
-    pth_file = os.path.join(placeholder, 'setuptools.pth')
-    log.warn('Creating %s', pth_file)
-    f = open(pth_file, 'w')
+    pth_file = os.path.join(placeholder, "setuptools.pth")
+    log.warn("Creating %s", pth_file)
+    f = open(pth_file, "w")
     try:
         f.write(os.path.join(os.curdir, setuptools_file))
     finally:
         f.close()
 
-_create_fake_setuptools_pkg_info = _no_sandbox(
-    _create_fake_setuptools_pkg_info
-)
+
+_create_fake_setuptools_pkg_info = _no_sandbox(_create_fake_setuptools_pkg_info)
 
 
 def _patch_egg_dir(path):
     # let's check if it's already patched
-    pkg_info = os.path.join(path, 'EGG-INFO', 'PKG-INFO')
+    pkg_info = os.path.join(path, "EGG-INFO", "PKG-INFO")
     if os.path.exists(pkg_info):
         if _same_content(pkg_info, SETUPTOOLS_PKG_INFO):
-            log.warn('%s already patched.', pkg_info)
+            log.warn("%s already patched.", pkg_info)
             return False
     _rename_path(path)
     os.mkdir(path)
-    os.mkdir(os.path.join(path, 'EGG-INFO'))
-    pkg_info = os.path.join(path, 'EGG-INFO', 'PKG-INFO')
-    f = open(pkg_info, 'w')
+    os.mkdir(os.path.join(path, "EGG-INFO"))
+    pkg_info = os.path.join(path, "EGG-INFO", "PKG-INFO")
+    f = open(pkg_info, "w")
     try:
         f.write(SETUPTOOLS_PKG_INFO)
     finally:
         f.close()
     return True
 
+
 _patch_egg_dir = _no_sandbox(_patch_egg_dir)
 
 
 def _before_install():
-    log.warn('Before install bootstrap.')
+    log.warn("Before install bootstrap.")
     _fake_setuptools()
 
 
 def _under_prefix(location):
-    if 'install' not in sys.argv:
+    if "install" not in sys.argv:
         return True
-    args = sys.argv[sys.argv.index('install') + 1:]
+    args = sys.argv[sys.argv.index("install") + 1 :]
     for index, arg in enumerate(args):
-        for option in ('--root', '--prefix'):
-            if arg.startswith('%s=' % option):
-                top_dir = arg.split('root=')[-1]
+        for option in ("--root", "--prefix"):
+            if arg.startswith("%s=" % option):
+                top_dir = arg.split("root=")[-1]
                 return location.startswith(top_dir)
             elif arg == option:
                 if len(args) > index:
                     top_dir = args[index + 1]
                     return location.startswith(top_dir)
-        if arg == '--user' and USER_SITE is not None:
+        if arg == "--user" and USER_SITE is not None:
             return location.startswith(USER_SITE)
     return True
 
 
 def _fake_setuptools():
-    log.warn('Scanning installed packages')
+    log.warn("Scanning installed packages")
     try:
         import pkg_resources
     except ImportError:
         # we're cool
-        log.warn('Setuptools or Distribute does not seem to be installed.')
+        log.warn("Setuptools or Distribute does not seem to be installed.")
         return
     ws = pkg_resources.working_set
     try:
         setuptools_dist = ws.find(
-            pkg_resources.Requirement.parse('setuptools', replacement=False)
-            )
+            pkg_resources.Requirement.parse("setuptools", replacement=False)
+        )
     except TypeError:
         # old distribute API
-        setuptools_dist = ws.find(
-            pkg_resources.Requirement.parse('setuptools')
-        )
+        setuptools_dist = ws.find(pkg_resources.Requirement.parse("setuptools"))
 
     if setuptools_dist is None:
-        log.warn('No setuptools distribution found')
+        log.warn("No setuptools distribution found")
         return
     # detecting if it was already faked
     setuptools_location = setuptools_dist.location
-    log.warn('Setuptools installation detected at %s', setuptools_location)
+    log.warn("Setuptools installation detected at %s", setuptools_location)
 
     # if --root or --preix was provided, and if
     # setuptools is not located in them, we don't patch it
     if not _under_prefix(setuptools_location):
-        log.warn('Not patching, --root or --prefix is installing Distribute'
-                 ' in another location')
+        log.warn(
+            "Not patching, --root or --prefix is installing Distribute"
+            " in another location"
+        )
         return
 
     # let's see if its an egg
-    if not setuptools_location.endswith('.egg'):
-        log.warn('Non-egg installation')
+    if not setuptools_location.endswith(".egg"):
+        log.warn("Non-egg installation")
         res = _remove_flat_installation(setuptools_location)
         if not res:
             return
     else:
-        log.warn('Egg installation')
-        pkg_info = os.path.join(setuptools_location, 'EGG-INFO', 'PKG-INFO')
-        if (os.path.exists(pkg_info) and
-            _same_content(pkg_info, SETUPTOOLS_PKG_INFO)):
-            log.warn('Already patched.')
+        log.warn("Egg installation")
+        pkg_info = os.path.join(setuptools_location, "EGG-INFO", "PKG-INFO")
+        if os.path.exists(pkg_info) and _same_content(pkg_info, SETUPTOOLS_PKG_INFO):
+            log.warn("Already patched.")
             return
-        log.warn('Patching...')
+        log.warn("Patching...")
         # let's create a fake egg replacing setuptools one
         res = _patch_egg_dir(setuptools_location)
         if not res:
             return
-    log.warn('Patching complete.')
+    log.warn("Patching complete.")
     _relaunch()
 
 
 def _relaunch():
-    log.warn('Relaunching...')
+    log.warn("Relaunching...")
     # we have to relaunch the process
     # pip marker to avoid a relaunch bug
-    _cmd1 = ['-c', 'install', '--single-version-externally-managed']
-    _cmd2 = ['-c', 'install', '--record']
+    _cmd1 = ["-c", "install", "--single-version-externally-managed"]
+    _cmd2 = ["-c", "install", "--record"]
     if sys.argv[:3] == _cmd1 or sys.argv[:3] == _cmd2:
-        sys.argv[0] = 'setup.py'
+        sys.argv[0] = "setup.py"
     args = [sys.executable] + sys.argv
     sys.exit(subprocess.call(args))
 
@@ -471,6 +491,7 @@ def _extractall(self, path=".", members=None):
     import copy
     import operator
     from tarfile import ExtractError
+
     directories = []
 
     if members is None:
@@ -486,12 +507,14 @@ def _extractall(self, path=".", members=None):
 
     # Reverse sort directories.
     if sys.version_info < (2, 4):
+
         def sorter(dir1, dir2):
             return cmp(dir1.name, dir2.name)
+
         directories.sort(sorter)
         directories.reverse()
     else:
-        directories.sort(key=operator.attrgetter('name'), reverse=True)
+        directories.sort(key=operator.attrgetter("name"), reverse=True)
 
     # Set correct owner, mtime and filemode on directories.
     for tarinfo in directories:
@@ -517,8 +540,9 @@ def _build_install_args(options):
         if sys.version_info < (2, 6):
             log.warn("--user requires Python 2.6 or later")
             raise SystemExit(1)
-        install_args.append('--user')
+        install_args.append("--user")
     return install_args
+
 
 def _parse_args():
     """
@@ -526,15 +550,23 @@ def _parse_args():
     """
     parser = optparse.OptionParser()
     parser.add_option(
-        '--user', dest='user_install', action='store_true', default=False,
-        help='install in user site package (requires Python 2.6 or later)')
+        "--user",
+        dest="user_install",
+        action="store_true",
+        default=False,
+        help="install in user site package (requires Python 2.6 or later)",
+    )
     parser.add_option(
-        '--download-base', dest='download_base', metavar="URL",
+        "--download-base",
+        dest="download_base",
+        metavar="URL",
         default=DEFAULT_URL,
-        help='alternative URL from where to download the distribute package')
+        help="alternative URL from where to download the distribute package",
+    )
     options, args = parser.parse_args()
     # positional arguments are ignored
     return options
+
 
 def main(version=DEFAULT_VERSION):
     """Install or upgrade setuptools and EasyInstall"""
@@ -542,5 +574,6 @@ def main(version=DEFAULT_VERSION):
     tarball = download_setuptools(download_base=options.download_base)
     return _install(tarball, _build_install_args(options))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     sys.exit(main())

--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file has been taken from Keras' `docs` module found here:  
+# This file has been taken from Keras' `docs` module found here:
 # https://github.com/keras-team/keras/blob/master/docs/autogen.py
 #
 from __future__ import print_function
@@ -11,13 +11,13 @@ import os
 import shutil
 
 import sys
-if sys.version[0] == '2':
+
+if sys.version[0] == "2":
     reload(sys)
-    sys.setdefaultencoding('utf8')
+    sys.setdefaultencoding("utf8")
 
 
-EXCLUDE = {
-}
+EXCLUDE = {}
 
 
 PAGES = [
@@ -34,11 +34,11 @@ PAGES = [
     # },
 ]
 
-ROOT = 'http://hyperopt.github.io/hyperopt'
+ROOT = "http://hyperopt.github.io/hyperopt"
 
 
 def get_function_signature(function, method=True):
-    wrapped = getattr(function, '_original_function', None)
+    wrapped = getattr(function, "_original_function", None)
     if wrapped is None:
         signature = inspect.getargspec(function)
     else:
@@ -49,70 +49,70 @@ def get_function_signature(function, method=True):
     else:
         args = signature.args
     if defaults:
-        kwargs = zip(args[-len(defaults):], defaults)
-        args = args[:-len(defaults)]
+        kwargs = zip(args[-len(defaults) :], defaults)
+        args = args[: -len(defaults)]
     else:
         kwargs = []
-    st = '%s.%s(' % (clean_module_name(function.__module__), function.__name__)
+    st = "%s.%s(" % (clean_module_name(function.__module__), function.__name__)
 
     for a in args:
-        st += str(a) + ', '
+        st += str(a) + ", "
     for a, v in kwargs:
         if isinstance(v, str):
-            v = '\'' + v + '\''
-        st += str(a) + '=' + str(v) + ', '
+            v = "'" + v + "'"
+        st += str(a) + "=" + str(v) + ", "
     if kwargs or args:
-        signature = st[:-2] + ')'
+        signature = st[:-2] + ")"
     else:
-        signature = st + ')'
+        signature = st + ")"
     return signature
 
 
 def get_class_signature(cls):
     try:
         class_signature = get_function_signature(cls.__init__)
-        class_signature = class_signature.replace('__init__', cls.__name__)
+        class_signature = class_signature.replace("__init__", cls.__name__)
     except (TypeError, AttributeError):
         # in case the class inherits from object and does not
         # define __init__
         class_signature = "{clean_module_name}.{cls_name}()".format(
-            clean_module_name=clean_module_name(cls.__module__),
-            cls_name=cls.__name__
+            clean_module_name=clean_module_name(cls.__module__), cls_name=cls.__name__
         )
     return class_signature
 
 
 def clean_module_name(name):
-    assert name[:8] == 'hyperopt.', 'Invalid module name: %s' % name
+    assert name[:8] == "hyperopt.", "Invalid module name: %s" % name
     return name
 
 
 def class_to_docs_link(cls):
     module_name = clean_module_name(cls.__module__)
     module_name = module_name[6:]
-    link = ROOT + module_name.replace('.', '/') + '#' + cls.__name__.lower()
+    link = ROOT + module_name.replace(".", "/") + "#" + cls.__name__.lower()
     return link
 
 
 def class_to_source_link(cls):
     module_name = clean_module_name(cls.__module__)
-    path = module_name.replace('.', '/')
-    path += '.py'
+    path = module_name.replace(".", "/")
+    path += ".py"
     line = inspect.getsourcelines(cls)[-1]
-    link = ('https://github.com/hyperopt/'
-            'hyperopt/blob/master/' + path + '#L' + str(line))
-    return '[[source]](' + link + ')'
+    link = "https://github.com/hyperopt/" "hyperopt/blob/master/" + path + "#L" + str(
+        line
+    )
+    return "[[source]](" + link + ")"
 
 
 def code_snippet(snippet):
-    result = '```python\n'
-    result += snippet + '\n'
-    result += '```\n'
+    result = "```python\n"
+    result += snippet + "\n"
+    result += "```\n"
     return result
 
 
 def count_leading_spaces(s):
-    ws = re.search(r'\S', s)
+    ws = re.search(r"\S", s)
     if ws:
         return ws.start()
     else:
@@ -120,69 +120,69 @@ def count_leading_spaces(s):
 
 
 def process_list_block(docstring, starting_point, leading_spaces, marker):
-    ending_point = docstring.find('\n\n', starting_point)
-    block = docstring[starting_point:(None if ending_point == -1 else
-                                      ending_point - 1)]
+    ending_point = docstring.find("\n\n", starting_point)
+    block = docstring[
+        starting_point : (None if ending_point == -1 else ending_point - 1)
+    ]
     # Place marker for later reinjection.
     docstring = docstring.replace(block, marker)
-    lines = block.split('\n')
+    lines = block.split("\n")
     # Remove the computed number of leading white spaces from each line.
-    lines = [re.sub('^' + ' ' * leading_spaces, '', line) for line in lines]
+    lines = [re.sub("^" + " " * leading_spaces, "", line) for line in lines]
     # Usually lines have at least 4 additional leading spaces.
     # These have to be removed, but first the list roots have to be detected.
-    top_level_regex = r'^    ([^\s\\\(]+):(.*)'
-    top_level_replacement = r'- __\1__:\2'
+    top_level_regex = r"^    ([^\s\\\(]+):(.*)"
+    top_level_replacement = r"- __\1__:\2"
     lines = [re.sub(top_level_regex, top_level_replacement, line) for line in lines]
     # All the other lines get simply the 4 leading space (if present) removed
-    lines = [re.sub(r'^    ', '', line) for line in lines]
+    lines = [re.sub(r"^    ", "", line) for line in lines]
     # Fix text lines after lists
     indent = 0
     text_block = False
     for i in range(len(lines)):
         line = lines[i]
-        spaces = re.search(r'\S', line)
+        spaces = re.search(r"\S", line)
         if spaces:
             # If it is a list element
-            if line[spaces.start()] == '-':
+            if line[spaces.start()] == "-":
                 indent = spaces.start() + 1
                 if text_block:
                     text_block = False
-                    lines[i] = '\n' + line
+                    lines[i] = "\n" + line
             elif spaces.start() < indent:
                 text_block = True
                 indent = spaces.start()
-                lines[i] = '\n' + line
+                lines[i] = "\n" + line
         else:
             text_block = False
             indent = 0
-    block = '\n'.join(lines)
+    block = "\n".join(lines)
     return docstring, block
 
 
 def process_docstring(docstring):
     # First, extract code blocks and process them.
     code_blocks = []
-    if '```' in docstring:
+    if "```" in docstring:
         tmp = docstring[:]
-        while '```' in tmp:
-            tmp = tmp[tmp.find('```'):]
-            index = tmp[3:].find('```') + 6
+        while "```" in tmp:
+            tmp = tmp[tmp.find("```") :]
+            index = tmp[3:].find("```") + 6
             snippet = tmp[:index]
             # Place marker in docstring for later reinjection.
-            docstring = docstring.replace(
-                snippet, '$CODE_BLOCK_%d' % len(code_blocks))
-            snippet_lines = snippet.split('\n')
+            docstring = docstring.replace(snippet, "$CODE_BLOCK_%d" % len(code_blocks))
+            snippet_lines = snippet.split("\n")
             # Remove leading spaces.
-            num_leading_spaces = snippet_lines[-1].find('`')
-            snippet_lines = ([snippet_lines[0]] +
-                             [line[num_leading_spaces:]
-                             for line in snippet_lines[1:]])
+            num_leading_spaces = snippet_lines[-1].find("`")
+            snippet_lines = [snippet_lines[0]] + [
+                line[num_leading_spaces:] for line in snippet_lines[1:]
+            ]
             # Most code snippets have 3 or 4 more leading spaces
             # on inner lines, but not all. Remove them.
             inner_lines = snippet_lines[1:-1]
             leading_spaces = None
             for line in inner_lines:
-                if not line or line[0] == '\n':
+                if not line or line[0] == "\n":
                     continue
                 spaces = count_leading_spaces(line)
                 if leading_spaces is None:
@@ -190,16 +190,17 @@ def process_docstring(docstring):
                 if spaces < leading_spaces:
                     leading_spaces = spaces
             if leading_spaces:
-                snippet_lines = ([snippet_lines[0]] +
-                                 [line[leading_spaces:]
-                                  for line in snippet_lines[1:-1]] +
-                                 [snippet_lines[-1]])
-            snippet = '\n'.join(snippet_lines)
+                snippet_lines = (
+                    [snippet_lines[0]]
+                    + [line[leading_spaces:] for line in snippet_lines[1:-1]]
+                    + [snippet_lines[-1]]
+                )
+            snippet = "\n".join(snippet_lines)
             code_blocks.append(snippet)
             tmp = tmp[index:]
 
     # Format docstring lists.
-    section_regex = r'\n( +)# (.*)\n'
+    section_regex = r"\n( +)# (.*)\n"
     section_idx = re.search(section_regex, docstring)
     shift = 0
     sections = {}
@@ -207,22 +208,19 @@ def process_docstring(docstring):
         anchor = section_idx.group(2)
         leading_spaces = len(section_idx.group(1))
         shift += section_idx.end()
-        marker = '$' + anchor.replace(' ', '_') + '$'
-        docstring, content = process_list_block(docstring,
-                                                shift,
-                                                leading_spaces,
-                                                marker)
+        marker = "$" + anchor.replace(" ", "_") + "$"
+        docstring, content = process_list_block(
+            docstring, shift, leading_spaces, marker
+        )
         sections[marker] = content
         section_idx = re.search(section_regex, docstring[shift:])
 
     # Format docstring section titles.
-    docstring = re.sub(r'\n(\s+)# (.*)\n',
-                       r'\n\1__\2__\n\n',
-                       docstring)
+    docstring = re.sub(r"\n(\s+)# (.*)\n", r"\n\1__\2__\n\n", docstring)
 
     # Strip all remaining leading spaces.
-    lines = docstring.split('\n')
-    docstring = '\n'.join([line.lstrip(' ') for line in lines])
+    lines = docstring.split("\n")
+    docstring = "\n".join([line.lstrip(" ") for line in lines])
 
     # Reinject list blocks.
     for marker, content in sections.items():
@@ -230,23 +228,23 @@ def process_docstring(docstring):
 
     # Reinject code blocks.
     for i, code_block in enumerate(code_blocks):
-        docstring = docstring.replace(
-            '$CODE_BLOCK_%d' % i, code_block)
+        docstring = docstring.replace("$CODE_BLOCK_%d" % i, code_block)
     return docstring
 
-print('Cleaning up existing sources directory.')
-if os.path.exists('sources'):
-    shutil.rmtree('sources')
 
-print('Populating sources directory with templates.')
-for subdir, dirs, fnames in os.walk('templates'):
+print("Cleaning up existing sources directory.")
+if os.path.exists("sources"):
+    shutil.rmtree("sources")
+
+print("Populating sources directory with templates.")
+for subdir, dirs, fnames in os.walk("templates"):
     for fname in fnames:
-        new_subdir = subdir.replace('templates', 'sources')
+        new_subdir = subdir.replace("templates", "sources")
         if not os.path.exists(new_subdir):
             os.makedirs(new_subdir)
-        if fname[-3:] == '.md':
+        if fname[-3:] == ".md":
             fpath = os.path.join(subdir, fname)
-            new_fpath = fpath.replace('templates', 'sources')
+            new_fpath = fpath.replace("templates", "sources")
             shutil.copy(fpath, new_fpath)
 
 
@@ -260,7 +258,7 @@ def collect_class_methods(cls, methods):
         return [getattr(cls, m) if isinstance(m, str) else m for m in methods]
     methods = []
     for _, method in inspect.getmembers(cls, predicate=inspect.isroutine):
-        if method.__name__[0] == '_' or method.__name__ in EXCLUDE:
+        if method.__name__[0] == "_" or method.__name__ in EXCLUDE:
             continue
         methods.append(method)
     return methods
@@ -270,27 +268,30 @@ def render_function(function, method=True):
     subblocks = []
     signature = get_function_signature(function, method=method)
     if method:
-        signature = signature.replace(
-            clean_module_name(function.__module__) + '.', '')
-    subblocks.append('### ' + function.__name__ + '\n')
+        signature = signature.replace(clean_module_name(function.__module__) + ".", "")
+    subblocks.append("### " + function.__name__ + "\n")
     subblocks.append(code_snippet(signature))
     docstring = function.__doc__
     if docstring:
         subblocks.append(process_docstring(docstring))
-    return '\n\n'.join(subblocks)
+    return "\n\n".join(subblocks)
 
 
 def read_page_data(page_data, type):
-    assert type in ['classes', 'functions', 'methods']
+    assert type in ["classes", "functions", "methods"]
     data = page_data.get(type, [])
-    for module in page_data.get('all_module_{}'.format(type), []):
+    for module in page_data.get("all_module_{}".format(type), []):
         module_data = []
         for name in dir(module):
-            if name[0] == '_' or name in EXCLUDE:
+            if name[0] == "_" or name in EXCLUDE:
                 continue
             module_member = getattr(module, name)
-            if (inspect.isclass(module_member) and type == 'classes' or
-               inspect.isfunction(module_member) and type == 'functions'):
+            if (
+                inspect.isclass(module_member)
+                and type == "classes"
+                or inspect.isfunction(module_member)
+                and type == "functions"
+            ):
                 instance = module_member
                 if module.__name__ in instance.__module__:
                     if instance not in module_data:
@@ -300,16 +301,16 @@ def read_page_data(page_data, type):
     return data
 
 
-if __name__ == '__main__':
-    readme = read_file('../README.md')
-    index = read_file('templates/index.md')
-    index = index.replace('{{autogenerated}}', readme[readme.find('##'):])
-    with open('sources/index.md', 'w') as f:
+if __name__ == "__main__":
+    readme = read_file("../README.md")
+    index = read_file("templates/index.md")
+    index = index.replace("{{autogenerated}}", readme[readme.find("##") :])
+    with open("sources/index.md", "w") as f:
         f.write(index)
 
-    print('Generating Hyperopt docs')
+    print("Generating Hyperopt docs")
     for page_data in PAGES:
-        classes = read_page_data(page_data, 'classes')
+        classes = read_page_data(page_data, "classes")
 
         blocks = []
         for element in classes:
@@ -318,55 +319,58 @@ if __name__ == '__main__':
             cls = element[0]
             subblocks = []
             signature = get_class_signature(cls)
-            subblocks.append('<span style="float:right;">' +
-                             class_to_source_link(cls) + '</span>')
+            subblocks.append(
+                '<span style="float:right;">' + class_to_source_link(cls) + "</span>"
+            )
             if element[1]:
-                subblocks.append('## ' + cls.__name__ + ' class\n')
+                subblocks.append("## " + cls.__name__ + " class\n")
             else:
-                subblocks.append('### ' + cls.__name__ + '\n')
+                subblocks.append("### " + cls.__name__ + "\n")
             subblocks.append(code_snippet(signature))
             docstring = cls.__doc__
             if docstring:
                 subblocks.append(process_docstring(docstring))
             methods = collect_class_methods(cls, element[1])
             if methods:
-                subblocks.append('\n---')
-                subblocks.append('## ' + cls.__name__ + ' methods\n')
-                subblocks.append('\n---\n'.join(
-                    [render_function(method, method=True) for method in methods]))
-            blocks.append('\n'.join(subblocks))
+                subblocks.append("\n---")
+                subblocks.append("## " + cls.__name__ + " methods\n")
+                subblocks.append(
+                    "\n---\n".join(
+                        [render_function(method, method=True) for method in methods]
+                    )
+                )
+            blocks.append("\n".join(subblocks))
 
-        methods = read_page_data(page_data, 'methods')
+        methods = read_page_data(page_data, "methods")
 
         for method in methods:
             blocks.append(render_function(method, method=True))
 
-        functions = read_page_data(page_data, 'functions')
+        functions = read_page_data(page_data, "functions")
 
         for function in functions:
             blocks.append(render_function(function, method=False))
 
         if not blocks:
-            raise RuntimeError('Found no content for page ' +
-                               page_data['page'])
+            raise RuntimeError("Found no content for page " + page_data["page"])
 
-        mkdown = '\n----\n\n'.join(blocks)
+        mkdown = "\n----\n\n".join(blocks)
         # save module page.
         # Either insert content into existing page,
         # or create page otherwise
-        page_name = page_data['page']
-        path = os.path.join('sources', page_name)
+        page_name = page_data["page"]
+        path = os.path.join("sources", page_name)
         if os.path.exists(path):
             template = read_file(path)
-            assert '{{autogenerated}}' in template, ('Template found for ' + path +
-                                                     ' but missing {{autogenerated}}'
-                                                     ' tag.')
-            mkdown = template.replace('{{autogenerated}}', mkdown)
-            print('...inserting autogenerated content into template:', path)
+            assert "{{autogenerated}}" in template, (
+                "Template found for " + path + " but missing {{autogenerated}}" " tag."
+            )
+            mkdown = template.replace("{{autogenerated}}", mkdown)
+            print("...inserting autogenerated content into template:", path)
         else:
-            print('...creating new page with autogenerated content:', path)
+            print("...creating new page with autogenerated content:", path)
         subdir = os.path.dirname(path)
         if not os.path.exists(subdir):
             os.makedirs(subdir)
-        with open(path, 'w') as f:
+        with open(path, "w") as f:
             f.write(mkdown)

--- a/hyperopt/__init__.py
+++ b/hyperopt/__init__.py
@@ -40,4 +40,4 @@ from . import anneal
 # -- spark extension
 from .spark import SparkTrials
 
-__version__ = '0.2.1'
+__version__ = "0.2.1"

--- a/hyperopt/algobase.py
+++ b/hyperopt/algobase.py
@@ -16,10 +16,7 @@ __contact__ = "github.com/hyperopt/hyperopt"
 
 
 class ExprEvaluator(object):
-    def __init__(self, expr,
-                 deepcopy_inputs=False,
-                 max_program_len=None,
-                 memo_gc=True):
+    def __init__(self, expr, deepcopy_inputs=False, max_program_len=None, memo_gc=True):
         """
         Parameters
         ----------
@@ -52,7 +49,7 @@ class ExprEvaluator(object):
             #    this error would have been appreciated.
             #
             # TODO: Good candidate for Py3K keyword-only argument
-            raise ValueError('deepcopy_inputs should be bool', deepcopy_inputs)
+            raise ValueError("deepcopy_inputs should be bool", deepcopy_inputs)
         self.deepcopy_inputs = deepcopy_inputs
         if max_program_len is None:
             self.max_program_len = pyll.base.DEFAULT_MAX_PROGRAM_LEN
@@ -82,7 +79,7 @@ class ExprEvaluator(object):
         todo = deque([self.expr])
         while todo:
             if len(todo) > self.max_program_len:
-                raise RuntimeError('Probably infinite loop in document')
+                raise RuntimeError("Probably infinite loop in document")
             node = todo.pop()
 
             if node in memo:
@@ -90,7 +87,7 @@ class ExprEvaluator(object):
                 continue
 
             # -- different kinds of nodes are treated differently:
-            if node.name == 'switch':
+            if node.name == "switch":
                 waiting_on = self.on_switch(memo, node)
                 if waiting_on is None:
                     continue
@@ -120,10 +117,9 @@ class ExprEvaluator(object):
                     #      dictionary all of the nodes are stored in the memo
                     #      so all keys are preserved until the entire outer
                     #      function returns
-                    evaluator = self.__class__(rval,
-                                               self.deep_copy_inputs,
-                                               self.max_program_len,
-                                               self.memo_gc)
+                    evaluator = self.__class__(
+                        rval, self.deep_copy_inputs, self.max_program_len, self.memo_gc
+                    )
                     foo = evaluator(memo)
                     self.set_in_memo(memo, node, foo)
                 else:
@@ -175,10 +171,9 @@ class ExprEvaluator(object):
             try:
                 int(switch_i)
             except:
-                raise TypeError('switch argument was', switch_i)
+                raise TypeError("switch argument was", switch_i)
             if switch_i != int(switch_i) or switch_i < 0:
-                raise ValueError('switch pos must be positive int',
-                                 switch_i)
+                raise ValueError("switch pos must be positive int", switch_i)
             rval_var = node.pos_args[switch_i + 1]
             if rval_var in memo:
                 self.set_in_memo(memo, node, memo[rval_var])
@@ -191,8 +186,7 @@ class ExprEvaluator(object):
     def on_node(self, memo, node):
         # -- Retrieve computed arguments of apply node
         args = _args = [memo[v] for v in node.pos_args]
-        kwargs = _kwargs = dict([(k, memo[v])
-                                 for (k, v) in node.named_args])
+        kwargs = _kwargs = dict([(k, memo[v]) for (k, v) in node.named_args])
 
         if self.memo_gc:
             # -- Ensure no computed argument has been (accidentally) freed for
@@ -222,31 +216,27 @@ class SuggestAlgo(ExprEvaluator):
     delegate that to an `on_node_hyperparameter` method. This method
     must be implemented by a derived class.
     """
+
     def __init__(self, domain, trials, seed):
         ExprEvaluator.__init__(self, domain.s_idxs_vals)
         self.domain = domain
         self.trials = trials
-        self.label_by_node = dict([
-            (n, l) for l, n in list(self.domain.vh.vals_by_label().items())])
+        self.label_by_node = dict(
+            [(n, l) for l, n in list(self.domain.vh.vals_by_label().items())]
+        )
         self._seed = seed
         self.rng = np.random.RandomState(seed)
 
     def __call__(self, new_id):
         self.rng.seed(self._seed + new_id)
         memo = self.eval_nodes(
-            memo={
-                self.domain.s_new_ids: [new_id],
-                self.domain.s_rng: self.rng,
-            })
+            memo={self.domain.s_new_ids: [new_id], self.domain.s_rng: self.rng}
+        )
         idxs, vals = memo[self.expr]
         new_result = self.domain.new_result()
-        new_misc = dict(
-            tid=new_id,
-            cmd=self.domain.cmd,
-            workdir=self.domain.workdir)
+        new_misc = dict(tid=new_id, cmd=self.domain.cmd, workdir=self.domain.workdir)
         miscs_update_idxs_vals([new_misc], idxs, vals)
-        rval = self.trials.new_trial_docs(
-            [new_id], [None], [new_result], [new_misc])
+        rval = self.trials.new_trial_docs([new_id], [None], [new_result], [new_misc])
         return rval
 
     def on_node(self, memo, node):
@@ -260,11 +250,10 @@ class SuggestAlgo(ExprEvaluator):
         new_ids = list(new_ids)
         self.rng.seed([self._seed] + new_ids)
         memo = self.eval_nodes(
-            memo={
-                self.domain.s_new_ids: new_ids,
-                self.domain.s_rng: self.rng,
-            })
+            memo={self.domain.s_new_ids: new_ids, self.domain.s_rng: self.rng}
+        )
         idxs, vals = memo[self.expr]
         return idxs, vals
+
 
 # -- flake-8 abhors blank line EOF

--- a/hyperopt/atpe.py
+++ b/hyperopt/atpe.py
@@ -38,11 +38,10 @@ def ClosedNamedTempFile(contents):
         os.unlink(file_name)
 
 
-
 class Hyperparameter:
     """ This class represents a hyperparameter."""
 
-    def __init__(self, config, parent=None, root='root'):
+    def __init__(self, config, parent=None, root="root"):
         self.config = config
         self.root = root
         self.name = root[5:]
@@ -50,8 +49,8 @@ class Hyperparameter:
         self.resultVariableName = re.sub("\\.\\d+\\.", ".", self.name)
 
         self.hyperoptVariableName = self.root
-        if 'name' in config:
-            self.hyperoptVariableName = config['name']
+        if "name" in config:
+            self.hyperoptVariableName = config["name"]
 
     def createHyperoptSpace(self, lockedValues=None):
         name = self.root
@@ -59,145 +58,182 @@ class Hyperparameter:
         if lockedValues is None:
             lockedValues = {}
 
-        if 'anyOf' in self.config or 'oneOf' in self.config:
+        if "anyOf" in self.config or "oneOf" in self.config:
             data = []
-            if 'anyOf' in self.config:
-                data = self.config['anyOf']
+            if "anyOf" in self.config:
+                data = self.config["anyOf"]
             else:
-                data = self.config['oneOf']
+                data = self.config["oneOf"]
 
-            subSpaces = [Hyperparameter(param, self, name + "." + str(index)).createHyperoptSpace(lockedValues) for index, param in enumerate(data)]
+            subSpaces = [
+                Hyperparameter(
+                    param, self, name + "." + str(index)
+                ).createHyperoptSpace(lockedValues)
+                for index, param in enumerate(data)
+            ]
             for index, space in enumerate(subSpaces):
                 space["$index"] = index
 
             choices = hp.choice(self.hyperoptVariableName, subSpaces)
 
             return choices
-        elif 'enum' in self.config:
+        elif "enum" in self.config:
             if self.name in lockedValues:
                 return lockedValues[self.name]
 
-            choices = hp.choice(self.hyperoptVariableName, self.config['enum'])
+            choices = hp.choice(self.hyperoptVariableName, self.config["enum"])
             return choices
-        elif 'constant' in self.config:
+        elif "constant" in self.config:
             if self.name in lockedValues:
                 return lockedValues[self.name]
 
-            return self.config['constant']
-        elif self.config['type'] == 'object':
+            return self.config["constant"]
+        elif self.config["type"] == "object":
             space = {}
-            for key in self.config['properties'].keys():
-                config = self.config['properties'][key]
-                space[key] = Hyperparameter(config, self, name + "." + key).createHyperoptSpace(lockedValues)
+            for key in self.config["properties"].keys():
+                config = self.config["properties"][key]
+                space[key] = Hyperparameter(
+                    config, self, name + "." + key
+                ).createHyperoptSpace(lockedValues)
             return space
-        elif self.config['type'] == 'number':
+        elif self.config["type"] == "number":
             if self.name in lockedValues:
                 return lockedValues[self.name]
 
-            mode = self.config.get('mode', 'uniform')
-            scaling = self.config.get('scaling', 'linear')
+            mode = self.config.get("mode", "uniform")
+            scaling = self.config.get("scaling", "linear")
 
-            if mode == 'uniform':
-                min = self.config.get('min', 0)
-                max = self.config.get('max', 1)
-                rounding = self.config.get('rounding', None)
+            if mode == "uniform":
+                min = self.config.get("min", 0)
+                max = self.config.get("max", 1)
+                rounding = self.config.get("rounding", None)
 
-                if scaling == 'linear':
+                if scaling == "linear":
                     if rounding is not None:
-                        return hp.quniform(self.hyperoptVariableName, min, max, rounding)
+                        return hp.quniform(
+                            self.hyperoptVariableName, min, max, rounding
+                        )
                     else:
                         return hp.uniform(self.hyperoptVariableName, min, max)
-                elif scaling == 'logarithmic':
+                elif scaling == "logarithmic":
                     if rounding is not None:
-                        return hp.qloguniform(self.hyperoptVariableName, math.log(min), math.log(max), rounding)
+                        return hp.qloguniform(
+                            self.hyperoptVariableName,
+                            math.log(min),
+                            math.log(max),
+                            rounding,
+                        )
                     else:
-                        return hp.loguniform(self.hyperoptVariableName, math.log(min), math.log(max))
-            if mode == 'randint':
-                max = self.config.get('max', 1)
+                        return hp.loguniform(
+                            self.hyperoptVariableName, math.log(min), math.log(max)
+                        )
+            if mode == "randint":
+                max = self.config.get("max", 1)
                 return hp.randint(self.hyperoptVariableName, max)
 
-            if mode == 'normal':
-                mean = self.config.get('mean', 0)
-                stddev = self.config.get('stddev', 1)
-                rounding = self.config.get('rounding', None)
+            if mode == "normal":
+                mean = self.config.get("mean", 0)
+                stddev = self.config.get("stddev", 1)
+                rounding = self.config.get("rounding", None)
 
-                if scaling == 'linear':
+                if scaling == "linear":
                     if rounding is not None:
-                        return hp.qnormal(self.hyperoptVariableName, mean, stddev, rounding)
+                        return hp.qnormal(
+                            self.hyperoptVariableName, mean, stddev, rounding
+                        )
                     else:
                         return hp.normal(self.hyperoptVariableName, mean, stddev)
-                elif scaling == 'logarithmic':
+                elif scaling == "logarithmic":
                     if rounding is not None:
-                        return hp.qlognormal(self.hyperoptVariableName, math.log(mean), math.log(stddev), rounding)
+                        return hp.qlognormal(
+                            self.hyperoptVariableName,
+                            math.log(mean),
+                            math.log(stddev),
+                            rounding,
+                        )
                     else:
-                        return hp.lognormal(self.hyperoptVariableName, math.log(mean), math.log(stddev))
+                        return hp.lognormal(
+                            self.hyperoptVariableName, math.log(mean), math.log(stddev)
+                        )
 
     def getFlatParameterNames(self):
         name = self.root
 
-        if 'anyOf' in self.config or 'oneOf' in self.config:
+        if "anyOf" in self.config or "oneOf" in self.config:
             keys = set()
-            if 'anyOf' in self.config:
-                data = self.config['anyOf']
+            if "anyOf" in self.config:
+                data = self.config["anyOf"]
             else:
-                data = self.config['oneOf']
+                data = self.config["oneOf"]
 
             for index, param in enumerate(data):
-                subKeys = Hyperparameter(param, self, name + "." + str(index)).getFlatParameterNames()
+                subKeys = Hyperparameter(
+                    param, self, name + "." + str(index)
+                ).getFlatParameterNames()
                 for key in subKeys:
                     keys.add(key)
 
             return keys
-        elif 'enum' in self.config or 'constant' in self.config:
+        elif "enum" in self.config or "constant" in self.config:
             return [name]
-        elif self.config['type'] == 'object':
+        elif self.config["type"] == "object":
             keys = set()
-            for key in self.config['properties'].keys():
-                config = self.config['properties'][key]
-                subKeys = Hyperparameter(config, self, name + "." + key).getFlatParameterNames()
+            for key in self.config["properties"].keys():
+                config = self.config["properties"][key]
+                subKeys = Hyperparameter(
+                    config, self, name + "." + key
+                ).getFlatParameterNames()
                 for key in subKeys:
                     keys.add(key)
 
             return keys
-        elif self.config['type'] == 'number':
+        elif self.config["type"] == "number":
             return [name]
 
     def getFlatParameters(self):
         name = self.root
-        if 'anyOf' in self.config or 'oneOf' in self.config:
+        if "anyOf" in self.config or "oneOf" in self.config:
             parameters = []
-            if 'anyOf' in self.config:
-                data = self.config['anyOf']
+            if "anyOf" in self.config:
+                data = self.config["anyOf"]
             else:
-                data = self.config['oneOf']
+                data = self.config["oneOf"]
 
             for index, param in enumerate(data):
-                subParameters = Hyperparameter(param, self, name + "." + str(index)).getFlatParameters()
+                subParameters = Hyperparameter(
+                    param, self, name + "." + str(index)
+                ).getFlatParameters()
                 parameters = parameters + subParameters
             return parameters
-        elif 'enum' in self.config or 'constant' in self.config:
+        elif "enum" in self.config or "constant" in self.config:
             return [self]
-        elif self.config['type'] == 'object':
+        elif self.config["type"] == "object":
             parameters = []
-            for key in self.config['properties'].keys():
-                config = self.config['properties'][key]
-                subParameters = Hyperparameter(config, self, name + "." + key).getFlatParameters()
+            for key in self.config["properties"].keys():
+                config = self.config["properties"][key]
+                subParameters = Hyperparameter(
+                    config, self, name + "." + key
+                ).getFlatParameters()
                 parameters = parameters + subParameters
             return parameters
-        elif self.config['type'] == 'number':
+        elif self.config["type"] == "number":
             return [self]
 
     def getLog10Cardinality(self):
-        if 'anyOf' in self.config or 'oneOf' in self.config:
-            if 'anyOf' in self.config:
-                data = self.config['anyOf']
+        if "anyOf" in self.config or "oneOf" in self.config:
+            if "anyOf" in self.config:
+                data = self.config["anyOf"]
             else:
-                data = self.config['oneOf']
+                data = self.config["oneOf"]
 
-            log10_cardinality = Hyperparameter(data[0], self, self.root + ".0").getLog10Cardinality()
+            log10_cardinality = Hyperparameter(
+                data[0], self, self.root + ".0"
+            ).getLog10Cardinality()
             for index, subParam in enumerate(data[1:]):
                 # We used logarithm identities to create this reduction formula
-                other_log10_cardinality = Hyperparameter(subParam, self, self.root + "." + str(index)).getLog10Cardinality()
+                other_log10_cardinality = Hyperparameter(
+                    subParam, self, self.root + "." + str(index)
+                ).getLog10Cardinality()
 
                 # Revert to linear at high and low values, for numerical stability. Check here: https://www.desmos.com/calculator/efkbbftd18 to observe
                 if (log10_cardinality - other_log10_cardinality) > 3:
@@ -205,21 +241,32 @@ class Hyperparameter:
                 elif (other_log10_cardinality - log10_cardinality) > 3:
                     log10_cardinality = other_log10_cardinality + 1
                 else:
-                    log10_cardinality = other_log10_cardinality + math.log10(1 + math.pow(10, log10_cardinality - other_log10_cardinality))
+                    log10_cardinality = other_log10_cardinality + math.log10(
+                        1 + math.pow(10, log10_cardinality - other_log10_cardinality)
+                    )
             return log10_cardinality + math.log10(len(data))
-        elif 'enum' in self.config:
-            return math.log10(len(self.config['enum']))
-        elif 'constant' in self.config:
+        elif "enum" in self.config:
+            return math.log10(len(self.config["enum"]))
+        elif "constant" in self.config:
             return math.log10(1)
-        elif self.config['type'] == 'object':
+        elif self.config["type"] == "object":
             log10_cardinality = 0
-            for index, subParam in enumerate(self.config['properties'].values()):
-                subParameter = Hyperparameter(subParam, self, self.root + "." + str(index))
+            for index, subParam in enumerate(self.config["properties"].values()):
+                subParameter = Hyperparameter(
+                    subParam, self, self.root + "." + str(index)
+                )
                 log10_cardinality += subParameter.getLog10Cardinality()
             return log10_cardinality
-        elif self.config['type'] == 'number':
-            if 'rounding' in self.config:
-                return math.log10(min(20, (self.config['max'] - self.config['min']) / self.config['rounding'] + 1))
+        elif self.config["type"] == "number":
+            if "rounding" in self.config:
+                return math.log10(
+                    min(
+                        20,
+                        (self.config["max"] - self.config["min"])
+                        / self.config["rounding"]
+                        + 1,
+                    )
+                )
             else:
                 return math.log10(20)  # Default of 20 for fully uniform numbers.
 
@@ -230,7 +277,11 @@ class Hyperparameter:
             result_key = root + "." + key
             if isinstance(value, str):
                 flatParams[result_key[1:]] = value
-            elif isinstance(value, float) or isinstance(value, bool) or isinstance(value, int):
+            elif (
+                isinstance(value, float)
+                or isinstance(value, bool)
+                or isinstance(value, int)
+            ):
                 flatParams[result_key[1:]] = value
             elif isinstance(value, dict):
                 for subkey, subvalue in value.items():
@@ -238,17 +289,17 @@ class Hyperparameter:
 
         for key in params.keys():
             value = params[key]
-            recurse(key, value, '')
+            recurse(key, value, "")
 
         flatValues = {}
 
-        if 'anyOf' in self.config or 'oneOf' in self.config:
-            if 'anyOf' in self.config:
-                data = self.config['anyOf']
+        if "anyOf" in self.config or "oneOf" in self.config:
+            if "anyOf" in self.config:
+                data = self.config["anyOf"]
             else:
-                data = self.config['oneOf']
+                data = self.config["oneOf"]
 
-            subParameterIndex = flatParams[self.resultVariableName + '.$index']
+            subParameterIndex = flatParams[self.resultVariableName + ".$index"]
             flatValues[self.name] = subParameterIndex
 
             for index, param in enumerate(data):
@@ -263,17 +314,19 @@ class Hyperparameter:
                         flatValues[flatParam.name] = ""
 
             return flatValues
-        elif 'constant' in self.config:
+        elif "constant" in self.config:
             flatValues[self.name] = flatParams[self.resultVariableName]
             return flatValues
-        elif 'enum' in self.config:
+        elif "enum" in self.config:
             flatValues[self.name] = flatParams[self.resultVariableName]
             return flatValues
-        elif self.config['type'] == 'object':
-            for key in self.config['properties'].keys():
-                config = self.config['properties'][key]
+        elif self.config["type"] == "object":
+            for key in self.config["properties"].keys():
+                config = self.config["properties"][key]
 
-                subFlatValues = Hyperparameter(config, self, self.root + "." + key).convertToFlatValues(flatParams)
+                subFlatValues = Hyperparameter(
+                    config, self, self.root + "." + key
+                ).convertToFlatValues(flatParams)
 
                 for key in subFlatValues:
                     flatValues[key] = subFlatValues[key]
@@ -284,34 +337,38 @@ class Hyperparameter:
                             flatValues[key] = params[key]
 
             return flatValues
-        elif self.config['type'] == 'number':
+        elif self.config["type"] == "number":
             flatValues[self.name] = flatParams[self.resultVariableName]
             return flatValues
 
     def convertToStructuredValues(self, flatValues):
-        if 'anyOf' in self.config or 'oneOf' in self.config:
-            if 'anyOf' in self.config:
-                data = self.config['anyOf']
+        if "anyOf" in self.config or "oneOf" in self.config:
+            if "anyOf" in self.config:
+                data = self.config["anyOf"]
             else:
-                data = self.config['oneOf']
+                data = self.config["oneOf"]
 
             subParameterIndex = flatValues[self.name]
-            subParam = Hyperparameter(data[subParameterIndex], self, self.root + "." + str(subParameterIndex))
+            subParam = Hyperparameter(
+                data[subParameterIndex], self, self.root + "." + str(subParameterIndex)
+            )
 
             structured = subParam.convertToStructuredValues(flatValues)
-            structured['$index'] = subParameterIndex
+            structured["$index"] = subParameterIndex
 
             return structured
-        elif 'constant' in self.config:
+        elif "constant" in self.config:
             return flatValues[self.name]
-        elif 'enum' in self.config:
+        elif "enum" in self.config:
             return flatValues[self.name]
-        elif self.config['type'] == 'object':
+        elif self.config["type"] == "object":
             result = {}
-            for key in self.config['properties'].keys():
-                config = self.config['properties'][key]
+            for key in self.config["properties"].keys():
+                config = self.config["properties"][key]
 
-                subStructuredValue = Hyperparameter(config, self, self.root + "." + key).convertToStructuredValues(flatValues)
+                subStructuredValue = Hyperparameter(
+                    config, self, self.root + "." + key
+                ).convertToStructuredValues(flatValues)
 
                 result[key] = subStructuredValue
 
@@ -320,289 +377,277 @@ class Hyperparameter:
                         if key.startswith("$"):
                             result[key] = flatValues[key]
             return result
-        elif self.config['type'] == 'number':
+        elif self.config["type"] == "number":
             return flatValues[self.name]
-
 
     @staticmethod
     def createHyperparameterConfigForHyperoptDomain(domain):
         if domain.name is None:
-            data = {
-                "type": "object",
-                "properties": {}
-            }
+            data = {"type": "object", "properties": {}}
 
             for key in domain.params:
-                data['properties'][key] = Hyperparameter.createHyperparameterConfigForHyperoptDomain(domain.params[key])
+                data["properties"][
+                    key
+                ] = Hyperparameter.createHyperparameterConfigForHyperoptDomain(
+                    domain.params[key]
+                )
 
-                if 'name' not in data['properties'][key]:
-                    data['properties'][key]['name'] = key
+                if "name" not in data["properties"][key]:
+                    data["properties"][key]["name"] = key
 
             return data
-        elif domain.name == 'dict':
-            data = {
-                "type": "object",
-                "properties": {}
-            }
+        elif domain.name == "dict":
+            data = {"type": "object", "properties": {}}
 
             for item in domain.named_args:
-                data['properties'][item[0]] = Hyperparameter.createHyperparameterConfigForHyperoptDomain(item[1])
+                data["properties"][
+                    item[0]
+                ] = Hyperparameter.createHyperparameterConfigForHyperoptDomain(item[1])
 
             return data
-        elif domain.name == 'switch':
-            data = {
-                "oneOf": [
-
-                ]
-            }
-            data['name'] = domain.pos_args[0].pos_args
+        elif domain.name == "switch":
+            data = {"oneOf": []}
+            data["name"] = domain.pos_args[0].pos_args
 
             for item in domain.pos_args[1:]:
-                data['oneOf'].append(Hyperparameter.createHyperparameterConfigForHyperoptDomain(item))
+                data["oneOf"].append(
+                    Hyperparameter.createHyperparameterConfigForHyperoptDomain(item)
+                )
             return data
-        elif domain.name == 'hyperopt_param':
-            data = Hyperparameter.createHyperparameterConfigForHyperoptDomain(domain.pos_args[1])
-            data['name'] = domain.pos_args[0]._obj
+        elif domain.name == "hyperopt_param":
+            data = Hyperparameter.createHyperparameterConfigForHyperoptDomain(
+                domain.pos_args[1]
+            )
+            data["name"] = domain.pos_args[0]._obj
             return data
-        elif domain.name == 'uniform':
+        elif domain.name == "uniform":
             data = {"type": "number"}
-            data['scaling'] = 'linear'
-            data['mode'] = 'uniform'
-            data['min'] = domain.pos_args[0]._obj
-            data['max'] = domain.pos_args[1]._obj
+            data["scaling"] = "linear"
+            data["mode"] = "uniform"
+            data["min"] = domain.pos_args[0]._obj
+            data["max"] = domain.pos_args[1]._obj
             return data
-        elif domain.name == 'quniform':
+        elif domain.name == "quniform":
             data = {"type": "number"}
-            data['scaling'] = 'linear'
-            data['mode'] = 'uniform'
-            data['min'] = domain.pos_args[0]._obj
-            data['max'] = domain.pos_args[1]._obj
-            data['rounding'] = domain.pos_args[2]._obj
+            data["scaling"] = "linear"
+            data["mode"] = "uniform"
+            data["min"] = domain.pos_args[0]._obj
+            data["max"] = domain.pos_args[1]._obj
+            data["rounding"] = domain.pos_args[2]._obj
             return data
-        elif domain.name == 'loguniform':
+        elif domain.name == "loguniform":
             data = {"type": "number"}
-            data['scaling'] = 'logarithmic'
-            data['mode'] = 'uniform'
-            data['min'] = math.exp(domain.pos_args[0]._obj)
-            data['max'] = math.exp(domain.pos_args[1]._obj)
+            data["scaling"] = "logarithmic"
+            data["mode"] = "uniform"
+            data["min"] = math.exp(domain.pos_args[0]._obj)
+            data["max"] = math.exp(domain.pos_args[1]._obj)
             return data
-        elif domain.name == 'qloguniform':
+        elif domain.name == "qloguniform":
             data = {"type": "number"}
-            data['scaling'] = 'logarithmic'
-            data['mode'] = 'uniform'
-            data['min'] = math.exp(domain.pos_args[0]._obj)
-            data['max'] = math.exp(domain.pos_args[1]._obj)
-            data['rounding'] = domain.pos_args[2]._obj
+            data["scaling"] = "logarithmic"
+            data["mode"] = "uniform"
+            data["min"] = math.exp(domain.pos_args[0]._obj)
+            data["max"] = math.exp(domain.pos_args[1]._obj)
+            data["rounding"] = domain.pos_args[2]._obj
             return data
-        elif domain.name == 'normal':
+        elif domain.name == "normal":
             data = {"type": "number"}
-            data['scaling'] = 'linear'
-            data['mode'] = 'normal'
-            data['mean'] = domain.pos_args[0]._obj
-            data['stddev'] = domain.pos_args[1]._obj
+            data["scaling"] = "linear"
+            data["mode"] = "normal"
+            data["mean"] = domain.pos_args[0]._obj
+            data["stddev"] = domain.pos_args[1]._obj
             return data
-        elif domain.name == 'qnormal':
+        elif domain.name == "qnormal":
             data = {"type": "number"}
-            data['scaling'] = 'linear'
-            data['mode'] = 'normal'
-            data['mean'] = domain.pos_args[0]._obj
-            data['stddev'] = domain.pos_args[1]._obj
-            data['rounding'] = domain.pos_args[2]._obj
+            data["scaling"] = "linear"
+            data["mode"] = "normal"
+            data["mean"] = domain.pos_args[0]._obj
+            data["stddev"] = domain.pos_args[1]._obj
+            data["rounding"] = domain.pos_args[2]._obj
             return data
-        elif domain.name == 'lognormal':
+        elif domain.name == "lognormal":
             data = {"type": "number"}
-            data['scaling'] = 'logarithmic'
-            data['mode'] = 'normal'
-            data['mean'] = math.exp(domain.pos_args[0]._obj)
-            data['stddev'] = math.exp(domain.pos_args[1]._obj)
+            data["scaling"] = "logarithmic"
+            data["mode"] = "normal"
+            data["mean"] = math.exp(domain.pos_args[0]._obj)
+            data["stddev"] = math.exp(domain.pos_args[1]._obj)
             return data
-        elif domain.name == 'qlognormal':
+        elif domain.name == "qlognormal":
             data = {"type": "number"}
-            data['scaling'] = 'logarithmic'
-            data['mode'] = 'normal'
-            data['mean'] = math.exp(domain.pos_args[0]._obj)
-            data['stddev'] = math.exp(domain.pos_args[1]._obj)
-            data['rounding'] = domain.pos_args[2]._obj
+            data["scaling"] = "logarithmic"
+            data["mode"] = "normal"
+            data["mean"] = math.exp(domain.pos_args[0]._obj)
+            data["stddev"] = math.exp(domain.pos_args[1]._obj)
+            data["rounding"] = domain.pos_args[2]._obj
             return data
-        elif domain.name == 'literal':
-            data = {
-                'type': 'string',
-                'constant': domain._obj
-            }
+        elif domain.name == "literal":
+            data = {"type": "string", "constant": domain._obj}
             return data
-        elif domain.name == 'randint':
+        elif domain.name == "randint":
             data = {"type": "number"}
             max = domain.pos_args[0]._obj
-            data['max'] = max
-            data['mode'] = 'randint'
+            data["max"] = max
+            data["mode"] = "randint"
             return data
         else:
             raise ValueError("Unsupported hyperopt domain type " + str(domain))
 
 
-
 class ATPEOptimizer:
-    resultInformationKeys = [
-        'trial',
-        'status',
-        'loss',
-        'time',
-        'log',
-        'error'
-    ]
+    resultInformationKeys = ["trial", "status", "loss", "time", "log", "error"]
 
     atpeParameters = [
-        'gamma',
-        'nEICandidates',
-        'resultFilteringAgeMultiplier',
-        'resultFilteringLossRankMultiplier',
-        'resultFilteringMode',
-        'resultFilteringRandomProbability',
-        'secondaryCorrelationExponent',
-        'secondaryCorrelationMultiplier',
-        'secondaryCutoff',
-        'secondaryFixedProbability',
-        'secondaryLockingMode',
-        'secondaryProbabilityMode',
-        'secondaryTopLockingPercentile',
+        "gamma",
+        "nEICandidates",
+        "resultFilteringAgeMultiplier",
+        "resultFilteringLossRankMultiplier",
+        "resultFilteringMode",
+        "resultFilteringRandomProbability",
+        "secondaryCorrelationExponent",
+        "secondaryCorrelationMultiplier",
+        "secondaryCutoff",
+        "secondaryFixedProbability",
+        "secondaryLockingMode",
+        "secondaryProbabilityMode",
+        "secondaryTopLockingPercentile",
     ]
 
     atpeParameterCascadeOrdering = [
-        'resultFilteringMode',
-        'secondaryProbabilityMode',
-        'secondaryLockingMode',
-        'resultFilteringAgeMultiplier',
-        'resultFilteringLossRankMultiplier',
-        'resultFilteringRandomProbability',
-        'secondaryTopLockingPercentile',
-        'secondaryCorrelationExponent',
-        'secondaryCorrelationMultiplier',
-        'secondaryFixedProbability',
-        'secondaryCutoff',
-        'gamma',
-        'nEICandidates'
+        "resultFilteringMode",
+        "secondaryProbabilityMode",
+        "secondaryLockingMode",
+        "resultFilteringAgeMultiplier",
+        "resultFilteringLossRankMultiplier",
+        "resultFilteringRandomProbability",
+        "secondaryTopLockingPercentile",
+        "secondaryCorrelationExponent",
+        "secondaryCorrelationMultiplier",
+        "secondaryFixedProbability",
+        "secondaryCutoff",
+        "gamma",
+        "nEICandidates",
     ]
 
     atpeParameterValues = {
-        'resultFilteringMode': ['age', 'loss_rank', 'none', 'random'],
-        'secondaryLockingMode': ['random', 'top'],
-        'secondaryProbabilityMode': ['correlation', 'fixed']
+        "resultFilteringMode": ["age", "loss_rank", "none", "random"],
+        "secondaryLockingMode": ["random", "top"],
+        "secondaryProbabilityMode": ["correlation", "fixed"],
     }
 
     atpeModelFeatureKeys = [
-        'all_correlation_best_percentile25_ratio',
-        'all_correlation_best_percentile50_ratio',
-        'all_correlation_best_percentile75_ratio',
-        'all_correlation_kurtosis',
-        'all_correlation_percentile5_percentile25_ratio',
-        'all_correlation_skew',
-        'all_correlation_stddev_best_ratio',
-        'all_correlation_stddev_median_ratio',
-        'all_loss_best_percentile25_ratio',
-        'all_loss_best_percentile50_ratio',
-        'all_loss_best_percentile75_ratio',
-        'all_loss_kurtosis',
-        'all_loss_percentile5_percentile25_ratio',
-        'all_loss_skew',
-        'all_loss_stddev_best_ratio',
-        'all_loss_stddev_median_ratio',
-        'log10_cardinality',
-        'recent_10_correlation_best_percentile25_ratio',
-        'recent_10_correlation_best_percentile50_ratio',
-        'recent_10_correlation_best_percentile75_ratio',
-        'recent_10_correlation_kurtosis',
-        'recent_10_correlation_percentile5_percentile25_ratio',
-        'recent_10_correlation_skew',
-        'recent_10_correlation_stddev_best_ratio',
-        'recent_10_correlation_stddev_median_ratio',
-        'recent_10_loss_best_percentile25_ratio',
-        'recent_10_loss_best_percentile50_ratio',
-        'recent_10_loss_best_percentile75_ratio',
-        'recent_10_loss_kurtosis',
-        'recent_10_loss_percentile5_percentile25_ratio',
-        'recent_10_loss_skew',
-        'recent_10_loss_stddev_best_ratio',
-        'recent_10_loss_stddev_median_ratio',
-        'recent_15%_correlation_best_percentile25_ratio',
-        'recent_15%_correlation_best_percentile50_ratio',
-        'recent_15%_correlation_best_percentile75_ratio',
-        'recent_15%_correlation_kurtosis',
-        'recent_15%_correlation_percentile5_percentile25_ratio',
-        'recent_15%_correlation_skew',
-        'recent_15%_correlation_stddev_best_ratio',
-        'recent_15%_correlation_stddev_median_ratio',
-        'recent_15%_loss_best_percentile25_ratio',
-        'recent_15%_loss_best_percentile50_ratio',
-        'recent_15%_loss_best_percentile75_ratio',
-        'recent_15%_loss_kurtosis',
-        'recent_15%_loss_percentile5_percentile25_ratio',
-        'recent_15%_loss_skew',
-        'recent_15%_loss_stddev_best_ratio',
-        'recent_15%_loss_stddev_median_ratio',
-        'recent_25_correlation_best_percentile25_ratio',
-        'recent_25_correlation_best_percentile50_ratio',
-        'recent_25_correlation_best_percentile75_ratio',
-        'recent_25_correlation_kurtosis',
-        'recent_25_correlation_percentile5_percentile25_ratio',
-        'recent_25_correlation_skew',
-        'recent_25_correlation_stddev_best_ratio',
-        'recent_25_correlation_stddev_median_ratio',
-        'recent_25_loss_best_percentile25_ratio',
-        'recent_25_loss_best_percentile50_ratio',
-        'recent_25_loss_best_percentile75_ratio',
-        'recent_25_loss_kurtosis',
-        'recent_25_loss_percentile5_percentile25_ratio',
-        'recent_25_loss_skew',
-        'recent_25_loss_stddev_best_ratio',
-        'recent_25_loss_stddev_median_ratio',
-        'top_10%_correlation_best_percentile25_ratio',
-        'top_10%_correlation_best_percentile50_ratio',
-        'top_10%_correlation_best_percentile75_ratio',
-        'top_10%_correlation_kurtosis',
-        'top_10%_correlation_percentile5_percentile25_ratio',
-        'top_10%_correlation_skew',
-        'top_10%_correlation_stddev_best_ratio',
-        'top_10%_correlation_stddev_median_ratio',
-        'top_10%_loss_best_percentile25_ratio',
-        'top_10%_loss_best_percentile50_ratio',
-        'top_10%_loss_best_percentile75_ratio',
-        'top_10%_loss_kurtosis',
-        'top_10%_loss_percentile5_percentile25_ratio',
-        'top_10%_loss_skew',
-        'top_10%_loss_stddev_best_ratio',
-        'top_10%_loss_stddev_median_ratio',
-        'top_20%_correlation_best_percentile25_ratio',
-        'top_20%_correlation_best_percentile50_ratio',
-        'top_20%_correlation_best_percentile75_ratio',
-        'top_20%_correlation_kurtosis',
-        'top_20%_correlation_percentile5_percentile25_ratio',
-        'top_20%_correlation_skew',
-        'top_20%_correlation_stddev_best_ratio',
-        'top_20%_correlation_stddev_median_ratio',
-        'top_20%_loss_best_percentile25_ratio',
-        'top_20%_loss_best_percentile50_ratio',
-        'top_20%_loss_best_percentile75_ratio',
-        'top_20%_loss_kurtosis',
-        'top_20%_loss_percentile5_percentile25_ratio',
-        'top_20%_loss_skew',
-        'top_20%_loss_stddev_best_ratio',
-        'top_20%_loss_stddev_median_ratio',
-        'top_30%_correlation_best_percentile25_ratio',
-        'top_30%_correlation_best_percentile50_ratio',
-        'top_30%_correlation_best_percentile75_ratio',
-        'top_30%_correlation_kurtosis',
-        'top_30%_correlation_percentile5_percentile25_ratio',
-        'top_30%_correlation_skew',
-        'top_30%_correlation_stddev_best_ratio',
-        'top_30%_correlation_stddev_median_ratio',
-        'top_30%_loss_best_percentile25_ratio',
-        'top_30%_loss_best_percentile50_ratio',
-        'top_30%_loss_best_percentile75_ratio',
-        'top_30%_loss_kurtosis',
-        'top_30%_loss_percentile5_percentile25_ratio',
-        'top_30%_loss_skew',
-        'top_30%_loss_stddev_best_ratio',
-        'top_30%_loss_stddev_median_ratio'
+        "all_correlation_best_percentile25_ratio",
+        "all_correlation_best_percentile50_ratio",
+        "all_correlation_best_percentile75_ratio",
+        "all_correlation_kurtosis",
+        "all_correlation_percentile5_percentile25_ratio",
+        "all_correlation_skew",
+        "all_correlation_stddev_best_ratio",
+        "all_correlation_stddev_median_ratio",
+        "all_loss_best_percentile25_ratio",
+        "all_loss_best_percentile50_ratio",
+        "all_loss_best_percentile75_ratio",
+        "all_loss_kurtosis",
+        "all_loss_percentile5_percentile25_ratio",
+        "all_loss_skew",
+        "all_loss_stddev_best_ratio",
+        "all_loss_stddev_median_ratio",
+        "log10_cardinality",
+        "recent_10_correlation_best_percentile25_ratio",
+        "recent_10_correlation_best_percentile50_ratio",
+        "recent_10_correlation_best_percentile75_ratio",
+        "recent_10_correlation_kurtosis",
+        "recent_10_correlation_percentile5_percentile25_ratio",
+        "recent_10_correlation_skew",
+        "recent_10_correlation_stddev_best_ratio",
+        "recent_10_correlation_stddev_median_ratio",
+        "recent_10_loss_best_percentile25_ratio",
+        "recent_10_loss_best_percentile50_ratio",
+        "recent_10_loss_best_percentile75_ratio",
+        "recent_10_loss_kurtosis",
+        "recent_10_loss_percentile5_percentile25_ratio",
+        "recent_10_loss_skew",
+        "recent_10_loss_stddev_best_ratio",
+        "recent_10_loss_stddev_median_ratio",
+        "recent_15%_correlation_best_percentile25_ratio",
+        "recent_15%_correlation_best_percentile50_ratio",
+        "recent_15%_correlation_best_percentile75_ratio",
+        "recent_15%_correlation_kurtosis",
+        "recent_15%_correlation_percentile5_percentile25_ratio",
+        "recent_15%_correlation_skew",
+        "recent_15%_correlation_stddev_best_ratio",
+        "recent_15%_correlation_stddev_median_ratio",
+        "recent_15%_loss_best_percentile25_ratio",
+        "recent_15%_loss_best_percentile50_ratio",
+        "recent_15%_loss_best_percentile75_ratio",
+        "recent_15%_loss_kurtosis",
+        "recent_15%_loss_percentile5_percentile25_ratio",
+        "recent_15%_loss_skew",
+        "recent_15%_loss_stddev_best_ratio",
+        "recent_15%_loss_stddev_median_ratio",
+        "recent_25_correlation_best_percentile25_ratio",
+        "recent_25_correlation_best_percentile50_ratio",
+        "recent_25_correlation_best_percentile75_ratio",
+        "recent_25_correlation_kurtosis",
+        "recent_25_correlation_percentile5_percentile25_ratio",
+        "recent_25_correlation_skew",
+        "recent_25_correlation_stddev_best_ratio",
+        "recent_25_correlation_stddev_median_ratio",
+        "recent_25_loss_best_percentile25_ratio",
+        "recent_25_loss_best_percentile50_ratio",
+        "recent_25_loss_best_percentile75_ratio",
+        "recent_25_loss_kurtosis",
+        "recent_25_loss_percentile5_percentile25_ratio",
+        "recent_25_loss_skew",
+        "recent_25_loss_stddev_best_ratio",
+        "recent_25_loss_stddev_median_ratio",
+        "top_10%_correlation_best_percentile25_ratio",
+        "top_10%_correlation_best_percentile50_ratio",
+        "top_10%_correlation_best_percentile75_ratio",
+        "top_10%_correlation_kurtosis",
+        "top_10%_correlation_percentile5_percentile25_ratio",
+        "top_10%_correlation_skew",
+        "top_10%_correlation_stddev_best_ratio",
+        "top_10%_correlation_stddev_median_ratio",
+        "top_10%_loss_best_percentile25_ratio",
+        "top_10%_loss_best_percentile50_ratio",
+        "top_10%_loss_best_percentile75_ratio",
+        "top_10%_loss_kurtosis",
+        "top_10%_loss_percentile5_percentile25_ratio",
+        "top_10%_loss_skew",
+        "top_10%_loss_stddev_best_ratio",
+        "top_10%_loss_stddev_median_ratio",
+        "top_20%_correlation_best_percentile25_ratio",
+        "top_20%_correlation_best_percentile50_ratio",
+        "top_20%_correlation_best_percentile75_ratio",
+        "top_20%_correlation_kurtosis",
+        "top_20%_correlation_percentile5_percentile25_ratio",
+        "top_20%_correlation_skew",
+        "top_20%_correlation_stddev_best_ratio",
+        "top_20%_correlation_stddev_median_ratio",
+        "top_20%_loss_best_percentile25_ratio",
+        "top_20%_loss_best_percentile50_ratio",
+        "top_20%_loss_best_percentile75_ratio",
+        "top_20%_loss_kurtosis",
+        "top_20%_loss_percentile5_percentile25_ratio",
+        "top_20%_loss_skew",
+        "top_20%_loss_stddev_best_ratio",
+        "top_20%_loss_stddev_median_ratio",
+        "top_30%_correlation_best_percentile25_ratio",
+        "top_30%_correlation_best_percentile50_ratio",
+        "top_30%_correlation_best_percentile75_ratio",
+        "top_30%_correlation_kurtosis",
+        "top_30%_correlation_percentile5_percentile25_ratio",
+        "top_30%_correlation_skew",
+        "top_30%_correlation_stddev_best_ratio",
+        "top_30%_correlation_stddev_median_ratio",
+        "top_30%_loss_best_percentile25_ratio",
+        "top_30%_loss_best_percentile50_ratio",
+        "top_30%_loss_best_percentile75_ratio",
+        "top_30%_loss_kurtosis",
+        "top_30%_loss_percentile5_percentile25_ratio",
+        "top_30%_loss_skew",
+        "top_30%_loss_stddev_best_ratio",
+        "top_30%_loss_stddev_median_ratio",
     ]
 
     def __init__(self):
@@ -610,74 +655,101 @@ class ATPEOptimizer:
             import lightgbm
             import sklearn
         except ImportError:
-            raise ImportError("You must install lightgbm and sklearn in order to use the ATPE algorithm. Please run `pip install lightgbm scikit-learn` and try again. These are not built in dependencies of hyperopt.")
+            raise ImportError(
+                "You must install lightgbm and sklearn in order to use the ATPE algorithm. Please run `pip install lightgbm scikit-learn` and try again. These are not built in dependencies of hyperopt."
+            )
 
-        scalingModelData = json.loads(pkg_resources.resource_string(__name__, "atpe_models/scaling_model.json").decode('utf-8'))
+        scalingModelData = json.loads(
+            pkg_resources.resource_string(
+                __name__, "atpe_models/scaling_model.json"
+            ).decode("utf-8")
+        )
         self.featureScalingModels = {}
         for key in self.atpeModelFeatureKeys:
             self.featureScalingModels[key] = sklearn.preprocessing.StandardScaler()
-            self.featureScalingModels[key].scale_ = numpy.array(scalingModelData[key]['scales'])
-            self.featureScalingModels[key].mean_ = numpy.array(scalingModelData[key]['means'])
-            self.featureScalingModels[key].var_ = numpy.array(scalingModelData[key]['variances'])
+            self.featureScalingModels[key].scale_ = numpy.array(
+                scalingModelData[key]["scales"]
+            )
+            self.featureScalingModels[key].mean_ = numpy.array(
+                scalingModelData[key]["means"]
+            )
+            self.featureScalingModels[key].var_ = numpy.array(
+                scalingModelData[key]["variances"]
+            )
 
         self.parameterModels = {}
         self.parameterModelConfigurations = {}
         for param in self.atpeParameters:
-            modelData = pkg_resources.resource_string(__name__, "atpe_models/model-" + param + '.txt')
+            modelData = pkg_resources.resource_string(
+                __name__, "atpe_models/model-" + param + ".txt"
+            )
             with ClosedNamedTempFile(modelData) as model_file_name:
-                self.parameterModels[param] = lightgbm.Booster(model_file=model_file_name)
+                self.parameterModels[param] = lightgbm.Booster(
+                    model_file=model_file_name
+                )
 
-            configString = pkg_resources.resource_string(__name__, "atpe_models/model-" + param + '-configuration.json')
-            data = json.loads(configString.decode('utf-8'))
+            configString = pkg_resources.resource_string(
+                __name__, "atpe_models/model-" + param + "-configuration.json"
+            )
+            data = json.loads(configString.decode("utf-8"))
             self.parameterModelConfigurations[param] = data
 
         self.lastATPEParameters = None
         self.lastLockedParameters = []
         self.atpeParamDetails = None
 
-    def recommendNextParameters(self, hyperparameterSpace, results, currentTrials, lockedValues=None):
+    def recommendNextParameters(
+        self, hyperparameterSpace, results, currentTrials, lockedValues=None
+    ):
         rstate = numpy.random.RandomState(seed=int(random.randint(1, 2 ** 32 - 1)))
 
-        params = {'param': {}}
+        params = {"param": {}}
 
         def sample(parameters):
-            params['param'] = parameters
-            return {"loss": 0.5, 'status': 'ok'}
+            params["param"] = parameters
+            return {"loss": 0.5, "status": "ok"}
 
         parameters = Hyperparameter(hyperparameterSpace).getFlatParameters()
 
         if lockedValues is not None:
             # Remove any locked values from ones the optimizer will examine
-            parameters = list(filter(lambda param: param.name not in lockedValues.keys(), parameters))
+            parameters = list(
+                filter(lambda param: param.name not in lockedValues.keys(), parameters)
+            )
 
         log10_cardinality = Hyperparameter(hyperparameterSpace).getLog10Cardinality()
         initializationRounds = max(10, int(log10_cardinality))
 
         atpeParams = {}
         atpeParamDetails = {}
-        if len(list(result for result in results if result['loss'])) < initializationRounds:
+        if (
+            len(list(result for result in results if result["loss"]))
+            < initializationRounds
+        ):
             atpeParams = {
-                'gamma': 1.0,
-                'nEICandidates': 24,
-                'resultFilteringAgeMultiplier': None,
-                'resultFilteringLossRankMultiplier': None,
-                'resultFilteringMode': "none",
-                'resultFilteringRandomProbability': None,
-                'secondaryCorrelationExponent': 1.0,
-                'secondaryCorrelationMultiplier': None,
-                'secondaryCutoff': 0,
-                'secondarySorting': 0,
-                'secondaryFixedProbability': 0.5,
-                'secondaryLockingMode': 'top',
-                'secondaryProbabilityMode': 'fixed',
-                'secondaryTopLockingPercentile': 0
+                "gamma": 1.0,
+                "nEICandidates": 24,
+                "resultFilteringAgeMultiplier": None,
+                "resultFilteringLossRankMultiplier": None,
+                "resultFilteringMode": "none",
+                "resultFilteringRandomProbability": None,
+                "secondaryCorrelationExponent": 1.0,
+                "secondaryCorrelationMultiplier": None,
+                "secondaryCutoff": 0,
+                "secondarySorting": 0,
+                "secondaryFixedProbability": 0.5,
+                "secondaryLockingMode": "top",
+                "secondaryProbabilityMode": "fixed",
+                "secondaryTopLockingPercentile": 0,
             }
         else:
             # Calculate the statistics for the distribution
             stats = self.computeAllResultStatistics(hyperparameterSpace, results)
-            stats['num_parameters'] = len(parameters)
-            stats['log10_cardinality'] = Hyperparameter(hyperparameterSpace).getLog10Cardinality()
-            stats['log10_trial'] = math.log10(len(results))
+            stats["num_parameters"] = len(parameters)
+            stats["log10_cardinality"] = Hyperparameter(
+                hyperparameterSpace
+            ).getLog10Cardinality()
+            stats["log10_trial"] = math.log10(len(results))
             baseVector = []
 
             for feature in self.atpeModelFeatureKeys:
@@ -687,26 +759,60 @@ class ATPEOptimizer:
 
             baseVector = numpy.array([baseVector])
 
-            for atpeParamIndex, atpeParameter in enumerate(self.atpeParameterCascadeOrdering):
+            for atpeParamIndex, atpeParameter in enumerate(
+                self.atpeParameterCascadeOrdering
+            ):
                 vector = copy.copy(baseVector)[0].tolist()
                 atpeParamFeatures = self.atpeParameterCascadeOrdering[:atpeParamIndex]
                 for atpeParamFeature in atpeParamFeatures:
                     # We have to insert a special value of -3 for any conditional parameters.
-                    if atpeParamFeature == 'resultFilteringAgeMultiplier' and atpeParams['resultFilteringMode'] != 'age':
-                        vector.append(-3)  # This is the default value inserted when parameters aren't relevant
-                    elif atpeParamFeature == 'resultFilteringLossRankMultiplier' and atpeParams['resultFilteringMode'] != 'loss_rank':
-                        vector.append(-3)  # This is the default value inserted when parameters aren't relevant
-                    elif atpeParamFeature == 'resultFilteringRandomProbability' and atpeParams['resultFilteringMode'] != 'random':
-                        vector.append(-3)  # This is the default value inserted when parameters aren't relevant
-                    elif atpeParamFeature == 'secondaryCorrelationMultiplier' and atpeParams['secondaryProbabilityMode'] != 'correlation':
-                        vector.append(-3)  # This is the default value inserted when parameters aren't relevant
-                    elif atpeParamFeature == 'secondaryFixedProbability' and atpeParams['secondaryProbabilityMode'] != 'fixed':
-                        vector.append(-3)  # This is the default value inserted when parameters aren't relevant
-                    elif atpeParamFeature == 'secondaryTopLockingPercentile' and atpeParams['secondaryLockingMode'] != 'top':
-                        vector.append(-3)  # This is the default value inserted when parameters aren't relevant
+                    if (
+                        atpeParamFeature == "resultFilteringAgeMultiplier"
+                        and atpeParams["resultFilteringMode"] != "age"
+                    ):
+                        vector.append(
+                            -3
+                        )  # This is the default value inserted when parameters aren't relevant
+                    elif (
+                        atpeParamFeature == "resultFilteringLossRankMultiplier"
+                        and atpeParams["resultFilteringMode"] != "loss_rank"
+                    ):
+                        vector.append(
+                            -3
+                        )  # This is the default value inserted when parameters aren't relevant
+                    elif (
+                        atpeParamFeature == "resultFilteringRandomProbability"
+                        and atpeParams["resultFilteringMode"] != "random"
+                    ):
+                        vector.append(
+                            -3
+                        )  # This is the default value inserted when parameters aren't relevant
+                    elif (
+                        atpeParamFeature == "secondaryCorrelationMultiplier"
+                        and atpeParams["secondaryProbabilityMode"] != "correlation"
+                    ):
+                        vector.append(
+                            -3
+                        )  # This is the default value inserted when parameters aren't relevant
+                    elif (
+                        atpeParamFeature == "secondaryFixedProbability"
+                        and atpeParams["secondaryProbabilityMode"] != "fixed"
+                    ):
+                        vector.append(
+                            -3
+                        )  # This is the default value inserted when parameters aren't relevant
+                    elif (
+                        atpeParamFeature == "secondaryTopLockingPercentile"
+                        and atpeParams["secondaryLockingMode"] != "top"
+                    ):
+                        vector.append(
+                            -3
+                        )  # This is the default value inserted when parameters aren't relevant
                     elif atpeParamFeature in self.atpeParameterValues:
                         for value in self.atpeParameterValues[atpeParamFeature]:
-                            vector.append(1.0 if atpeParams[atpeParamFeature] == value else 0)
+                            vector.append(
+                                1.0 if atpeParams[atpeParamFeature] == value else 0
+                            )
                     else:
                         vector.append(float(atpeParams[atpeParamFeature]))
 
@@ -714,147 +820,238 @@ class ATPEOptimizer:
                 for atpeParamFeature in atpeParamFeatures:
                     if atpeParamFeature in self.atpeParameterValues:
                         for value in self.atpeParameterValues[atpeParamFeature]:
-                            allFeatureKeysForATPEParamModel.append(atpeParamFeature + "_" + value)
+                            allFeatureKeysForATPEParamModel.append(
+                                atpeParamFeature + "_" + value
+                            )
                     else:
                         allFeatureKeysForATPEParamModel.append(atpeParamFeature)
 
                 value = self.parameterModels[atpeParameter].predict([vector])[0]
-                featureContributions = self.parameterModels[atpeParameter].predict([vector], pred_contrib=True)[0]
+                featureContributions = self.parameterModels[atpeParameter].predict(
+                    [vector], pred_contrib=True
+                )[0]
 
-                atpeParamDetails[atpeParameter] = {
-                    "value": None,
-                    "reason": None
-                }
+                atpeParamDetails[atpeParameter] = {"value": None, "reason": None}
 
                 # Set the value
                 if atpeParameter in self.atpeParameterValues:
                     # Renormalize the predicted probabilities
                     config = self.parameterModelConfigurations[atpeParameter]
-                    for atpeParamValueIndex, atpeParamValue in enumerate(self.atpeParameterValues[atpeParameter]):
-                        value[atpeParamValueIndex] = (((value[atpeParamValueIndex] - config['predMeans'][atpeParamValue]) / config['predStddevs'][atpeParamValue]) *
-                                                      config['origStddevs'][atpeParamValue]) + config['origMeans'][atpeParamValue]
-                        value[atpeParamValueIndex] = max(0.0, min(1.0, value[atpeParamValueIndex]))
+                    for atpeParamValueIndex, atpeParamValue in enumerate(
+                        self.atpeParameterValues[atpeParameter]
+                    ):
+                        value[atpeParamValueIndex] = (
+                            (
+                                (
+                                    value[atpeParamValueIndex]
+                                    - config["predMeans"][atpeParamValue]
+                                )
+                                / config["predStddevs"][atpeParamValue]
+                            )
+                            * config["origStddevs"][atpeParamValue]
+                        ) + config["origMeans"][atpeParamValue]
+                        value[atpeParamValueIndex] = max(
+                            0.0, min(1.0, value[atpeParamValueIndex])
+                        )
 
                     maxVal = numpy.max(value)
-                    for atpeParamValueIndex, atpeParamValue in enumerate(self.atpeParameterValues[atpeParameter]):
-                        value[atpeParamValueIndex] = max(value[atpeParamValueIndex], maxVal * 0.15)  # We still allow the non reccomended modes to get chosen 15% of the time
+                    for atpeParamValueIndex, atpeParamValue in enumerate(
+                        self.atpeParameterValues[atpeParameter]
+                    ):
+                        value[atpeParamValueIndex] = max(
+                            value[atpeParamValueIndex], maxVal * 0.15
+                        )  # We still allow the non reccomended modes to get chosen 15% of the time
 
                     # Make a random weighted choice based on the normalized probabilities
                     probabilities = value / numpy.sum(value)
-                    chosen = numpy.random.choice(a=self.atpeParameterValues[atpeParameter], p=probabilities)
+                    chosen = numpy.random.choice(
+                        a=self.atpeParameterValues[atpeParameter], p=probabilities
+                    )
                     atpeParams[atpeParameter] = str(chosen)
                 else:
                     # Renormalize the predictions
                     config = self.parameterModelConfigurations[atpeParameter]
-                    value = (((value - config['predMean']) / config['predStddev']) * config['origStddev']) + config['origMean']
+                    value = (
+                        ((value - config["predMean"]) / config["predStddev"])
+                        * config["origStddev"]
+                    ) + config["origMean"]
                     atpeParams[atpeParameter] = float(value)
 
                 atpeParamDetails[atpeParameter]["reason"] = {}
                 # If we are predicting a class, we get separate feature contributions for each class. Take the average
                 if atpeParameter in self.atpeParameterValues:
                     featureContributions = numpy.mean(
-                        numpy.reshape(featureContributions, newshape=(len(allFeatureKeysForATPEParamModel) + 1, len(self.atpeParameterValues[atpeParameter]))), axis=1)
+                        numpy.reshape(
+                            featureContributions,
+                            newshape=(
+                                len(allFeatureKeysForATPEParamModel) + 1,
+                                len(self.atpeParameterValues[atpeParameter]),
+                            ),
+                        ),
+                        axis=1,
+                    )
 
-                contributions = [(self.atpeModelFeatureKeys[index], float(featureContributions[index])) for index in range(len(self.atpeModelFeatureKeys))]
+                contributions = [
+                    (
+                        self.atpeModelFeatureKeys[index],
+                        float(featureContributions[index]),
+                    )
+                    for index in range(len(self.atpeModelFeatureKeys))
+                ]
                 contributions = sorted(contributions, key=lambda r: -r[1])
                 # Only focus on the top 10% of features, since it gives more useful information. Otherwise the total gets really squashed out over many features,
                 # because our model is highly regularized.
-                contributions = contributions[:int(len(contributions) / 10)]
+                contributions = contributions[: int(len(contributions) / 10)]
                 total = numpy.sum([contrib[1] for contrib in contributions])
 
                 for contributionIndex, contribution in enumerate(contributions[:3]):
-                    atpeParamDetails[atpeParameter]['reason'][contribution[0]] = str(int(float(contribution[1]) * 100.0 / total)) + "%"
+                    atpeParamDetails[atpeParameter]["reason"][contribution[0]] = (
+                        str(int(float(contribution[1]) * 100.0 / total)) + "%"
+                    )
 
                 # Apply bounds to all the parameters
-                if atpeParameter == 'gamma':
-                    atpeParams['gamma'] = max(0.2, min(2.0, atpeParams['gamma']))
-                if atpeParameter == 'nEICandidates':
-                    atpeParams['nEICandidates'] = int(max(2.0, min(48, atpeParams['nEICandidates'])))
-                if atpeParameter == 'resultFilteringAgeMultiplier':
-                    atpeParams['resultFilteringAgeMultiplier'] = max(1.0, min(4.0, atpeParams['resultFilteringAgeMultiplier']))
-                if atpeParameter == 'resultFilteringLossRankMultiplier':
-                    atpeParams['resultFilteringLossRankMultiplier'] = max(1.0, min(4.0, atpeParams['resultFilteringLossRankMultiplier']))
-                if atpeParameter == 'resultFilteringRandomProbability':
-                    atpeParams['resultFilteringRandomProbability'] = max(0.7, min(0.9, atpeParams['resultFilteringRandomProbability']))
-                if atpeParameter == 'secondaryCorrelationExponent':
-                    atpeParams['secondaryCorrelationExponent'] = max(1.0, min(3.0, atpeParams['secondaryCorrelationExponent']))
-                if atpeParameter == 'secondaryCorrelationMultiplier':
-                    atpeParams['secondaryCorrelationMultiplier'] = max(0.2, min(1.8, atpeParams['secondaryCorrelationMultiplier']))
-                if atpeParameter == 'secondaryCutoff':
-                    atpeParams['secondaryCutoff'] = max(-1.0, min(1.0, atpeParams['secondaryCutoff']))
-                if atpeParameter == 'secondaryFixedProbability':
-                    atpeParams['secondaryFixedProbability'] = max(0.2, min(0.8, atpeParams['secondaryFixedProbability']))
-                if atpeParameter == 'secondaryTopLockingPercentile':
-                    atpeParams['secondaryTopLockingPercentile'] = max(0, min(10.0, atpeParams['secondaryTopLockingPercentile']))
+                if atpeParameter == "gamma":
+                    atpeParams["gamma"] = max(0.2, min(2.0, atpeParams["gamma"]))
+                if atpeParameter == "nEICandidates":
+                    atpeParams["nEICandidates"] = int(
+                        max(2.0, min(48, atpeParams["nEICandidates"]))
+                    )
+                if atpeParameter == "resultFilteringAgeMultiplier":
+                    atpeParams["resultFilteringAgeMultiplier"] = max(
+                        1.0, min(4.0, atpeParams["resultFilteringAgeMultiplier"])
+                    )
+                if atpeParameter == "resultFilteringLossRankMultiplier":
+                    atpeParams["resultFilteringLossRankMultiplier"] = max(
+                        1.0, min(4.0, atpeParams["resultFilteringLossRankMultiplier"])
+                    )
+                if atpeParameter == "resultFilteringRandomProbability":
+                    atpeParams["resultFilteringRandomProbability"] = max(
+                        0.7, min(0.9, atpeParams["resultFilteringRandomProbability"])
+                    )
+                if atpeParameter == "secondaryCorrelationExponent":
+                    atpeParams["secondaryCorrelationExponent"] = max(
+                        1.0, min(3.0, atpeParams["secondaryCorrelationExponent"])
+                    )
+                if atpeParameter == "secondaryCorrelationMultiplier":
+                    atpeParams["secondaryCorrelationMultiplier"] = max(
+                        0.2, min(1.8, atpeParams["secondaryCorrelationMultiplier"])
+                    )
+                if atpeParameter == "secondaryCutoff":
+                    atpeParams["secondaryCutoff"] = max(
+                        -1.0, min(1.0, atpeParams["secondaryCutoff"])
+                    )
+                if atpeParameter == "secondaryFixedProbability":
+                    atpeParams["secondaryFixedProbability"] = max(
+                        0.2, min(0.8, atpeParams["secondaryFixedProbability"])
+                    )
+                if atpeParameter == "secondaryTopLockingPercentile":
+                    atpeParams["secondaryTopLockingPercentile"] = max(
+                        0, min(10.0, atpeParams["secondaryTopLockingPercentile"])
+                    )
 
             # Now blank out unneeded params so they don't confuse us
-            if atpeParams['secondaryLockingMode'] == 'random':
-                atpeParams['secondaryTopLockingPercentile'] = None
+            if atpeParams["secondaryLockingMode"] == "random":
+                atpeParams["secondaryTopLockingPercentile"] = None
 
-            if atpeParams['secondaryProbabilityMode'] == 'fixed':
-                atpeParams['secondaryCorrelationMultiplier'] = None
+            if atpeParams["secondaryProbabilityMode"] == "fixed":
+                atpeParams["secondaryCorrelationMultiplier"] = None
             else:
-                atpeParams['secondaryFixedProbability'] = None
+                atpeParams["secondaryFixedProbability"] = None
 
-            if atpeParams['resultFilteringMode'] == 'none':
-                atpeParams['resultFilteringAgeMultiplier'] = None
-                atpeParams['resultFilteringLossRankMultiplier'] = None
-                atpeParams['resultFilteringRandomProbability'] = None
-            elif atpeParams['resultFilteringMode'] == 'age':
-                atpeParams['resultFilteringLossRankMultiplier'] = None
-                atpeParams['resultFilteringRandomProbability'] = None
-            elif atpeParams['resultFilteringMode'] == 'loss_rank':
-                atpeParams['resultFilteringAgeMultiplier'] = None
-                atpeParams['resultFilteringRandomProbability'] = None
-            elif atpeParams['resultFilteringMode'] == 'random':
-                atpeParams['resultFilteringAgeMultiplier'] = None
-                atpeParams['resultFilteringLossRankMultiplier'] = None
+            if atpeParams["resultFilteringMode"] == "none":
+                atpeParams["resultFilteringAgeMultiplier"] = None
+                atpeParams["resultFilteringLossRankMultiplier"] = None
+                atpeParams["resultFilteringRandomProbability"] = None
+            elif atpeParams["resultFilteringMode"] == "age":
+                atpeParams["resultFilteringLossRankMultiplier"] = None
+                atpeParams["resultFilteringRandomProbability"] = None
+            elif atpeParams["resultFilteringMode"] == "loss_rank":
+                atpeParams["resultFilteringAgeMultiplier"] = None
+                atpeParams["resultFilteringRandomProbability"] = None
+            elif atpeParams["resultFilteringMode"] == "random":
+                atpeParams["resultFilteringAgeMultiplier"] = None
+                atpeParams["resultFilteringLossRankMultiplier"] = None
 
             for atpeParameter in self.atpeParameters:
                 if atpeParams[atpeParameter] is None:
                     del atpeParamDetails[atpeParameter]
                 else:
-                    atpeParamDetails[atpeParameter]['value'] = atpeParams[atpeParameter]
+                    atpeParamDetails[atpeParameter]["value"] = atpeParams[atpeParameter]
 
         self.lastATPEParameters = atpeParams
         self.atpeParamDetails = atpeParamDetails
 
-
         def computePrimarySecondary():
             if len(results) < initializationRounds:
-                return parameters, [], [0.5] * len(parameters)  # Put all parameters as primary
+                return (
+                    parameters,
+                    [],
+                    [0.5] * len(parameters),
+                )  # Put all parameters as primary
 
-            if len(set(result['loss'] for result in results)) < 5:
-                return parameters, [], [0.5] * len(parameters)  # Put all parameters as primary
+            if len(set(result["loss"] for result in results)) < 5:
+                return (
+                    parameters,
+                    [],
+                    [0.5] * len(parameters),
+                )  # Put all parameters as primary
 
-            numberParameters = [parameter for parameter in parameters if parameter.config['type'] == 'number']
-            otherParameters = [parameter for parameter in parameters if parameter.config['type'] != 'number']
+            numberParameters = [
+                parameter
+                for parameter in parameters
+                if parameter.config["type"] == "number"
+            ]
+            otherParameters = [
+                parameter
+                for parameter in parameters
+                if parameter.config["type"] != "number"
+            ]
 
             totalWeight = 0
             correlations = {}
             for parameter in numberParameters:
-                if len(set(result[parameter.name] for result in results if result[parameter.name] is not None)) < 2:
+                if (
+                    len(
+                        set(
+                            result[parameter.name]
+                            for result in results
+                            if result[parameter.name] is not None
+                        )
+                    )
+                    < 2
+                ):
                     correlations[parameter.name] = 0
                 else:
                     values = []
                     valueLosses = []
                     for result in results:
-                        if result[parameter.name] is not None and result['loss'] is not None:
+                        if (
+                            result[parameter.name] is not None
+                            and result["loss"] is not None
+                        ):
                             values.append(result[parameter.name])
-                            valueLosses.append(result['loss'])
+                            valueLosses.append(result["loss"])
 
-                    correlation = math.pow(abs(scipy.stats.spearmanr(values, valueLosses)[0]), atpeParams['secondaryCorrelationExponent'])
+                    correlation = math.pow(
+                        abs(scipy.stats.spearmanr(values, valueLosses)[0]),
+                        atpeParams["secondaryCorrelationExponent"],
+                    )
                     correlations[parameter.name] = correlation
                     totalWeight += correlation
 
-            threshold = totalWeight * abs(atpeParams['secondaryCutoff'])
+            threshold = totalWeight * abs(atpeParams["secondaryCutoff"])
 
-            if atpeParams['secondaryCutoff'] < 0:
+            if atpeParams["secondaryCutoff"] < 0:
                 # Reverse order - we lock in the highest correlated parameters
-                sortedParameters = sorted(numberParameters, key=lambda parameter: correlations[parameter.name])
+                sortedParameters = sorted(
+                    numberParameters, key=lambda parameter: correlations[parameter.name]
+                )
             else:
                 # Normal order - sort properties by their correlation to lock in lowest correlated parameters
-                sortedParameters = sorted(numberParameters, key=lambda parameter: -correlations[parameter.name])
+                sortedParameters = sorted(
+                    numberParameters,
+                    key=lambda parameter: -correlations[parameter.name],
+                )
 
             primaryParameters = []
             secondaryParameters = []
@@ -867,12 +1064,21 @@ class ATPEOptimizer:
 
                 cumulative -= correlations[parameter.name]
 
-            return primaryParameters + otherParameters, secondaryParameters, correlations
+            return (
+                primaryParameters + otherParameters,
+                secondaryParameters,
+                correlations,
+            )
 
-        if len([result['loss'] for result in results if result['loss'] is not None]) == 0:
+        if (
+            len([result["loss"] for result in results if result["loss"] is not None])
+            == 0
+        ):
             maxLoss = 1
         else:
-            maxLoss = numpy.max([result['loss'] for result in results if result['loss'] is not None])
+            maxLoss = numpy.max(
+                [result["loss"] for result in results if result["loss"] is not None]
+            )
 
         # We create a copy of lockedValues so we don't modify the object that was passed in as an argument - treat it as immutable.
         # The ATPE algorithm will lock additional values in a stochastic manner
@@ -884,57 +1090,107 @@ class ATPEOptimizer:
         filteredResults = []
         removedResults = []
         if len(results) > initializationRounds:
-            primaryParameters, secondaryParameters, correlations = computePrimarySecondary()
+            (
+                primaryParameters,
+                secondaryParameters,
+                correlations,
+            ) = computePrimarySecondary()
 
             self.lastLockedParameters = []
 
-            sortedResults = list(sorted(list(results), key=lambda result: (result['loss'] if result['loss'] is not None else (maxLoss + 1))))
+            sortedResults = list(
+                sorted(
+                    list(results),
+                    key=lambda result: (
+                        result["loss"] if result["loss"] is not None else (maxLoss + 1)
+                    ),
+                )
+            )
             topResults = sortedResults
-            if atpeParams['secondaryLockingMode'] == 'top':
-                topResultsN = max(1, int(math.ceil(len(sortedResults) * atpeParams['secondaryTopLockingPercentile'] / 100.0)))
+            if atpeParams["secondaryLockingMode"] == "top":
+                topResultsN = max(
+                    1,
+                    int(
+                        math.ceil(
+                            len(sortedResults)
+                            * atpeParams["secondaryTopLockingPercentile"]
+                            / 100.0
+                        )
+                    ),
+                )
                 topResults = sortedResults[:topResultsN]
 
             # Any secondary parameters have may be locked to either the current best value or any value within the result pool.
             for secondary in secondaryParameters:
-                if atpeParams['secondaryProbabilityMode'] == 'fixed':
-                    if random.uniform(0, 1) < atpeParams['secondaryFixedProbability']:
+                if atpeParams["secondaryProbabilityMode"] == "fixed":
+                    if random.uniform(0, 1) < atpeParams["secondaryFixedProbability"]:
                         self.lastLockedParameters.append(secondary.name)
-                        if atpeParams['secondaryLockingMode'] == 'top':
+                        if atpeParams["secondaryLockingMode"] == "top":
                             lockResult = random.choice(topResults)
-                            if lockResult[secondary.name] is not None and lockResult[secondary.name] != "":
-                                lockedValues[secondary.name] = lockResult[secondary.name]
-                        elif atpeParams['secondaryLockingMode'] == 'random':
-                            lockedValues[secondary.name] = self.chooseRandomValueForParameter(secondary)
+                            if (
+                                lockResult[secondary.name] is not None
+                                and lockResult[secondary.name] != ""
+                            ):
+                                lockedValues[secondary.name] = lockResult[
+                                    secondary.name
+                                ]
+                        elif atpeParams["secondaryLockingMode"] == "random":
+                            lockedValues[
+                                secondary.name
+                            ] = self.chooseRandomValueForParameter(secondary)
 
-                elif atpeParams['secondaryProbabilityMode'] == 'correlation':
-                    probability = max(0, min(1, abs(correlations[secondary.name]) * atpeParams['secondaryCorrelationMultiplier']))
+                elif atpeParams["secondaryProbabilityMode"] == "correlation":
+                    probability = max(
+                        0,
+                        min(
+                            1,
+                            abs(correlations[secondary.name])
+                            * atpeParams["secondaryCorrelationMultiplier"],
+                        ),
+                    )
                     if random.uniform(0, 1) < probability:
                         self.lastLockedParameters.append(secondary.name)
-                        if atpeParams['secondaryLockingMode'] == 'top':
+                        if atpeParams["secondaryLockingMode"] == "top":
                             lockResult = random.choice(topResults)
-                            if lockResult[secondary.name] is not None and lockResult[secondary.name] != "":
-                                lockedValues[secondary.name] = lockResult[secondary.name]
-                        elif atpeParams['secondaryLockingMode'] == 'random':
-                            lockedValues[secondary.name] = self.chooseRandomValueForParameter(secondary)
+                            if (
+                                lockResult[secondary.name] is not None
+                                and lockResult[secondary.name] != ""
+                            ):
+                                lockedValues[secondary.name] = lockResult[
+                                    secondary.name
+                                ]
+                        elif atpeParams["secondaryLockingMode"] == "random":
+                            lockedValues[
+                                secondary.name
+                            ] = self.chooseRandomValueForParameter(secondary)
 
             # Now last step, we filter results prior to sending them into ATPE
             for resultIndex, result in enumerate(results):
-                if atpeParams['resultFilteringMode'] == 'none':
+                if atpeParams["resultFilteringMode"] == "none":
                     filteredResults.append(result)
-                elif atpeParams['resultFilteringMode'] == 'random':
-                    if random.uniform(0, 1) < atpeParams['resultFilteringRandomProbability']:
+                elif atpeParams["resultFilteringMode"] == "random":
+                    if (
+                        random.uniform(0, 1)
+                        < atpeParams["resultFilteringRandomProbability"]
+                    ):
                         filteredResults.append(result)
                     else:
                         removedResults.append(result)
-                elif atpeParams['resultFilteringMode'] == 'age':
+                elif atpeParams["resultFilteringMode"] == "age":
                     age = float(resultIndex) / float(len(results))
-                    if random.uniform(0, 1) < (atpeParams['resultFilteringAgeMultiplier'] * age):
+                    if random.uniform(0, 1) < (
+                        atpeParams["resultFilteringAgeMultiplier"] * age
+                    ):
                         filteredResults.append(result)
                     else:
                         removedResults.append(result)
-                elif atpeParams['resultFilteringMode'] == 'loss_rank':
-                    rank = 1.0 - (float(sortedResults.index(result)) / float(len(results)))
-                    if random.uniform(0, 1) < (atpeParams['resultFilteringLossRankMultiplier'] * rank):
+                elif atpeParams["resultFilteringMode"] == "loss_rank":
+                    rank = 1.0 - (
+                        float(sortedResults.index(result)) / float(len(results))
+                    )
+                    if random.uniform(0, 1) < (
+                        atpeParams["resultFilteringLossRankMultiplier"] * rank
+                    ):
                         filteredResults.append(result)
                     else:
                         removedResults.append(result)
@@ -944,57 +1200,70 @@ class ATPEOptimizer:
         if len(filteredResults) == 0:
             filteredResults = results
 
-        hyperopt.fmin(fn=sample,
-                      space=Hyperparameter(hyperparameterSpace).createHyperoptSpace(lockedValues),
-                      algo=functools.partial(hyperopt.tpe.suggest, n_startup_jobs=initializationRounds, gamma=atpeParams['gamma'],
-                                             n_EI_candidates=int(atpeParams['nEICandidates'])),
-                      max_evals=1,
-                      trials=self.convertResultsToTrials(hyperparameterSpace, filteredResults),
-                      rstate=rstate,
-                      show_progressbar=False)
+        hyperopt.fmin(
+            fn=sample,
+            space=Hyperparameter(hyperparameterSpace).createHyperoptSpace(lockedValues),
+            algo=functools.partial(
+                hyperopt.tpe.suggest,
+                n_startup_jobs=initializationRounds,
+                gamma=atpeParams["gamma"],
+                n_EI_candidates=int(atpeParams["nEICandidates"]),
+            ),
+            max_evals=1,
+            trials=self.convertResultsToTrials(hyperparameterSpace, filteredResults),
+            rstate=rstate,
+            show_progressbar=False,
+        )
 
-        return params.get('param')
-
+        return params.get("param")
 
     def chooseRandomValueForParameter(self, parameter):
-        if parameter.config.get('mode', 'uniform') == 'uniform':
-            minVal = parameter.config['min']
-            maxVal = parameter.config['max']
+        if parameter.config.get("mode", "uniform") == "uniform":
+            minVal = parameter.config["min"]
+            maxVal = parameter.config["max"]
 
-            if parameter.config.get('scaling', 'linear') == 'logarithmic':
+            if parameter.config.get("scaling", "linear") == "logarithmic":
                 minVal = math.log(minVal)
                 maxVal = math.log(maxVal)
 
             value = random.uniform(minVal, maxVal)
 
-            if parameter.config.get('scaling', 'linear') == 'logarithmic':
+            if parameter.config.get("scaling", "linear") == "logarithmic":
                 value = math.exp(value)
 
-            if 'rounding' in parameter.config:
-                value = round(value / parameter.config['rounding']) * parameter.config['rounding']
-        elif parameter.config.get('mode', 'uniform') == 'normal':
-            meanVal = parameter.config['mean']
-            stddevVal = parameter.config['stddev']
+            if "rounding" in parameter.config:
+                value = (
+                    round(value / parameter.config["rounding"])
+                    * parameter.config["rounding"]
+                )
+        elif parameter.config.get("mode", "uniform") == "normal":
+            meanVal = parameter.config["mean"]
+            stddevVal = parameter.config["stddev"]
 
-            if parameter.config.get('scaling', 'linear') == 'logarithmic':
+            if parameter.config.get("scaling", "linear") == "logarithmic":
                 meanVal = math.log(meanVal)
                 stddevVal = math.log(stddevVal)
 
             value = random.gauss(meanVal, stddevVal)
 
-            if parameter.config.get('scaling', 'linear') == 'logarithmic':
+            if parameter.config.get("scaling", "linear") == "logarithmic":
                 value = math.exp(value)
 
-            if 'rounding' in parameter.config:
-                value = round(value / parameter.config['rounding']) * parameter.config['rounding']
-        elif parameter.config.get('mode', 'uniform') == 'randint':
-            max = parameter.config['max']
-            value = random.randint(0, max-1)
+            if "rounding" in parameter.config:
+                value = (
+                    round(value / parameter.config["rounding"])
+                    * parameter.config["rounding"]
+                )
+        elif parameter.config.get("mode", "uniform") == "randint":
+            max = parameter.config["max"]
+            value = random.randint(0, max - 1)
 
         return value
 
     def computePartialResultStatistics(self, hyperparameterSpace, results):
-        losses = numpy.array(sorted([result['loss'] for result in results if result['loss'] is not None]))
+        losses = numpy.array(
+            sorted([result["loss"] for result in results if result["loss"] is not None])
+        )
 
         bestLoss = 0
         percentile5Loss = 0
@@ -1003,7 +1272,7 @@ class ATPEOptimizer:
         percentile75Loss = 0
         statistics = {}
 
-        numpy.warnings.filterwarnings('ignore')
+        numpy.warnings.filterwarnings("ignore")
 
         if len(set(losses)) > 1:
             bestLoss = numpy.percentile(losses, 0)
@@ -1012,35 +1281,39 @@ class ATPEOptimizer:
             percentile50Loss = numpy.percentile(losses, 50)
             percentile75Loss = numpy.percentile(losses, 75)
 
-            statistics['loss_skew'] = scipy.stats.skew(losses)
-            statistics['loss_kurtosis'] = scipy.stats.kurtosis(losses)
+            statistics["loss_skew"] = scipy.stats.skew(losses)
+            statistics["loss_kurtosis"] = scipy.stats.kurtosis(losses)
         else:
-            statistics['loss_skew'] = 0
-            statistics['loss_kurtosis'] = 0
+            statistics["loss_skew"] = 0
+            statistics["loss_kurtosis"] = 0
 
         if percentile50Loss == 0:
-            statistics['loss_stddev_median_ratio'] = 0
-            statistics['loss_best_percentile50_ratio'] = 0
+            statistics["loss_stddev_median_ratio"] = 0
+            statistics["loss_best_percentile50_ratio"] = 0
         else:
-            statistics['loss_stddev_median_ratio'] = numpy.std(losses) / percentile50Loss
-            statistics['loss_best_percentile50_ratio'] = bestLoss / percentile50Loss
+            statistics["loss_stddev_median_ratio"] = (
+                numpy.std(losses) / percentile50Loss
+            )
+            statistics["loss_best_percentile50_ratio"] = bestLoss / percentile50Loss
 
         if bestLoss == 0:
-            statistics['loss_stddev_best_ratio'] = 0
+            statistics["loss_stddev_best_ratio"] = 0
         else:
-            statistics['loss_stddev_best_ratio'] = numpy.std(losses) / bestLoss
+            statistics["loss_stddev_best_ratio"] = numpy.std(losses) / bestLoss
 
         if percentile25Loss == 0:
-            statistics['loss_best_percentile25_ratio'] = 0
-            statistics['loss_percentile5_percentile25_ratio'] = 0
+            statistics["loss_best_percentile25_ratio"] = 0
+            statistics["loss_percentile5_percentile25_ratio"] = 0
         else:
-            statistics['loss_best_percentile25_ratio'] = bestLoss / percentile25Loss
-            statistics['loss_percentile5_percentile25_ratio'] = percentile5Loss / percentile25Loss
+            statistics["loss_best_percentile25_ratio"] = bestLoss / percentile25Loss
+            statistics["loss_percentile5_percentile25_ratio"] = (
+                percentile5Loss / percentile25Loss
+            )
 
         if percentile75Loss == 0:
-            statistics['loss_best_percentile75_ratio'] = 0
+            statistics["loss_best_percentile75_ratio"] = 0
         else:
-            statistics['loss_best_percentile75_ratio'] = bestLoss / percentile75Loss
+            statistics["loss_best_percentile75_ratio"] = bestLoss / percentile75Loss
 
         def getValue(result, parameter):
             return result[parameter.name]
@@ -1049,16 +1322,31 @@ class ATPEOptimizer:
         parameters = Hyperparameter(hyperparameterSpace).getFlatParameters()
         correlations = []
         for parameter in parameters:
-            if parameter.config['type'] == 'number':
-                if len(set(getValue(result, parameter) for result in results if (getValue(result, parameter) is not None and result['loss'] is not None))) < 2:
+            if parameter.config["type"] == "number":
+                if (
+                    len(
+                        set(
+                            getValue(result, parameter)
+                            for result in results
+                            if (
+                                getValue(result, parameter) is not None
+                                and result["loss"] is not None
+                            )
+                        )
+                    )
+                    < 2
+                ):
                     correlations.append(0)
                 else:
                     values = []
                     valueLosses = []
                     for result in results:
-                        if result['loss'] is not None and (isinstance(getValue(result, parameter), float) or isinstance(getValue(result, parameter), int)):
+                        if result["loss"] is not None and (
+                            isinstance(getValue(result, parameter), float)
+                            or isinstance(getValue(result, parameter), int)
+                        ):
                             values.append(getValue(result, parameter))
-                            valueLosses.append(result['loss'])
+                            valueLosses.append(result["loss"])
 
                     correlation = abs(scipy.stats.spearmanr(values, valueLosses)[0])
                     if math.isnan(correlation) or math.isinf(correlation):
@@ -1069,53 +1357,69 @@ class ATPEOptimizer:
         correlations = numpy.array(correlations)
 
         if len(set(correlations)) == 1:
-            statistics['correlation_skew'] = 0
-            statistics['correlation_kurtosis'] = 0
-            statistics['correlation_stddev_median_ratio'] = 0
-            statistics['correlation_stddev_best_ratio'] = 0
+            statistics["correlation_skew"] = 0
+            statistics["correlation_kurtosis"] = 0
+            statistics["correlation_stddev_median_ratio"] = 0
+            statistics["correlation_stddev_best_ratio"] = 0
 
-            statistics['correlation_best_percentile25_ratio'] = 0
-            statistics['correlation_best_percentile50_ratio'] = 0
-            statistics['correlation_best_percentile75_ratio'] = 0
-            statistics['correlation_percentile5_percentile25_ratio'] = 0
+            statistics["correlation_best_percentile25_ratio"] = 0
+            statistics["correlation_best_percentile50_ratio"] = 0
+            statistics["correlation_best_percentile75_ratio"] = 0
+            statistics["correlation_percentile5_percentile25_ratio"] = 0
         else:
-            bestCorrelation = numpy.percentile(correlations, 100)  # Correlations are in the opposite order of losses, higher correlation is considered "best"
+            bestCorrelation = numpy.percentile(
+                correlations, 100
+            )  # Correlations are in the opposite order of losses, higher correlation is considered "best"
             percentile5Correlation = numpy.percentile(correlations, 95)
             percentile25Correlation = numpy.percentile(correlations, 75)
             percentile50Correlation = numpy.percentile(correlations, 50)
             percentile75Correlation = numpy.percentile(correlations, 25)
 
-            statistics['correlation_skew'] = scipy.stats.skew(correlations)
-            statistics['correlation_kurtosis'] = scipy.stats.kurtosis(correlations)
+            statistics["correlation_skew"] = scipy.stats.skew(correlations)
+            statistics["correlation_kurtosis"] = scipy.stats.kurtosis(correlations)
 
             if percentile50Correlation == 0:
-                statistics['correlation_stddev_median_ratio'] = 0
-                statistics['correlation_best_percentile50_ratio'] = 0
+                statistics["correlation_stddev_median_ratio"] = 0
+                statistics["correlation_best_percentile50_ratio"] = 0
             else:
-                statistics['correlation_stddev_median_ratio'] = numpy.std(correlations) / percentile50Correlation
-                statistics['correlation_best_percentile50_ratio'] = bestCorrelation / percentile50Correlation
+                statistics["correlation_stddev_median_ratio"] = (
+                    numpy.std(correlations) / percentile50Correlation
+                )
+                statistics["correlation_best_percentile50_ratio"] = (
+                    bestCorrelation / percentile50Correlation
+                )
 
             if bestCorrelation == 0:
-                statistics['correlation_stddev_best_ratio'] = 0
+                statistics["correlation_stddev_best_ratio"] = 0
             else:
-                statistics['correlation_stddev_best_ratio'] = numpy.std(correlations) / bestCorrelation
+                statistics["correlation_stddev_best_ratio"] = (
+                    numpy.std(correlations) / bestCorrelation
+                )
 
             if percentile25Correlation == 0:
-                statistics['correlation_best_percentile25_ratio'] = 0
-                statistics['correlation_percentile5_percentile25_ratio'] = 0
+                statistics["correlation_best_percentile25_ratio"] = 0
+                statistics["correlation_percentile5_percentile25_ratio"] = 0
             else:
-                statistics['correlation_best_percentile25_ratio'] = bestCorrelation / percentile25Correlation
-                statistics['correlation_percentile5_percentile25_ratio'] = percentile5Correlation / percentile25Correlation
+                statistics["correlation_best_percentile25_ratio"] = (
+                    bestCorrelation / percentile25Correlation
+                )
+                statistics["correlation_percentile5_percentile25_ratio"] = (
+                    percentile5Correlation / percentile25Correlation
+                )
 
             if percentile75Correlation == 0:
-                statistics['correlation_best_percentile75_ratio'] = 0
+                statistics["correlation_best_percentile75_ratio"] = 0
             else:
-                statistics['correlation_best_percentile75_ratio'] = bestCorrelation / percentile75Correlation
+                statistics["correlation_best_percentile75_ratio"] = (
+                    bestCorrelation / percentile75Correlation
+                )
 
         return statistics
 
     def computeAllResultStatistics(self, hyperparameterSpace, results):
-        losses = numpy.array(sorted([result['loss'] for result in results if result['loss'] is not None]))
+        losses = numpy.array(
+            sorted([result["loss"] for result in results if result["loss"] is not None])
+        )
 
         if len(set(losses)) > 1:
             percentile10Loss = numpy.percentile(losses, 10)
@@ -1127,9 +1431,21 @@ class ATPEOptimizer:
             percentile30Loss = losses[0]
 
         allResults = list(results)
-        percentile10Results = [result for result in results if result['loss'] is not None and result['loss'] <= percentile10Loss]
-        percentile20Results = [result for result in results if result['loss'] is not None and result['loss'] <= percentile20Loss]
-        percentile30Results = [result for result in results if result['loss'] is not None and result['loss'] <= percentile30Loss]
+        percentile10Results = [
+            result
+            for result in results
+            if result["loss"] is not None and result["loss"] <= percentile10Loss
+        ]
+        percentile20Results = [
+            result
+            for result in results
+            if result["loss"] is not None and result["loss"] <= percentile20Loss
+        ]
+        percentile30Results = [
+            result
+            for result in results
+            if result["loss"] is not None and result["loss"] <= percentile30Loss
+        ]
 
         recent10Count = min(len(results), 10)
         recent10Results = results[-recent10Count:]
@@ -1141,33 +1457,47 @@ class ATPEOptimizer:
         recent15PercentResults = results[-recent15PercentCount:]
 
         statistics = {}
-        allResultStatistics = self.computePartialResultStatistics(hyperparameterSpace, allResults)
+        allResultStatistics = self.computePartialResultStatistics(
+            hyperparameterSpace, allResults
+        )
         for stat, value in allResultStatistics.items():
-            statistics['all_' + stat] = value
+            statistics["all_" + stat] = value
 
-        percentile10Statistics = self.computePartialResultStatistics(hyperparameterSpace, percentile10Results)
+        percentile10Statistics = self.computePartialResultStatistics(
+            hyperparameterSpace, percentile10Results
+        )
         for stat, value in percentile10Statistics.items():
-            statistics['top_10%_' + stat] = value
+            statistics["top_10%_" + stat] = value
 
-        percentile20Statistics = self.computePartialResultStatistics(hyperparameterSpace, percentile20Results)
+        percentile20Statistics = self.computePartialResultStatistics(
+            hyperparameterSpace, percentile20Results
+        )
         for stat, value in percentile20Statistics.items():
-            statistics['top_20%_' + stat] = value
+            statistics["top_20%_" + stat] = value
 
-        percentile30Statistics = self.computePartialResultStatistics(hyperparameterSpace, percentile30Results)
+        percentile30Statistics = self.computePartialResultStatistics(
+            hyperparameterSpace, percentile30Results
+        )
         for stat, value in percentile30Statistics.items():
-            statistics['top_30%_' + stat] = value
+            statistics["top_30%_" + stat] = value
 
-        recent10Statistics = self.computePartialResultStatistics(hyperparameterSpace, recent10Results)
+        recent10Statistics = self.computePartialResultStatistics(
+            hyperparameterSpace, recent10Results
+        )
         for stat, value in recent10Statistics.items():
-            statistics['recent_10_' + stat] = value
+            statistics["recent_10_" + stat] = value
 
-        recent25Statistics = self.computePartialResultStatistics(hyperparameterSpace, recent25Results)
+        recent25Statistics = self.computePartialResultStatistics(
+            hyperparameterSpace, recent25Results
+        )
         for stat, value in recent25Statistics.items():
-            statistics['recent_25_' + stat] = value
+            statistics["recent_25_" + stat] = value
 
-        recent15PercentResult = self.computePartialResultStatistics(hyperparameterSpace, recent15PercentResults)
+        recent15PercentResult = self.computePartialResultStatistics(
+            hyperparameterSpace, recent15PercentResults
+        )
         for stat, value in recent15PercentResult.items():
-            statistics['recent_15%_' + stat] = value
+            statistics["recent_15%_" + stat] = value
 
         # Although we have added lots of protection in the computePartialResultStatistics code, one last hedge against any NaN or infinity values coming up
         # in our statistics
@@ -1182,33 +1512,35 @@ class ATPEOptimizer:
 
         for resultIndex, result in enumerate(results):
             data = {
-                'book_time': datetime.datetime.now(),
-                'exp_key': None,
-                'misc': {'cmd': ('domain_attachment', 'FMinIter_Domain'),
-                         'idxs': {},
-                         'tid': resultIndex,
-                         'vals': {},
-                         'workdir': None},
-                'owner': None,
-                'refresh_time': datetime.datetime.now(),
-                'result': {'loss': result['loss'], 'status': result['status']},
-                'spec': None,
-                'state': 2,
-                'tid': resultIndex,
-                'version': 0
+                "book_time": datetime.datetime.now(),
+                "exp_key": None,
+                "misc": {
+                    "cmd": ("domain_attachment", "FMinIter_Domain"),
+                    "idxs": {},
+                    "tid": resultIndex,
+                    "vals": {},
+                    "workdir": None,
+                },
+                "owner": None,
+                "refresh_time": datetime.datetime.now(),
+                "result": {"loss": result["loss"], "status": result["status"]},
+                "spec": None,
+                "state": 2,
+                "tid": resultIndex,
+                "version": 0,
             }
 
             for param in Hyperparameter(hyperparameterSpace).getFlatParameters():
                 value = result[param.name]
                 if value is not "" and value is not None:
-                    if 'enum' in param.config:
-                        value = param.config['enum'].index(value)
+                    if "enum" in param.config:
+                        value = param.config["enum"].index(value)
 
-                    data['misc']['idxs'][param.hyperoptVariableName] = [resultIndex]
-                    data['misc']['vals'][param.hyperoptVariableName] = [value]
+                    data["misc"]["idxs"][param.hyperoptVariableName] = [resultIndex]
+                    data["misc"]["vals"][param.hyperoptVariableName] = [value]
                 else:
-                    data['misc']['idxs'][param.hyperoptVariableName] = []
-                    data['misc']['vals'][param.hyperoptVariableName] = []
+                    data["misc"]["idxs"][param.hyperoptVariableName] = []
+                    data["misc"]["vals"][param.hyperoptVariableName] = []
 
             trials.insert_trial_doc(data)
         return trials
@@ -1218,69 +1550,71 @@ class ATPEOptimizer:
         for trialIndex, trial in enumerate(trials.trials):
             data = {
                 "trial": trialIndex,
-                "status": trial['result']['status'],
-                "loss": trial['result']['loss'],
+                "status": trial["result"]["status"],
+                "loss": trial["result"]["loss"],
                 "log": "",
-                "time": abs((trial['book_time'] - trial['refresh_time']).total_seconds())
+                "time": abs(
+                    (trial["book_time"] - trial["refresh_time"]).total_seconds()
+                ),
             }
 
-            params = trial['misc']['vals']
+            params = trial["misc"]["vals"]
             for param in Hyperparameter(hyperparameterSpace).getFlatParameters():
                 key = param.hyperoptVariableName
 
                 if len(params[key]) == 1:
                     value = params[key][0]
-                    if 'enum' in param.config:
-                        value = param.config['enum'][value]
+                    if "enum" in param.config:
+                        value = param.config["enum"][value]
 
                     data[param.name] = value
                 else:
-                    data[param.name] = ''
-
+                    data[param.name] = ""
 
             results.append(data)
         return results
-
-
 
 
 def suggest(new_ids, domain, trials, seed):
     optimizer = ATPEOptimizer()
 
     # Convert the PyLL domain back into a descriptive form of hyperparameter space
-    hyperparameterConfig = Hyperparameter.createHyperparameterConfigForHyperoptDomain(domain)
+    hyperparameterConfig = Hyperparameter.createHyperparameterConfigForHyperoptDomain(
+        domain
+    )
 
     results = optimizer.convertTrialsToResults(hyperparameterConfig, trials)
 
     # If there is a loss value that is negative, then we must increment the values so they are all positive.
     # This is because ATPE has been optimized only for positive loss value
     if len(results) > 0:
-        minVal = min([result['loss'] for result in results if result['loss'] is not None])
+        minVal = min(
+            [result["loss"] for result in results if result["loss"] is not None]
+        )
         if minVal < 0:
             for result in results:
-                if result['loss'] is not None:
-                    result['loss'] = result['loss'] + minVal + 0.1
+                if result["loss"] is not None:
+                    result["loss"] = result["loss"] + minVal + 0.1
 
     hyperparameters = Hyperparameter(hyperparameterConfig)
 
     rval = []
     for new_id in new_ids:
-        parameters = optimizer.recommendNextParameters(hyperparameterConfig, results, currentTrials=[])
+        parameters = optimizer.recommendNextParameters(
+            hyperparameterConfig, results, currentTrials=[]
+        )
         flatParameters = hyperparameters.convertToFlatValues(parameters)
 
         rval_results = [domain.new_result()]
-        rval_miscs = [dict(
-            tid=new_id,
-            cmd=domain.cmd,
-            workdir=domain.workdir,
-            idxs = {
-                key: [0] for key in flatParameters
-            },
-            vals = {
-                key: [flatParameters[key]] for key in flatParameters
-            }
-
-        )]
+        rval_miscs = [
+            dict(
+                tid=new_id,
+                cmd=domain.cmd,
+                workdir=domain.workdir,
+                idxs={key: [0] for key in flatParameters},
+                vals={key: [flatParameters[key]] for key in flatParameters},
+            )
+        ]
 
         rval.extend(trials.new_trial_docs([new_id], [None], rval_results, rval_miscs))
 

--- a/hyperopt/base.py
+++ b/hyperopt/base.py
@@ -37,6 +37,7 @@ import numpy as np
 try:
     import bson  # -- comes with pymongo
     from bson.objectid import ObjectId
+
     have_bson = True
 except ImportError:
     have_bson = False
@@ -44,8 +45,13 @@ except ImportError:
 from . import pyll
 from .pyll.stochastic import recursive_set_rng_kwarg
 
-from .exceptions import (DuplicateLabel, InvalidTrial, InvalidResultStatus,
-                         InvalidLoss, AllTrialsFailed)
+from .exceptions import (
+    DuplicateLabel,
+    InvalidTrial,
+    InvalidResultStatus,
+    InvalidLoss,
+    AllTrialsFailed,
+)
 from .utils import pmin_sampled
 from .utils import use_obj_for_literal_in_memo
 from .vectorize import VectorizeHelper
@@ -62,17 +68,18 @@ logger = logging.getLogger(__name__)
 #    one of these values. They are used by optimization routines
 #    and plotting functions.
 
-STATUS_NEW = 'new'
-STATUS_RUNNING = 'running'
-STATUS_SUSPENDED = 'suspended'
-STATUS_OK = 'ok'
-STATUS_FAIL = 'fail'
+STATUS_NEW = "new"
+STATUS_RUNNING = "running"
+STATUS_SUSPENDED = "suspended"
+STATUS_OK = "ok"
+STATUS_FAIL = "fail"
 STATUS_STRINGS = (
-    'new',        # computations have not started
-    'running',    # computations are in prog
-    'suspended',  # computations have been suspended, job is not finished
-    'ok',         # computations are finished, terminated normally
-    'fail')       # computations are finished, terminated with error
+    "new",  # computations have not started
+    "running",  # computations are in prog
+    "suspended",  # computations have been suspended, job is not finished
+    "ok",  # computations are finished, terminated normally
+    "fail",
+)  # computations are finished, terminated with error
 #   - result['status_fail'] should contain more info
 
 
@@ -92,29 +99,24 @@ JOB_STATES = [
     JOB_STATE_RUNNING,
     JOB_STATE_DONE,
     JOB_STATE_ERROR,
-    JOB_STATE_CANCEL]
-JOB_VALID_STATES = {
-    JOB_STATE_NEW,
-    JOB_STATE_RUNNING,
-    JOB_STATE_DONE}
+    JOB_STATE_CANCEL,
+]
+JOB_VALID_STATES = {JOB_STATE_NEW, JOB_STATE_RUNNING, JOB_STATE_DONE}
 
 
 TRIAL_KEYS = [
-    'tid',
-    'spec',
-    'result',
-    'misc',
-    'state',
-    'owner',
-    'book_time',
-    'refresh_time',
-    'exp_key']
+    "tid",
+    "spec",
+    "result",
+    "misc",
+    "state",
+    "owner",
+    "book_time",
+    "refresh_time",
+    "exp_key",
+]
 
-TRIAL_MISC_KEYS = [
-    'tid',
-    'cmd',
-    'idxs',
-    'vals']
+TRIAL_MISC_KEYS = ["tid", "cmd", "idxs", "vals"]
 
 
 def _all_same(*args):
@@ -142,7 +144,8 @@ def SONify(arg, memo=None):
             rval = type(arg)([SONify(ai, memo) for ai in arg])
         elif isinstance(arg, dict):
             rval = dict(
-                [(SONify(k, memo), SONify(v, memo)) for k, v in list(arg.items())])
+                [(SONify(k, memo), SONify(v, memo)) for k, v in list(arg.items())]
+            )
         elif isinstance(arg, (basestring, float, int, int, type(None))):
             rval = arg
         elif isinstance(arg, np.ndarray):
@@ -155,7 +158,7 @@ def SONify(arg, memo=None):
             rval = int(arg)
         else:
             add_arg_to_raise = False
-            raise TypeError('SONify', arg)
+            raise TypeError("SONify", arg)
     except Exception as e:
         if add_arg_to_raise:
             e.args = e.args + (arg,)
@@ -164,9 +167,7 @@ def SONify(arg, memo=None):
     return rval
 
 
-def miscs_update_idxs_vals(miscs, idxs, vals,
-                           assert_all_vals_used=True,
-                           idxs_map=None):
+def miscs_update_idxs_vals(miscs, idxs, vals, assert_all_vals_used=True, idxs_map=None):
     """
     Unpack the idxs-vals format into the list of dictionaries that is
     `misc`.
@@ -179,18 +180,18 @@ def miscs_update_idxs_vals(miscs, idxs, vals,
 
     assert set(idxs.keys()) == set(vals.keys())
 
-    misc_by_id = dict([(m['tid'], m) for m in miscs])
+    misc_by_id = dict([(m["tid"], m) for m in miscs])
     for m in miscs:
-        m['idxs'] = dict([(key, []) for key in idxs])
-        m['vals'] = dict([(key, []) for key in idxs])
+        m["idxs"] = dict([(key, []) for key in idxs])
+        m["vals"] = dict([(key, []) for key in idxs])
 
     for key in idxs:
         assert len(idxs[key]) == len(vals[key])
         for tid, val in zip(idxs[key], vals[key]):
             tid = idxs_map.get(tid, tid)
             if assert_all_vals_used or tid in misc_by_id:
-                misc_by_id[tid]['idxs'][key] = [tid]
-                misc_by_id[tid]['vals'][key] = [val]
+                misc_by_id[tid]["idxs"][key] = [tid]
+                misc_by_id[tid]["vals"][key] = [val]
 
     return miscs
 
@@ -198,16 +199,16 @@ def miscs_update_idxs_vals(miscs, idxs, vals,
 def miscs_to_idxs_vals(miscs, keys=None):
     if keys is None:
         if len(miscs) == 0:
-            raise ValueError('cannot infer keys from empty miscs')
-        keys = list(miscs[0]['idxs'].keys())
+            raise ValueError("cannot infer keys from empty miscs")
+        keys = list(miscs[0]["idxs"].keys())
     idxs = dict([(k, []) for k in keys])
     vals = dict([(k, []) for k in keys])
     for misc in miscs:
         for node_id in idxs:
-            t_idxs = misc['idxs'][node_id]
-            t_vals = misc['vals'][node_id]
+            t_idxs = misc["idxs"][node_id]
+            t_vals = misc["vals"][node_id]
             assert len(t_idxs) == len(t_vals)
-            assert t_idxs == [] or t_idxs == [misc['tid']]
+            assert t_idxs == [] or t_idxs == [misc["tid"]]
             idxs[node_id].extend(t_idxs)
             vals[node_id].extend(t_vals)
     return idxs, vals
@@ -215,13 +216,13 @@ def miscs_to_idxs_vals(miscs, keys=None):
 
 def spec_from_misc(misc):
     spec = {}
-    for k, v in list(misc['vals'].items()):
+    for k, v in list(misc["vals"].items()):
         if len(v) == 0:
             pass
         elif len(v) == 1:
             spec[k] = v[0]
         else:
-            raise NotImplementedError('multiple values', (k, v))
+            raise NotImplementedError("multiple values", (k, v))
     return spec
 
 
@@ -290,7 +291,7 @@ class Trials(object):
         return rval
 
     def aname(self, trial, name):
-        return 'ATTACH::%s::%s' % (trial['tid'], name)
+        return "ATTACH::%s::%s" % (trial["tid"], name)
 
     def trial_attachments(self, trial):
         """
@@ -302,7 +303,6 @@ class Trials(object):
 
         # don't offer more here than in MongoCtrl
         class Attachments(object):
-
             def __contains__(_self, name):
                 return self.aname(trial, name) in self.attachments
 
@@ -334,19 +334,21 @@ class Trials(object):
     def __getitem__(self, item):
         # -- how to make it obvious whether indexing is by _trials position
         #    or by tid if both are integers?
-        raise NotImplementedError('')
+        raise NotImplementedError("")
 
     def refresh(self):
         # In MongoTrials, this method fetches from database
         if self._exp_key is None:
             self._trials = [
-                tt for tt in self._dynamic_trials
-                if tt['state'] in JOB_VALID_STATES]
+                tt for tt in self._dynamic_trials if tt["state"] in JOB_VALID_STATES
+            ]
         else:
-            self._trials = [tt
-                            for tt in self._dynamic_trials
-                            if (tt['state'] in JOB_VALID_STATES and tt['exp_key'] == self._exp_key)]
-        self._ids.update([tt['tid'] for tt in self._trials])
+            self._trials = [
+                tt
+                for tt in self._dynamic_trials
+                if (tt["state"] in JOB_VALID_STATES and tt["exp_key"] == self._exp_key)
+            ]
+        self._ids.update([tt["tid"] for tt in self._trials])
 
     @property
     def trials(self):
@@ -354,19 +356,19 @@ class Trials(object):
 
     @property
     def tids(self):
-        return [tt['tid'] for tt in self._trials]
+        return [tt["tid"] for tt in self._trials]
 
     @property
     def specs(self):
-        return [tt['spec'] for tt in self._trials]
+        return [tt["spec"] for tt in self._trials]
 
     @property
     def results(self):
-        return [tt['result'] for tt in self._trials]
+        return [tt["result"] for tt in self._trials]
 
     @property
     def miscs(self):
-        return [tt['misc'] for tt in self._trials]
+        return [tt["misc"] for tt in self._trials]
 
     @property
     def idxs_vals(self):
@@ -381,18 +383,16 @@ class Trials(object):
         return self.idxs_vals[1]
 
     def assert_valid_trial(self, trial):
-        if not (hasattr(trial, 'keys') and hasattr(trial, 'values')):
-            raise InvalidTrial('trial should be dict-like', trial)
+        if not (hasattr(trial, "keys") and hasattr(trial, "values")):
+            raise InvalidTrial("trial should be dict-like", trial)
         for key in TRIAL_KEYS:
             if key not in trial:
-                raise InvalidTrial('trial missing key %s', key)
+                raise InvalidTrial("trial missing key %s", key)
         for key in TRIAL_MISC_KEYS:
-            if key not in trial['misc']:
+            if key not in trial["misc"]:
                 raise InvalidTrial('trial["misc"] missing key', key)
-        if trial['tid'] != trial['misc']['tid']:
-            raise InvalidTrial(
-                'tid mismatch between root and misc',
-                trial)
+        if trial["tid"] != trial["misc"]["tid"]:
+            raise InvalidTrial("tid mismatch between root and misc", trial)
         # -- check for SON-encodable
         if have_bson:
             try:
@@ -400,20 +400,19 @@ class Trials(object):
             except:
                 # TODO: save the trial object somewhere to inspect, fix, re-insert
                 #       so that precious data is not simply deallocated and lost.
-                print('-' * 80)
+                print("-" * 80)
                 print("CANT ENCODE")
-                print('-' * 80)
+                print("-" * 80)
                 raise
-        if trial['exp_key'] != self._exp_key:
-            raise InvalidTrial('wrong exp_key',
-                               (trial['exp_key'], self._exp_key))
+        if trial["exp_key"] != self._exp_key:
+            raise InvalidTrial("wrong exp_key", (trial["exp_key"], self._exp_key))
         # XXX how to assert that tids are unique?
         return trial
 
     def _insert_trial_docs(self, docs):
         """insert with no error checking
         """
-        rval = [doc['tid'] for doc in docs]
+        rval = [doc["tid"] for doc in docs]
         self._dynamic_trials.extend(docs)
         return rval
 
@@ -431,8 +430,7 @@ class Trials(object):
     def insert_trial_docs(self, docs):
         """ trials - something like is returned by self.new_trial_docs()
         """
-        docs = [self.assert_valid_trial(SONify(doc))
-                for doc in docs]
+        docs = [self.assert_valid_trial(SONify(doc)) for doc in docs]
         return self._insert_trial_docs(docs)
 
     def new_trial_ids(self, N):
@@ -446,41 +444,39 @@ class Trials(object):
         rval = []
         for tid, spec, result, misc in zip(tids, specs, results, miscs):
             doc = dict(
-                state=JOB_STATE_NEW,
-                tid=tid,
-                spec=spec,
-                result=result,
-                misc=misc)
-            doc['exp_key'] = self._exp_key
-            doc['owner'] = None
-            doc['version'] = 0
-            doc['book_time'] = None
-            doc['refresh_time'] = None
+                state=JOB_STATE_NEW, tid=tid, spec=spec, result=result, misc=misc
+            )
+            doc["exp_key"] = self._exp_key
+            doc["owner"] = None
+            doc["version"] = 0
+            doc["book_time"] = None
+            doc["refresh_time"] = None
             rval.append(doc)
         return rval
 
     def source_trial_docs(self, tids, specs, results, miscs, sources):
         assert _all_same(list(map(len, [tids, specs, results, miscs, sources])))
         rval = []
-        for tid, spec, result, misc, source in zip(tids, specs, results, miscs,
-                                                   sources):
+        for tid, spec, result, misc, source in zip(
+            tids, specs, results, miscs, sources
+        ):
             doc = dict(
                 version=0,
                 tid=tid,
                 spec=spec,
                 result=result,
                 misc=misc,
-                state=source['state'],
-                exp_key=source['exp_key'],
-                owner=source['owner'],
-                book_time=source['book_time'],
-                refresh_time=source['refresh_time'],
+                state=source["state"],
+                exp_key=source["exp_key"],
+                owner=source["owner"],
+                book_time=source["book_time"],
+                refresh_time=source["refresh_time"],
             )
             # -- ensure that misc has the following fields,
             #    some of which may already by set correctly.
-            assign = ('tid', tid), ('cmd', None), ('from_tid', source['tid'])
+            assign = ("tid", tid), ("cmd", None), ("from_tid", source["tid"])
             for k, v in assign:
-                assert doc['misc'].setdefault(k, v) == v
+                assert doc["misc"].setdefault(k, v) == v
             rval.append(doc)
         return rval
 
@@ -496,11 +492,11 @@ class Trials(object):
         if trials is None:
             trials = self._trials
         if arg in JOB_STATES:
-            queue = [doc for doc in trials if doc['state'] == arg]
-        elif hasattr(arg, '__iter__'):
+            queue = [doc for doc in trials if doc["state"] == arg]
+        elif hasattr(arg, "__iter__"):
             states = set(arg)
             assert all([x in JOB_STATES for x in states])
-            queue = [doc for doc in trials if doc['state'] in states]
+            queue = [doc for doc in trials if doc["state"] in states]
         else:
             raise TypeError(arg)
         rval = len(queue)
@@ -512,22 +508,22 @@ class Trials(object):
         called refresh() first.
         """
         if self._exp_key is not None:
-            exp_trials = [tt
-                          for tt in self._dynamic_trials
-                          if tt['exp_key'] == self._exp_key]
+            exp_trials = [
+                tt for tt in self._dynamic_trials if tt["exp_key"] == self._exp_key
+            ]
         else:
             exp_trials = self._dynamic_trials
         return self.count_by_state_synced(arg, trials=exp_trials)
 
     def losses(self, bandit=None):
         if bandit is None:
-            return [r.get('loss') for r in self.results]
+            return [r.get("loss") for r in self.results]
         else:
             return list(map(bandit.loss, self.results, self.specs))
 
     def statuses(self, bandit=None):
         if bandit is None:
-            return [r.get('status') for r in self.results]
+            return [r.get("status") for r in self.results]
         else:
             return list(map(bandit.status, self.results, self.specs))
 
@@ -543,27 +539,35 @@ class Trials(object):
 
         if bandit is None:
             results = self.results
-            loss = [r['loss']
-                    for r in results if r['status'] == STATUS_OK]
-            loss_v = [r.get('loss_variance', 0)
-                      for r in results if r['status'] == STATUS_OK]
-            true_loss = [r.get('true_loss', r['loss'])
-                         for r in results if r['status'] == STATUS_OK]
+            loss = [r["loss"] for r in results if r["status"] == STATUS_OK]
+            loss_v = [
+                r.get("loss_variance", 0) for r in results if r["status"] == STATUS_OK
+            ]
+            true_loss = [
+                r.get("true_loss", r["loss"])
+                for r in results
+                if r["status"] == STATUS_OK
+            ]
         else:
+
             def fmap(f):
-                rval = np.asarray([
-                    f(r, s)
-                    for (r, s) in zip(self.results, self.specs)
-                    if bandit.status(r) == STATUS_OK]).astype('float')
+                rval = np.asarray(
+                    [
+                        f(r, s)
+                        for (r, s) in zip(self.results, self.specs)
+                        if bandit.status(r) == STATUS_OK
+                    ]
+                ).astype("float")
                 if not np.all(np.isfinite(rval)):
                     raise ValueError()
                 return rval
+
             loss = fmap(bandit.loss)
             loss_v = fmap(bandit.loss_variance)
             true_loss = fmap(bandit.true_loss)
         loss3 = list(zip(loss, loss_v, true_loss))
         if not loss3:
-            raise ValueError('Empty loss vector')
+            raise ValueError("Empty loss vector")
         loss3.sort()
         loss3 = np.asarray(loss3)
         if np.all(loss3[:, 1] == 0):
@@ -572,8 +576,7 @@ class Trials(object):
         else:
             cutoff = 0
             sigma = np.sqrt(loss3[0][1])
-            while (cutoff < len(loss3) and
-                   loss3[cutoff][0] < loss3[0][0] + 3 * sigma):
+            while cutoff < len(loss3) and loss3[cutoff][0] < loss3[0][0] + 3 * sigma:
                 cutoff += 1
             pmin = pmin_sampled(loss3[:cutoff, 0], loss3[:cutoff, 1])
             avg_true_loss = (pmin * loss3[:cutoff, 2]).sum()
@@ -585,11 +588,14 @@ class Trials(object):
         Trial with lowest non-NaN loss and status=STATUS_OK.
         If no such trial exists, returns None.
         """
-        candidates = [t for t in self.trials
-                      if t['result']['status'] == STATUS_OK and not np.isnan(t['result']['loss'])]
+        candidates = [
+            t
+            for t in self.trials
+            if t["result"]["status"] == STATUS_OK and not np.isnan(t["result"]["loss"])
+        ]
         if not candidates:
             raise AllTrialsFailed
-        losses = [float(t['result']['loss']) for t in candidates]
+        losses = [float(t["result"]["loss"]) for t in candidates]
         if len(losses) == 0:
             return None
         best = np.argmin(losses)
@@ -598,7 +604,7 @@ class Trials(object):
     @property
     def argmin(self):
         best_trial = self.best_trial
-        vals = best_trial['misc']['vals']
+        vals = best_trial["misc"]["vals"]
         # unpack the one-element lists to values
         # and skip over the 0-element lists
         rval = {}
@@ -607,15 +613,20 @@ class Trials(object):
                 rval[k] = v[0]
         return rval
 
-    def fmin(self, fn, space, algo, max_evals,
-             max_queue_len=1,
-             rstate=None,
-             verbose=0,
-             pass_expr_memo_ctrl=None,
-             catch_eval_exceptions=False,
-             return_argmin=True,
-             show_progressbar=True,
-             ):
+    def fmin(
+        self,
+        fn,
+        space,
+        algo,
+        max_evals,
+        max_queue_len=1,
+        rstate=None,
+        verbose=0,
+        pass_expr_memo_ctrl=None,
+        catch_eval_exceptions=False,
+        return_argmin=True,
+        show_progressbar=True,
+    ):
         """Minimize a function over a hyperparameter space.
 
         For most parameters, see `hyperopt.fmin.fmin`.
@@ -638,8 +649,12 @@ class Trials(object):
         #    fmin should have been a Trials method in the first place
         #    but for now it's still sitting in another file.
         from .fmin import fmin
+
         return fmin(
-            fn, space, algo, max_evals,
+            fn,
+            space,
+            algo,
+            max_evals,
             trials=self,
             rstate=rstate,
             verbose=verbose,
@@ -648,7 +663,8 @@ class Trials(object):
             pass_expr_memo_ctrl=pass_expr_memo_ctrl,
             catch_eval_exceptions=catch_eval_exceptions,
             return_argmin=return_argmin,
-            show_progressbar=show_progressbar)
+            show_progressbar=show_progressbar,
+        )
 
 
 def trials_from_docs(docs, validate=True, **kwargs):
@@ -666,6 +682,7 @@ def trials_from_docs(docs, validate=True, **kwargs):
 class Ctrl(object):
     """Control object for interruptible, checkpoint-able evaluation
     """
+
     info = logger.info
     warn = logger.warn
     error = logger.error
@@ -686,7 +703,7 @@ class Ctrl(object):
     def checkpoint(self, r=None):
         assert self.current_trial in self.trials._trials
         if r is not None:
-            self.current_trial['result'] = r
+            self.current_trial["result"] = r
 
     @property
     def attachments(self):
@@ -711,13 +728,11 @@ class Ctrl(object):
         assert len(specs) == len(results) == len(miscs)
         if new_tids is None:
             new_tids = self.trials.new_trial_ids(num_news)
-        new_trials = self.trials.source_trial_docs(tids=new_tids,
-                                                   specs=specs,
-                                                   results=results,
-                                                   miscs=miscs,
-                                                   sources=[trial])
+        new_trials = self.trials.source_trial_docs(
+            tids=new_tids, specs=specs, results=results, miscs=miscs, sources=[trial]
+        )
         for t in new_trials:
-            t['state'] = JOB_STATE_DONE
+            t["state"] = JOB_STATE_DONE
         return self.trials.insert_trial_docs(new_trials)
 
 
@@ -725,6 +740,7 @@ class Domain(object):
     """Picklable representation of search space and evaluation function.
 
     """
+
     rec_eval_print_node_on_error = False
 
     # -- the Ctrl object is not used directly, but rather
@@ -733,12 +749,15 @@ class Domain(object):
     #    the pyll graph describing the search space.
     pyll_ctrl = pyll.as_apply(Ctrl)
 
-    def __init__(self, fn, expr,
-                 workdir=None,
-                 pass_expr_memo_ctrl=None,
-                 name=None,
-                 loss_target=None,
-                 ):
+    def __init__(
+        self,
+        fn,
+        expr,
+        workdir=None,
+        pass_expr_memo_ctrl=None,
+        name=None,
+        loss_target=None,
+    ):
         """
         Paramaters
         ----------
@@ -776,9 +795,7 @@ class Domain(object):
         """
         self.fn = fn
         if pass_expr_memo_ctrl is None:
-            self.pass_expr_memo_ctrl = getattr(fn,
-                                               'fmin_pass_expr_memo_ctrl',
-                                               False)
+            self.pass_expr_memo_ctrl = getattr(fn, "fmin_pass_expr_memo_ctrl", False)
         else:
             self.pass_expr_memo_ctrl = pass_expr_memo_ctrl
 
@@ -786,17 +803,17 @@ class Domain(object):
 
         self.params = {}
         for node in pyll.dfs(self.expr):
-            if node.name == 'hyperopt_param':
-                label = node.arg['label'].obj
+            if node.name == "hyperopt_param":
+                label = node.arg["label"].obj
                 if label in self.params:
                     raise DuplicateLabel(label)
-                self.params[label] = node.arg['obj']
+                self.params[label] = node.arg["obj"]
 
         self.loss_target = loss_target
         self.name = name
 
         self.workdir = workdir
-        self.s_new_ids = pyll.Literal('new_ids')  # -- list at eval-time
+        self.s_new_ids = pyll.Literal("new_ids")  # -- list at eval-time
         before = pyll.dfs(self.expr)
         # -- raises exception if expr contains cycles
         pyll.toposort(self.expr)
@@ -812,11 +829,11 @@ class Domain(object):
         assert set(idxs_by_label.keys()) == set(vals_by_label.keys())
         assert set(idxs_by_label.keys()) == set(self.params.keys())
 
-        self.s_rng = pyll.Literal('rng-placeholder')
+        self.s_rng = pyll.Literal("rng-placeholder")
         # -- N.B. operates inplace:
         self.s_idxs_vals = recursive_set_rng_kwarg(
-            pyll.scope.pos_args(idxs_by_label, vals_by_label),
-            self.s_rng)
+            pyll.scope.pos_args(idxs_by_label, vals_by_label), self.s_rng
+        )
 
         # -- raises an exception if no topological ordering exists
         pyll.toposort(self.s_idxs_vals)
@@ -826,13 +843,13 @@ class Domain(object):
         #    should be [un]serialized.
         #    XXX This mechanism deserves review as support for ipython
         #        workers improves.
-        self.cmd = ('domain_attachment', 'FMinIter_Domain')
+        self.cmd = ("domain_attachment", "FMinIter_Domain")
 
     def memo_from_config(self, config):
         memo = {}
         for node in pyll.dfs(self.expr):
-            if node.name == 'hyperopt_param':
-                label = node.arg['label'].obj
+            if node.name == "hyperopt_param":
+                label = node.arg["label"].obj
                 # -- hack because it's not really garbagecollected
                 #    this does have the desired effect of crashing the
                 #    function if rec_eval actually needs a value that
@@ -852,26 +869,27 @@ class Domain(object):
             pyll_rval = pyll.rec_eval(
                 self.expr,
                 memo=memo,
-                print_node_on_error=self.rec_eval_print_node_on_error)
+                print_node_on_error=self.rec_eval_print_node_on_error,
+            )
             rval = self.fn(pyll_rval)
 
         if isinstance(rval, (float, int, np.number)):
-            dict_rval = {'loss': float(rval), 'status': STATUS_OK}
+            dict_rval = {"loss": float(rval), "status": STATUS_OK}
         else:
             dict_rval = dict(rval)
-            status = dict_rval['status']
+            status = dict_rval["status"]
             if status not in STATUS_STRINGS:
                 raise InvalidResultStatus(dict_rval)
 
             if status == STATUS_OK:
                 # -- make sure that the loss is present and valid
                 try:
-                    dict_rval['loss'] = float(dict_rval['loss'])
+                    dict_rval["loss"] = float(dict_rval["loss"])
                 except (TypeError, KeyError):
                     raise InvalidLoss(dict_rval)
 
         if attach_attachments:
-            attachments = dict_rval.pop('attachments', {})
+            attachments = dict_rval.pop("attachments", {})
             for key, val in list(attachments.items()):
                 ctrl.attachments[key] = val
 
@@ -880,13 +898,13 @@ class Domain(object):
         #    anything.
         return dict_rval
 
-    def evaluate_async(self, config, ctrl, attach_attachments=True,):
-        '''
+    def evaluate_async(self, config, ctrl, attach_attachments=True):
+        """
         this is the first part of async evaluation for ipython parallel engines (see ipy.py)
 
         This breaks evaluate into two parts to allow for the apply_async call
         to only pass the objective function and arguments.
-        '''
+        """
         memo = self.memo_from_config(config)
         use_obj_for_literal_in_memo(self.expr, ctrl, Ctrl, memo)
         if self.pass_expr_memo_ctrl:
@@ -898,30 +916,31 @@ class Domain(object):
             pyll_rval = pyll.rec_eval(
                 self.expr,
                 memo=memo,
-                print_node_on_error=self.rec_eval_print_node_on_error)
+                print_node_on_error=self.rec_eval_print_node_on_error,
+            )
             return (self.fn, pyll_rval)
 
     def evaluate_async2(self, rval, ctrl, attach_attachments=True):
-        '''
+        """
         this is the second part of async evaluation for ipython parallel engines (see ipy.py)
-        '''
+        """
         if isinstance(rval, (float, int, np.number)):
-            dict_rval = {'loss': float(rval), 'status': STATUS_OK}
+            dict_rval = {"loss": float(rval), "status": STATUS_OK}
         else:
             dict_rval = dict(rval)
-            status = dict_rval['status']
+            status = dict_rval["status"]
             if status not in STATUS_STRINGS:
                 raise InvalidResultStatus(dict_rval)
 
             if status == STATUS_OK:
                 # -- make sure that the loss is present and valid
                 try:
-                    dict_rval['loss'] = float(dict_rval['loss'])
+                    dict_rval["loss"] = float(dict_rval["loss"])
                 except (TypeError, KeyError):
                     raise InvalidLoss(dict_rval)
 
         if attach_attachments:
-            attachments = dict_rval.pop('attachments', {})
+            attachments = dict_rval.pop("attachments", {})
             for key, val in list(attachments.items()):
                 ctrl.attachments[key] = val
 
@@ -931,22 +950,22 @@ class Domain(object):
         return dict_rval
 
     def short_str(self):
-        return 'Domain{%s}' % str(self.fn)
+        return "Domain{%s}" % str(self.fn)
 
     def loss(self, result, config=None):
         """Extract the scalar-valued loss from a result document
         """
-        return result.get('loss', None)
+        return result.get("loss", None)
 
     def loss_variance(self, result, config=None):
         """Return the variance in the estimate of the loss"""
-        return result.get('loss_variance', 0.0)
+        return result.get("loss_variance", 0.0)
 
     def true_loss(self, result, config=None):
         """Return a true loss, in the case that the `loss` is a surrogate"""
         # N.B. don't use get() here, it evaluates self.loss un-necessarily
         try:
-            return result['true_loss']
+            return result["true_loss"]
         except KeyError:
             return self.loss(result, config=config)
 
@@ -959,13 +978,13 @@ class Domain(object):
     def status(self, result, config=None):
         """Extract the job status from a result document
         """
-        return result['status']
+        return result["status"]
 
     def new_result(self):
         """Return a JSON-encodable object
         to serve as the 'result' for new jobs.
         """
-        return {'status': STATUS_NEW}
+        return {"status": STATUS_NEW}
 
 
 # -- flake8 doesn't like blank last line

--- a/hyperopt/criteria.py
+++ b/hyperopt/criteria.py
@@ -66,19 +66,18 @@ def logEI_gaussian(mean, var, thresh):
         score = np.asarray(score)
         rval = np.zeros_like(score)
 
-        olderr = np.seterr(all='ignore')
+        olderr = np.seterr(all="ignore")
         try:
             negs = score < 0
             nonnegs = np.logical_not(negs)
             negs_score = score[negs]
             negs_pdf = n.logpdf(negs_score)
-            r = np.exp(np.log(-negs_score) +
-                       n.logcdf(negs_score) -
-                       negs_pdf)
+            r = np.exp(np.log(-negs_score) + n.logcdf(negs_score) - negs_pdf)
             rval[negs] = np.log(sigma[negs]) + negs_pdf + np.log1p(-r)
             nonnegs_score = score[nonnegs]
             rval[nonnegs] = np.log(sigma[nonnegs]) + np.log(
-                nonnegs_score * n.cdf(nonnegs_score) + n.pdf(nonnegs_score))
+                nonnegs_score * n.cdf(nonnegs_score) + n.pdf(nonnegs_score)
+            )
             rval[np.logical_not(np.isfinite(rval))] = -np.inf
         finally:
             np.seterr(**olderr)

--- a/hyperopt/exceptions.py
+++ b/hyperopt/exceptions.py
@@ -13,13 +13,15 @@ class DuplicateLabel(BadSearchSpace):
 
 class InvalidTrial(ValueError):
     """Non trial-like object used as Trial"""
+
     def __init__(self, msg, obj):
-        ValueError.__init__(self, msg + ' ' + str(obj))
+        ValueError.__init__(self, msg + " " + str(obj))
         self.obj = obj
 
 
 class InvalidResultStatus(ValueError):
     """Status of fmin evaluation was not in base.STATUS_STRINGS"""
+
     def __init__(self, result):
         ValueError.__init__(self)
         self.result = result
@@ -27,6 +29,7 @@ class InvalidResultStatus(ValueError):
 
 class InvalidLoss(ValueError):
     """fmin evaluation returned invalid loss value"""
+
     def __init__(self, result):
         ValueError.__init__(self)
         self.result = result
@@ -34,5 +37,6 @@ class InvalidLoss(ValueError):
 
 class AllTrialsFailed(Exception):
     """All optimization steps have finished with status base.STATUS_FAIL"""
+
 
 # -- flake8 doesn't like blank last line

--- a/hyperopt/fmin.py
+++ b/hyperopt/fmin.py
@@ -25,7 +25,9 @@ logger = logging.getLogger(__name__)
 try:
     import cloudpickle as pickler
 except Exception as e:
-    logger.info('Failed to load cloudpickle, try installing cloudpickle via "pip install cloudpickle" for enhanced pickling support.')
+    logger.info(
+        'Failed to load cloudpickle, try installing cloudpickle via "pip install cloudpickle" for enhanced pickling support.'
+    )
     import six.moves.cPickle as pickler
 
 
@@ -33,22 +35,24 @@ def generate_trial(tid, space):
     variables = space.keys()
     idxs = {v: [tid] for v in variables}
     vals = {k: [v] for k, v in space.items()}
-    return {'state': base.JOB_STATE_NEW,
-            'tid': tid,
-            'spec': None,
-            'result': {'status': 'new'},
-            'misc': {'tid': tid,
-                     'cmd': ('domain_attachment',
-                             'FMinIter_Domain'),
-                     'workdir': None,
-                     'idxs': idxs,
-                     'vals': vals},
-            'exp_key': None,
-            'owner': None,
-            'version': 0,
-            'book_time': None,
-            'refresh_time': None,
-            }
+    return {
+        "state": base.JOB_STATE_NEW,
+        "tid": tid,
+        "spec": None,
+        "result": {"status": "new"},
+        "misc": {
+            "tid": tid,
+            "cmd": ("domain_attachment", "FMinIter_Domain"),
+            "workdir": None,
+            "idxs": idxs,
+            "vals": vals,
+        },
+        "exp_key": None,
+        "owner": None,
+        "version": 0,
+        "book_time": None,
+        "refresh_time": None,
+    }
 
 
 def generate_trials_to_calculate(points):
@@ -89,7 +93,7 @@ def partial(fn, **kwargs):
     fmin_pass_expr_memo_ctrl
     """
     rval = functools.partial(fn, **kwargs)
-    if hasattr(fn, 'fmin_pass_expr_memo_ctrl'):
+    if hasattr(fn, "fmin_pass_expr_memo_ctrl"):
         rval.fmin_pass_expr_memo_ctrl = fn.fmin_pass_expr_memo_ctrl
     return rval
 
@@ -97,16 +101,23 @@ def partial(fn, **kwargs):
 class FMinIter(object):
     """Object for conducting search experiments.
     """
+
     catch_eval_exceptions = False
     pickle_protocol = -1
 
-    def __init__(self, algo, domain, trials, rstate, asynchronous=None,
-                 max_queue_len=1,
-                 poll_interval_secs=1.0,
-                 max_evals=sys.maxsize,
-                 verbose=0,
-                 show_progressbar=True
-                 ):
+    def __init__(
+        self,
+        algo,
+        domain,
+        trials,
+        rstate,
+        asynchronous=None,
+        max_queue_len=1,
+        poll_interval_secs=1.0,
+        max_evals=sys.maxsize,
+        verbose=0,
+        show_progressbar=True,
+    ):
         self.algo = algo
         self.domain = domain
         self.trials = trials
@@ -121,29 +132,29 @@ class FMinIter(object):
         self.rstate = rstate
 
         if self.asynchronous:
-            if 'FMinIter_Domain' in trials.attachments:
-                logger.warn('over-writing old domain trials attachment')
+            if "FMinIter_Domain" in trials.attachments:
+                logger.warn("over-writing old domain trials attachment")
             msg = pickler.dumps(domain)
             # -- sanity check for unpickling
             pickler.loads(msg)
-            trials.attachments['FMinIter_Domain'] = msg
+            trials.attachments["FMinIter_Domain"] = msg
 
     def serial_evaluate(self, N=-1):
         for trial in self.trials._dynamic_trials:
-            if trial['state'] == base.JOB_STATE_NEW:
-                trial['state'] = base.JOB_STATE_RUNNING
+            if trial["state"] == base.JOB_STATE_NEW:
+                trial["state"] = base.JOB_STATE_RUNNING
                 now = coarse_utcnow()
-                trial['book_time'] = now
-                trial['refresh_time'] = now
-                spec = base.spec_from_misc(trial['misc'])
+                trial["book_time"] = now
+                trial["refresh_time"] = now
+                spec = base.spec_from_misc(trial["misc"])
                 ctrl = base.Ctrl(self.trials, current_trial=trial)
                 try:
                     result = self.domain.evaluate(spec, ctrl)
                 except Exception as e:
-                    logger.info('job exception: %s' % str(e))
-                    trial['state'] = base.JOB_STATE_ERROR
-                    trial['misc']['error'] = (str(type(e)), str(e))
-                    trial['refresh_time'] = coarse_utcnow()
+                    logger.info("job exception: %s" % str(e))
+                    trial["state"] = base.JOB_STATE_ERROR
+                    trial["misc"]["error"] = (str(type(e)), str(e))
+                    trial["refresh_time"] = coarse_utcnow()
                     if not self.catch_eval_exceptions:
                         # -- JOB_STATE_ERROR means this trial
                         #    will be removed from self.trials.trials
@@ -151,9 +162,9 @@ class FMinIter(object):
                         self.trials.refresh()
                         raise
                 else:
-                    trial['state'] = base.JOB_STATE_DONE
-                    trial['result'] = result
-                    trial['refresh_time'] = coarse_utcnow()
+                    trial["state"] = base.JOB_STATE_DONE
+                    trial["result"] = result
+                    trial["refresh_time"] = coarse_utcnow()
                 N -= 1
                 if N == 0:
                     break
@@ -180,7 +191,7 @@ class FMinIter(object):
             qlen = get_queue_len()
             while qlen > 0:
                 if not already_printed:
-                    logger.info('Waiting for %d jobs to finish ...' % qlen)
+                    logger.info("Waiting for %d jobs to finish ..." % qlen)
                     already_printed = True
                 time.sleep(self.poll_interval_secs)
                 qlen = get_queue_len()
@@ -204,22 +215,35 @@ class FMinIter(object):
         stopped = False
         qlen = get_queue_len()
         with std_out_err_redirect_tqdm() as orig_stdout:
-            with tqdm(total=N+qlen, file=orig_stdout, postfix='best loss: ?',
-                      disable=not self.show_progressbar, dynamic_ncols=True,
-                      ) as pbar:
+            with tqdm(
+                total=N + qlen,
+                file=orig_stdout,
+                postfix="best loss: ?",
+                disable=not self.show_progressbar,
+                dynamic_ncols=True,
+            ) as pbar:
                 while n_queued < N:
                     qlen = get_queue_len()
-                    while qlen < self.max_queue_len and n_queued < N and \
-                            not self.is_cancelled:
+                    while (
+                        qlen < self.max_queue_len
+                        and n_queued < N
+                        and not self.is_cancelled
+                    ):
                         n_to_enqueue = min(self.max_queue_len - qlen, N - n_queued)
                         new_ids = trials.new_trial_ids(n_to_enqueue)
                         self.trials.refresh()
                         if 0:
                             for d in self.trials.trials:
-                                print('trial %i %s %s' % (d['tid'], d['state'],
-                                                          d['result'].get('status')))
-                        new_trials = algo(new_ids, self.domain, trials,
-                                          self.rstate.randint(2 ** 31 - 1))
+                                print(
+                                    "trial %i %s %s"
+                                    % (d["tid"], d["state"], d["result"].get("status"))
+                                )
+                        new_trials = algo(
+                            new_ids,
+                            self.domain,
+                            trials,
+                            self.rstate.randint(2 ** 31 - 1),
+                        )
                         assert len(new_ids) >= len(new_trials)
                         if len(new_trials):
                             self.trials.insert_trial_docs(new_trials)
@@ -241,10 +265,14 @@ class FMinIter(object):
                         self.serial_evaluate()
 
                     try:
-                        best_loss = min([d['result']['loss'] for d in
-                                         self.trials.trials if
-                                         d['result']['status'] == 'ok'])
-                        pbar.postfix = 'best loss: ' + str(best_loss)
+                        best_loss = min(
+                            [
+                                d["result"]["loss"]
+                                for d in self.trials.trials
+                                if d["result"]["status"] == "ok"
+                            ]
+                        )
+                        pbar.postfix = "best loss: " + str(best_loss)
                     except:
                         pass
                     pbar.update(qlen)
@@ -255,11 +283,11 @@ class FMinIter(object):
         if block_until_done:
             self.block_until_done()
             self.trials.refresh()
-            logger.info('Queue empty, exiting run.')
+            logger.info("Queue empty, exiting run.")
         else:
             qlen = get_queue_len()
             if qlen:
-                msg = 'Exiting run, not waiting for %d jobs.' % qlen
+                msg = "Exiting run, not waiting for %d jobs." % qlen
                 logger.info(msg)
 
     def __iter__(self):
@@ -278,15 +306,22 @@ class FMinIter(object):
         return self
 
 
-def fmin(fn, space, algo, max_evals, trials=None, rstate=None,
-         allow_trials_fmin=True, pass_expr_memo_ctrl=None,
-         catch_eval_exceptions=False,
-         verbose=0,
-         return_argmin=True,
-         points_to_evaluate=None,
-         max_queue_len=1,
-         show_progressbar=True,
-         ):
+def fmin(
+    fn,
+    space,
+    algo,
+    max_evals,
+    trials=None,
+    rstate=None,
+    allow_trials_fmin=True,
+    pass_expr_memo_ctrl=None,
+    catch_eval_exceptions=False,
+    verbose=0,
+    return_argmin=True,
+    points_to_evaluate=None,
+    max_queue_len=1,
+    show_progressbar=True,
+):
     """Minimize a function over a hyperparameter space.
 
     More realistically: *explore* a function over a hyperparameter space
@@ -383,15 +418,16 @@ def fmin(fn, space, algo, max_evals, trials=None, rstate=None,
         If there were no succesfull trails, it returns None.
     """
     if rstate is None:
-        env_rseed = os.environ.get('HYPEROPT_FMIN_SEED', '')
+        env_rseed = os.environ.get("HYPEROPT_FMIN_SEED", "")
         if env_rseed:
             rstate = np.random.RandomState(int(env_rseed))
         else:
             rstate = np.random.RandomState()
 
-    if allow_trials_fmin and hasattr(trials, 'fmin'):
+    if allow_trials_fmin and hasattr(trials, "fmin"):
         return trials.fmin(
-            fn, space,
+            fn,
+            space,
             algo=algo,
             max_evals=max_evals,
             max_queue_len=max_queue_len,
@@ -410,19 +446,25 @@ def fmin(fn, space, algo, max_evals, trials=None, rstate=None,
             assert type(points_to_evaluate) == list
             trials = generate_trials_to_calculate(points_to_evaluate)
 
-    domain = base.Domain(fn, space,
-                         pass_expr_memo_ctrl=pass_expr_memo_ctrl)
+    domain = base.Domain(fn, space, pass_expr_memo_ctrl=pass_expr_memo_ctrl)
 
-    rval = FMinIter(algo, domain, trials, max_evals=max_evals,
-                    rstate=rstate,
-                    verbose=verbose,
-                    max_queue_len=max_queue_len,
-                    show_progressbar=show_progressbar)
+    rval = FMinIter(
+        algo,
+        domain,
+        trials,
+        max_evals=max_evals,
+        rstate=rstate,
+        verbose=verbose,
+        max_queue_len=max_queue_len,
+        show_progressbar=show_progressbar,
+    )
     rval.catch_eval_exceptions = catch_eval_exceptions
     rval.exhaust()
     if return_argmin:
         if len(trials.trials) == 0:
-            raise Exception("There are no evaluation tasks, cannot return argmin of task losses.")
+            raise Exception(
+                "There are no evaluation tasks, cannot return argmin of task losses."
+            )
         return trials.argmin
     elif len(trials) > 0:
         # Only if there are some succesfull trail runs, return the best point in the evaluation space
@@ -444,11 +486,12 @@ def space_eval(space, hp_assignment):
     nodes = pyll.toposort(space)
     memo = {}
     for node in nodes:
-        if node.name == 'hyperopt_param':
-            label = node.arg['label'].eval()
+        if node.name == "hyperopt_param":
+            label = node.arg["label"].eval()
             if label in hp_assignment:
                 memo[node] = hp_assignment[label]
     rval = pyll.rec_eval(space, memo=memo)
     return rval
+
 
 # -- flake8 doesn't like blank last line

--- a/hyperopt/graph_viz.py
+++ b/hyperopt/graph_viz.py
@@ -57,22 +57,24 @@ def dot_hyperparameters(expr):
         var_node(hp)
 
         # create an edge from anything it depends on
-        for and_conds in dct['conditions']:
+        for and_conds in dct["conditions"]:
             if len(and_conds) > 1:
-                parent_label = ' & '.join([
-                    '%(name)s%(op)s%(val)s' % cond.__dict__
-                    for cond in and_conds])
+                parent_label = " & ".join(
+                    ["%(name)s%(op)s%(val)s" % cond.__dict__ for cond in and_conds]
+                )
                 cond_node(parent_label)
                 edge(parent_label, hp)
                 for cond in and_conds:
-                    sub_parent_label = '%s%s%s' % (
-                        cond.name, cond.op, cond.val)
+                    sub_parent_label = "%s%s%s" % (cond.name, cond.op, cond.val)
                     cond_node(sub_parent_label)
                     edge(cond.name, sub_parent_label)
                     edge(sub_parent_label, parent_label)
             elif len(and_conds) == 1:
-                parent_label = '%s%s%s' % (
-                    and_conds[0].name, and_conds[0].op, and_conds[0].val)
+                parent_label = "%s%s%s" % (
+                    and_conds[0].name,
+                    and_conds[0].op,
+                    and_conds[0].val,
+                )
                 edge(and_conds[0].name, parent_label)
                 cond_node(parent_label)
                 edge(parent_label, hp)

--- a/hyperopt/ipy.py
+++ b/hyperopt/ipy.py
@@ -24,6 +24,7 @@ from .base import Ctrl
 from .utils import coarse_utcnow
 
 import sys
+
 print(sys.stderr, "WARNING: IPythonTrials is not as complete, stable", file=sys.stderr)
 print("         or well tested as Trials or MongoTrials.", file=sys.stderr)
 
@@ -33,10 +34,7 @@ class LostEngineError(RuntimeError):
 
 
 class IPythonTrials(Trials):
-
-    def __init__(self, client,
-                 job_error_reaction='raise',
-                 save_ipy_metadata=True):
+    def __init__(self, client, job_error_reaction="raise", save_ipy_metadata=True):
         self._client = client
         self._clientlbv = client.load_balanced_view()
         self.job_map = {}
@@ -46,7 +44,7 @@ class IPythonTrials(Trials):
         self._testing_fmin_was_called = False
 
     def _insert_trial_docs(self, docs):
-        rval = [doc['tid'] for doc in docs]
+        rval = [doc["tid"] for doc in docs]
         self._dynamic_trials.extend(docs)
         return rval
 
@@ -59,11 +57,11 @@ class IPythonTrials(Trials):
 
         # -- deal with lost engines, abandoned promises
         for eid, (p, tt) in list(self.job_map.items()):
-            if self.job_error_reaction == 'raise':
+            if self.job_error_reaction == "raise":
                 raise LostEngineError(p)
-            elif self.job_error_reaction == 'log':
-                tt['error'] = 'LostEngineError (%s)' % str(p)
-                tt['state'] = JOB_STATE_ERROR
+            elif self.job_error_reaction == "log":
+                tt["error"] = "LostEngineError (%s)" % str(p)
+                tt["state"] = JOB_STATE_ERROR
             else:
                 raise ValueError(self.job_error_reaction)
 
@@ -73,20 +71,20 @@ class IPythonTrials(Trials):
                 continue
             if p.ready():
                 try:
-                    tt['result'] = p.get()
-                    tt['state'] = JOB_STATE_DONE
+                    tt["result"] = p.get()
+                    tt["state"] = JOB_STATE_DONE
                     job_map[eid] = (None, None)
                 except Exception as e:
-                    if self.job_error_reaction == 'raise':
+                    if self.job_error_reaction == "raise":
                         raise
-                    elif self.job_error_reaction == 'log':
-                        tt['error'] = str(e)
-                        tt['state'] = JOB_STATE_ERROR
+                    elif self.job_error_reaction == "log":
+                        tt["error"] = str(e)
+                        tt["state"] = JOB_STATE_ERROR
                     else:
                         raise ValueError(self.job_error_reaction)
                 if self.save_ipy_metadata:
-                    tt['ipy_metadata'] = p.metadata
-                tt['refresh_time'] = coarse_utcnow()
+                    tt["ipy_metadata"] = p.metadata
+                tt["refresh_time"] = coarse_utcnow()
                 del job_map[eid]
 
         self.job_map = job_map
@@ -94,16 +92,16 @@ class IPythonTrials(Trials):
 
     def fmin(self, fn, space, **kw):
         # TODO: all underscore variables are completely unused throughout.
-        algo = kw.get('algo')
-        max_evals = kw.get('max_evals')
-        rstate = kw.get('rstate', None)
-        _allow_trials_fmin = True,
-        _pass_expr_memo_ctrl = None,
-        _catch_eval_exceptions = False,
-        verbose = kw.get('verbose', 0)
-        _return_argmin = True,
-        wait = True,
-        pass_expr_memo_ctrl = None,
+        algo = kw.get("algo")
+        max_evals = kw.get("max_evals")
+        rstate = kw.get("rstate", None)
+        _allow_trials_fmin = (True,)
+        _pass_expr_memo_ctrl = (None,)
+        _catch_eval_exceptions = (False,)
+        verbose = kw.get("verbose", 0)
+        _return_argmin = (True,)
+        wait = (True,)
+        pass_expr_memo_ctrl = (None,)
 
         if rstate is None:
             rstate = np.random
@@ -117,8 +115,7 @@ class IPythonTrials(Trials):
             except AttributeError:
                 pass_expr_memo_ctrl = False
 
-        domain = Domain(fn, space, None,
-                        pass_expr_memo_ctrl=False)
+        domain = Domain(fn, space, None, pass_expr_memo_ctrl=False)
 
         last_print_time = 0
 
@@ -126,13 +123,18 @@ class IPythonTrials(Trials):
             self.refresh()
 
             if verbose and last_print_time + 1 < time():
-                print('fmin: %4i/%4i/%4i/%4i  %f' % (
-                    self.count_by_state_unsynced(JOB_STATE_NEW),
-                    self.count_by_state_unsynced(JOB_STATE_RUNNING),
-                    self.count_by_state_unsynced(JOB_STATE_DONE),
-                    self.count_by_state_unsynced(JOB_STATE_ERROR),
-                    min([float('inf')] + [l for l in self.losses() if l is not None])
-                ))
+                print(
+                    "fmin: %4i/%4i/%4i/%4i  %f"
+                    % (
+                        self.count_by_state_unsynced(JOB_STATE_NEW),
+                        self.count_by_state_unsynced(JOB_STATE_RUNNING),
+                        self.count_by_state_unsynced(JOB_STATE_DONE),
+                        self.count_by_state_unsynced(JOB_STATE_ERROR),
+                        min(
+                            [float("inf")] + [l for l in self.losses() if l is not None]
+                        ),
+                    )
+                )
                 last_print_time = time()
 
             idles = [eid for (eid, (p, tt)) in list(self.job_map.items()) if p is None]
@@ -146,12 +148,12 @@ class IPythonTrials(Trials):
                     assert len(idles) >= len(new_trials)
                     for eid, new_trial in zip(idles, new_trials):
                         now = coarse_utcnow()
-                        new_trial['book_time'] = now
-                        new_trial['refresh_time'] = now
-                        tid, = self.insert_trial_docs([new_trial])
+                        new_trial["book_time"] = now
+                        new_trial["refresh_time"] = now
+                        (tid,) = self.insert_trial_docs([new_trial])
                         promise = call_domain(
                             domain,
-                            spec_from_misc(new_trial['misc']),
+                            spec_from_misc(new_trial["misc"]),
                             Ctrl(self, current_trial=new_trial),
                             new_trial,
                             self._clientlbv,
@@ -164,13 +166,13 @@ class IPythonTrials(Trials):
                         # for all else being SONify
 
                         tt = self._dynamic_trials[-1]
-                        assert tt['tid'] == tid
+                        assert tt["tid"] == tid
                         self.job_map[eid] = (promise, tt)
-                        tt['state'] = JOB_STATE_RUNNING
+                        tt["state"] = JOB_STATE_RUNNING
 
         if wait:
             if verbose:
-                print('fmin: Waiting on remaining jobs...')
+                print("fmin: Waiting on remaining jobs...")
             self.wait(verbose=verbose)
 
         return self.argmin
@@ -180,14 +182,18 @@ class IPythonTrials(Trials):
         while True:
             self.refresh()
             if verbose and last_print_time + verbose_print_interval < time():
-                print('fmin: %4i/%4i/%4i/%4i  %f' % (
-                    self.count_by_state_unsynced(JOB_STATE_NEW),
-                    self.count_by_state_unsynced(JOB_STATE_RUNNING),
-                    self.count_by_state_unsynced(JOB_STATE_DONE),
-                    self.count_by_state_unsynced(JOB_STATE_ERROR),
-                    min([float('inf')] +
-                        [l for l in self.losses() if l is not None])
-                ))
+                print(
+                    "fmin: %4i/%4i/%4i/%4i  %f"
+                    % (
+                        self.count_by_state_unsynced(JOB_STATE_NEW),
+                        self.count_by_state_unsynced(JOB_STATE_RUNNING),
+                        self.count_by_state_unsynced(JOB_STATE_DONE),
+                        self.count_by_state_unsynced(JOB_STATE_ERROR),
+                        min(
+                            [float("inf")] + [l for l in self.losses() if l is not None]
+                        ),
+                    )
+                )
                 last_print_time = time()
             if self.count_by_state_unsynced(JOB_STATE_NEW):
                 sleep(1e-1)
@@ -199,9 +205,9 @@ class IPythonTrials(Trials):
 
     def __getstate__(self):
         rval = dict(self.__dict__)
-        del rval['_client']
-        del rval['_trials']
-        del rval['job_map']
+        del rval["_client"]
+        del rval["_trials"]
+        del rval["job_map"]
         # print rval.keys()
         return rval
 
@@ -214,7 +220,6 @@ class IPythonTrials(Trials):
 # Monkey patching to allow the apply_async call and response to
 # be handled on behalf of the domain.
 class IPYAsync(object):
-
     def __init__(self, asynchronous, domain, rv, eid, tid, ctrl):
         self.asynchronous = asynchronous
         self.domain = domain
@@ -233,13 +238,15 @@ class IPYAsync(object):
             return self.domain.evaluate_async2(val, self.ctrl)
         else:
             return self.rv
+
     pass
+
 
 # @interactive
 
 
 def call_domain(domain, spec, ctrl, trial, view, eid, tid):
-    rv = {'loss': None, 'status': 'fail'}
+    rv = {"loss": None, "status": "fail"}
     # TODO: rt unused
     rt = coarse_utcnow()
     # print "in call domain for spec", str(spec)

--- a/hyperopt/main.py
+++ b/hyperopt/main.py
@@ -18,7 +18,9 @@ logger = logging.getLogger(__name__)
 try:
     import cloudpickle as pickler
 except Exception as e:
-    logger.info('Failed to load cloudpickle, try installing cloudpickle via "pip install cloudpickle" for enhanced pickling support.')
+    logger.info(
+        'Failed to load cloudpickle, try installing cloudpickle via "pip install cloudpickle" for enhanced pickling support.'
+    )
     import six.moves.cPickle as pickler
 
 __authors__ = "James Bergstra"
@@ -28,43 +30,55 @@ __contact__ = "github.com/hyperopt/hyperopt"
 
 def main_search():
     from optparse import OptionParser
-    parser = OptionParser(
-        usage="%prog [options] [<bandit> <bandit_algo>]")
-    parser.add_option('--load',
-                      default='',
-                      dest="load",
-                      metavar='FILE',
-                      help="unpickle experiment from here on startup")
-    parser.add_option('--save',
-                      default='experiment.pkl',
-                      dest="save",
-                      metavar='FILE',
-                      help="pickle experiment to here on exit")
-    parser.add_option("--steps",
-                      dest='steps',
-                      default='100',
-                      metavar='N',
-                      help="exit after queuing this many jobs (default: 100)")
-    parser.add_option("--workdir",
-                      dest="workdir",
-                      default=os.path.expanduser('~/.hyperopt.workdir'),
-                      help="create workdirs here",
-                      metavar="DIR")
-    parser.add_option("--bandit-argfile",
-                      dest="bandit_argfile",
-                      default=None,
-                      help="path to file containing arguments bandit constructor \
+
+    parser = OptionParser(usage="%prog [options] [<bandit> <bandit_algo>]")
+    parser.add_option(
+        "--load",
+        default="",
+        dest="load",
+        metavar="FILE",
+        help="unpickle experiment from here on startup",
+    )
+    parser.add_option(
+        "--save",
+        default="experiment.pkl",
+        dest="save",
+        metavar="FILE",
+        help="pickle experiment to here on exit",
+    )
+    parser.add_option(
+        "--steps",
+        dest="steps",
+        default="100",
+        metavar="N",
+        help="exit after queuing this many jobs (default: 100)",
+    )
+    parser.add_option(
+        "--workdir",
+        dest="workdir",
+        default=os.path.expanduser("~/.hyperopt.workdir"),
+        help="create workdirs here",
+        metavar="DIR",
+    )
+    parser.add_option(
+        "--bandit-argfile",
+        dest="bandit_argfile",
+        default=None,
+        help="path to file containing arguments bandit constructor \
                   file format: pickle of dictionary containing two keys,\
                   {'args' : tuple of positional arguments, \
-                   'kwargs' : dictionary of keyword arguments}")
-    parser.add_option("--bandit-algo-argfile",
-                      dest="bandit_algo_argfile",
-                      default=None,
-                      help="path to file containing arguments for bandit_algo "
-                      "constructor.  File format is pickled dictionary containing "
-                      "two keys: 'args', a tuple of positional arguments, and "
-                      "'kwargs', a dictionary of keyword arguments. "
-                      "NOTE: bandit is pre-pended as first element of arg tuple.")
+                   'kwargs' : dictionary of keyword arguments}",
+    )
+    parser.add_option(
+        "--bandit-algo-argfile",
+        dest="bandit_algo_argfile",
+        default=None,
+        help="path to file containing arguments for bandit_algo "
+        "constructor.  File format is pickled dictionary containing "
+        "two keys: 'args', a tuple of positional arguments, and "
+        "'kwargs', a dictionary of keyword arguments. "
+        "NOTE: bandit is pre-pended as first element of arg tuple.",
+    )
 
     (options, args) = parser.parse_args()
     try:
@@ -76,21 +90,21 @@ def main_search():
     try:
         if not options.load:
             raise IOError()
-        handle = open(options.load, 'rb')
+        handle = open(options.load, "rb")
         self = pickler.load(handle)
         handle.close()
     except IOError:
         bandit = utils.get_obj(bandit_json, argfile=options.bandit_argfile)
-        bandit_algo = utils.get_obj(bandit_algo_json,
-                                    argfile=options.bandit_algo_argfile,
-                                    args=(bandit,))
+        bandit_algo = utils.get_obj(
+            bandit_algo_json, argfile=options.bandit_algo_argfile, args=(bandit,)
+        )
         self = SerialExperiment(bandit_algo)
 
     try:
         self.run(int(options.steps))
     finally:
         if options.save:
-            pickler.dump(self, open(options.save, 'wb'))
+            pickler.dump(self, open(options.save, "wb"))
 
 
 def main(cmd, fn_pos=1):
@@ -98,14 +112,10 @@ def main(cmd, fn_pos=1):
     Entry point for bin/* scripts
     XXX
     """
-    logging.basicConfig(
-        stream=sys.stderr,
-        level=logging.INFO)
+    logging.basicConfig(stream=sys.stderr, level=logging.INFO)
     try:
         runner = dict(
-            search='main_search',
-            dryrun='main_dryrun',
-            plot_history='main_plot_history',
+            search="main_search", dryrun="main_dryrun", plot_history="main_plot_history"
         )[cmd]
     except KeyError:
         logger.error("Command not recognized: %s" % cmd)
@@ -115,13 +125,14 @@ def main(cmd, fn_pos=1):
         # TODO: argv1 never used
         argv1 = sys.argv[fn_pos]
     except IndexError:
-        logger.error('Module name required (XXX: print Usage)')
+        logger.error("Module name required (XXX: print Usage)")
         return 1
 
     # TODO: datasets is not imported at this point
-    fn = datasets.main.load_tokens(sys.argv[fn_pos].split('.') + [runner])
-    sys.exit(fn(sys.argv[fn_pos + 1:]))
+    fn = datasets.main.load_tokens(sys.argv[fn_pos].split(".") + [runner])
+    sys.exit(fn(sys.argv[fn_pos + 1 :]))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     cmd = sys.argv[1]
     sys.exit(main(cmd, 2))

--- a/hyperopt/mix.py
+++ b/hyperopt/mix.py
@@ -30,7 +30,6 @@ def suggest(new_ids, domain, trials, seed, p_suggest):
     ps, suggests = list(zip(*p_suggest))
     assert len(ps) == len(suggests) == len(p_suggest)
     if not np.isclose(sum(ps), 1.0):
-        raise ValueError('Probabilities should sum to 1', ps)
+        raise ValueError("Probabilities should sum to 1", ps)
     idx = rng.multinomial(n=1, pvals=ps).argmax()
-    return suggests[idx](new_ids, domain, trials,
-                         seed=int(rng.randint(2 ** 31)))
+    return suggests[idx](new_ids, domain, trials, seed=int(rng.randint(2 ** 31)))

--- a/hyperopt/plotting.py
+++ b/hyperopt/plotting.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 import pickle
 
 from past.builtins import xrange
+
 try:
     unicode = unicode
 except NameError:
@@ -28,10 +29,11 @@ __license__ = "3-clause BSD License"
 __contact__ = "github.com/hyperopt/hyperopt"
 
 default_status_colors = {
-    base.STATUS_NEW: 'k',
-    base.STATUS_RUNNING: 'g',
-    base.STATUS_OK: 'b',
-    base.STATUS_FAIL: 'r'}
+    base.STATUS_NEW: "k",
+    base.STATUS_RUNNING: "g",
+    base.STATUS_OK: "b",
+    base.STATUS_FAIL: "r",
+}
 
 
 def main_plot_history(trials, do_show=True, status_colors=None, title="Loss History"):
@@ -43,16 +45,20 @@ def main_plot_history(trials, do_show=True, status_colors=None, title="Loss Hist
         status_colors = default_status_colors
 
     # XXX: show the un-finished or error trials
-    Ys, colors = zip(*[(y, status_colors[s])
-                       for y, s in zip(trials.losses(), trials.statuses())
-                       if y is not None])
+    Ys, colors = zip(
+        *[
+            (y, status_colors[s])
+            for y, s in zip(trials.losses(), trials.statuses())
+            if y is not None
+        ]
+    )
     plt.scatter(range(len(Ys)), Ys, c=colors)
-    plt.xlabel('time')
-    plt.ylabel('loss')
+    plt.xlabel("time")
+    plt.ylabel("loss")
 
     best_err = trials.average_best_error()
     print("avg best error:", best_err)
-    plt.axhline(best_err, c='g')
+    plt.axhline(best_err, c="g")
 
     plt.title(title)
     if do_show:
@@ -64,32 +70,39 @@ def main_plot_histogram(trials, do_show=True, title="Loss Histogram"):
     import matplotlib.pyplot as plt
 
     status_colors = default_status_colors
-    Xs, Ys, Ss, Cs = zip(*[(x, y, s, status_colors[s])
-                           for (x, y, s) in zip(trials.specs, trials.losses(),
-                                                trials.statuses())
-                           if y is not None])
+    Xs, Ys, Ss, Cs = zip(
+        *[
+            (x, y, s, status_colors[s])
+            for (x, y, s) in zip(trials.specs, trials.losses(), trials.statuses())
+            if y is not None
+        ]
+    )
 
     # XXX: deal with ok vs. un-finished vs. error trials
-    print('Showing Histogram of %i jobs' % len(Ys))
+    print("Showing Histogram of %i jobs" % len(Ys))
     plt.hist(Ys)
-    plt.xlabel('loss')
-    plt.ylabel('frequency')
+    plt.xlabel("loss")
+    plt.ylabel("frequency")
 
     plt.title(title)
     if do_show:
         plt.show()
 
 
-def main_plot_vars(trials, do_show=True, fontsize=10,
-                   colorize_best=None,
-                   columns=5, arrange_by_loss=False
-                   ):
+def main_plot_vars(
+    trials,
+    do_show=True,
+    fontsize=10,
+    colorize_best=None,
+    columns=5,
+    arrange_by_loss=False,
+):
     # -- import here because file-level import is too early
     import matplotlib.pyplot as plt
 
     idxs, vals = miscs_to_idxs_vals(trials.miscs)
     losses = trials.losses()
-    finite_losses = [y for y in losses if y not in (None, float('inf'))]
+    finite_losses = [y for y in losses if y not in (None, float("inf"))]
     asrt = np.argsort(finite_losses)
     if colorize_best is not None:
         colorize_thresh = finite_losses[asrt[colorize_best + 1]]
@@ -99,7 +112,7 @@ def main_plot_vars(trials, do_show=True, fontsize=10,
 
     loss_min = min(finite_losses)
     loss_max = max(finite_losses)
-    print('finite loss range', loss_min, loss_max, colorize_thresh)
+    print("finite loss range", loss_min, loss_max, colorize_thresh)
 
     loss_by_tid = dict(zip(trials.tids, losses))
 
@@ -107,7 +120,7 @@ def main_plot_vars(trials, do_show=True, fontsize=10,
         if lossval is None:
             return 1, 1, 1
         else:
-            t = 4 * (lossval - loss_min) / (loss_max - loss_min + .0001)
+            t = 4 * (lossval - loss_min) / (loss_max - loss_min + 0.0001)
             if t < 1:
                 return t, 0, 0
             if t < 2:
@@ -117,12 +130,12 @@ def main_plot_vars(trials, do_show=True, fontsize=10,
             return 0, 0, 4 - t
 
     def color_fn_bw(lossval):
-        if lossval in (None, float('inf')):
+        if lossval in (None, float("inf")):
             return 1, 1, 1
         else:
-            t = (lossval - loss_min) / (loss_max - loss_min + .0001)
+            t = (lossval - loss_min) / (loss_max - loss_min + 0.0001)
             if lossval < colorize_thresh:
-                return 0., 1. - t, 0.  # -- red best black worst
+                return 0.0, 1.0 - t, 0.0  # -- red best black worst
             else:
                 return t, t, t  # -- white=worst, black=best
 
@@ -139,7 +152,7 @@ def main_plot_vars(trials, do_show=True, fontsize=10,
 
         # hide x ticks
         ticks_num, ticks_txt = plt.xticks()
-        plt.xticks(ticks_num, [''] * len(ticks_num))
+        plt.xticks(ticks_num, [""] * len(ticks_num))
 
         dist_name = label
 
@@ -147,7 +160,7 @@ def main_plot_vars(trials, do_show=True, fontsize=10,
             x = [loss_by_tid[ii] for ii in idxs[label]]
         else:
             x = idxs[label]
-        if 'log' in dist_name:
+        if "log" in dist_name:
             y = np.log(vals[label])
         else:
             y = vals[label]
@@ -155,16 +168,24 @@ def main_plot_vars(trials, do_show=True, fontsize=10,
         c = list(map(color_fn_bw, [loss_by_tid[ii] for ii in idxs[label]]))
         if len(y):
             plt.scatter(x, y, c=c)
-        if 'log' in dist_name:
+        if "log" in dist_name:
             nums, texts = plt.yticks()
-            plt.yticks(nums, ['%.2e' % np.exp(t) for t in nums])
+            plt.yticks(nums, ["%.2e" % np.exp(t) for t in nums])
 
     if do_show:
         plt.show()
 
 
-def main_plot_1D_attachment(trials, attachment_name, do_show=True, colorize_by_loss = True, max_darkness = 0.5,
-                            num_trails=None, preprocessing_fn=lambda x: x, line_width = 0.1):
+def main_plot_1D_attachment(
+    trials,
+    attachment_name,
+    do_show=True,
+    colorize_by_loss=True,
+    max_darkness=0.5,
+    num_trails=None,
+    preprocessing_fn=lambda x: x,
+    line_width=0.1,
+):
     """
     Plots trail attachments, which are 1D-Data.
 
@@ -185,7 +206,6 @@ def main_plot_1D_attachment(trials, attachment_name, do_show=True, colorize_by_l
     # -- import here because file-level import is too early
     import matplotlib.pyplot as plt
 
-
     plt.title(attachment_name)
 
     min_loss = min(l for l in trials.losses() if l is not None)
@@ -194,24 +214,44 @@ def main_plot_1D_attachment(trials, attachment_name, do_show=True, colorize_by_l
     if num_trails is None:
         plotted_trials = trials
     else:
-        trials_by_loss = sorted(filter(lambda t: 'loss' in t['result'], trials), key=lambda t: t['result']['loss'])
-        plotted_trials = [trials_by_loss[i] for i in np.linspace(0, len(trials_by_loss), num_trails, endpoint=False, dtype=np.int)]
-
+        trials_by_loss = sorted(
+            filter(lambda t: "loss" in t["result"], trials),
+            key=lambda t: t["result"]["loss"],
+        )
+        plotted_trials = [
+            trials_by_loss[i]
+            for i in np.linspace(
+                0, len(trials_by_loss), num_trails, endpoint=False, dtype=np.int
+            )
+        ]
 
     for trial in plotted_trials:
         t_attachments = trials.trial_attachments(trial)
         if attachment_name in t_attachments:
-            attachment_data = np.squeeze(np.asanyarray(pickle.loads(t_attachments[attachment_name])))
+            attachment_data = np.squeeze(
+                np.asanyarray(pickle.loads(t_attachments[attachment_name]))
+            )
             if len(attachment_data.shape) == 1:
                 attachment_data = preprocessing_fn(attachment_data)
                 if colorize_by_loss:
-                    color = (0., 0., 0., max_darkness*(trial['result']['loss'] - min_loss)/(max_loss-min_loss))
+                    color = (
+                        0.0,
+                        0.0,
+                        0.0,
+                        max_darkness
+                        * (trial["result"]["loss"] - min_loss)
+                        / (max_loss - min_loss),
+                    )
                 else:
                     color = None
-                plt.plot(attachment_data, color=color, linewidth=line_width,
-                         label="loss: {:.5}".format(trial['result']['loss']))
+                plt.plot(
+                    attachment_data,
+                    color=color,
+                    linewidth=line_width,
+                    label="loss: {:.5}".format(trial["result"]["loss"]),
+                )
             else:
-                pass #TODO: warn about the skipping
+                pass  # TODO: warn about the skipping
 
     if do_show:
         if len(plotted_trials) < 10:

--- a/hyperopt/pyll/base.py
+++ b/hyperopt/pyll/base.py
@@ -24,7 +24,7 @@ from six.moves import range
 
 standard_library.install_aliases()
 logger = logging.getLogger(__name__)
-np_versions = list(map(int, np.__version__.split('.')[:2]))
+np_versions = list(map(int, np.__version__.split(".")[:2]))
 
 DEFAULT_MAX_PROGRAM_LEN = 100000
 
@@ -51,76 +51,73 @@ class SymbolTable(object):
     def __init__(self):
         # -- list and dict are special because they are Python builtins
         self._impls = {
-            'list': list,
-            'dict': dict,
-            'range': range,
-            'len': len,
-            'int': int,
-            'float': float,
-            'map': map,
-            'max': max,
-            'min': min,
-            'getattr': getattr,
+            "list": list,
+            "dict": dict,
+            "range": range,
+            "len": len,
+            "int": int,
+            "float": float,
+            "map": map,
+            "max": max,
+            "min": min,
+            "getattr": getattr,
         }
 
     def _new_apply(self, name, args, kwargs, o_len, pure):
         pos_args = [as_apply(a) for a in args]
         named_args = [(k, as_apply(v)) for (k, v) in list(kwargs.items())]
         named_args.sort()
-        return Apply(name,
-                     pos_args=pos_args,
-                     named_args=named_args,
-                     o_len=o_len,
-                     pure=pure)
+        return Apply(
+            name, pos_args=pos_args, named_args=named_args, o_len=o_len, pure=pure
+        )
 
     def dict(self, *args, **kwargs):
         # XXX: figure out len
-        return self._new_apply('dict', args, kwargs, o_len=None,
-                               pure=True)
+        return self._new_apply("dict", args, kwargs, o_len=None, pure=True)
 
     def int(self, arg):
-        return self._new_apply('int', [as_apply(arg)], {}, o_len=None,
-                               pure=True)
+        return self._new_apply("int", [as_apply(arg)], {}, o_len=None, pure=True)
 
     def float(self, arg):
-        return self._new_apply('float', [as_apply(arg)], {}, o_len=None,
-                               pure=True)
+        return self._new_apply("float", [as_apply(arg)], {}, o_len=None, pure=True)
 
     def len(self, obj):
-        return self._new_apply('len', [obj], {}, o_len=None,
-                               pure=True)
+        return self._new_apply("len", [obj], {}, o_len=None, pure=True)
 
     def list(self, init):
-        return self._new_apply('list', [as_apply(init)], {}, o_len=None,
-                               pure=True)
+        return self._new_apply("list", [as_apply(init)], {}, o_len=None, pure=True)
 
     def map(self, fn, seq, pure=False):
         """
         pure - True is assertion that fn does not modify seq[i]
         """
-        return self._new_apply('map', [as_apply(fn), as_apply(seq)], {},
-                               o_len=seq.o_len, pure=pure)
+        return self._new_apply(
+            "map", [as_apply(fn), as_apply(seq)], {}, o_len=seq.o_len, pure=pure
+        )
 
     def range(self, *args):
-        return self._new_apply('range', args, {}, o_len=None, pure=True)
+        return self._new_apply("range", args, {}, o_len=None, pure=True)
 
     def max(self, *args):
         """ return max of args """
-        return self._new_apply('max', list(map(as_apply, args)), {},
-                               o_len=None, pure=True)
+        return self._new_apply(
+            "max", list(map(as_apply, args)), {}, o_len=None, pure=True
+        )
 
     def min(self, *args):
         """ return min of args """
-        return self._new_apply('min', list(map(as_apply, args)), {},
-                               o_len=None, pure=True)
+        return self._new_apply(
+            "min", list(map(as_apply, args)), {}, o_len=None, pure=True
+        )
 
     def getattr(self, obj, attr, *args):
         return self._new_apply(
-            'getattr',
+            "getattr",
             [as_apply(obj), as_apply(attr)] + list(map(as_apply, args)),
             {},
             o_len=None,
-            pure=True)
+            pure=True,
+        )
 
     def _define(self, f, o_len, pure):
         name = f.__name__
@@ -134,7 +131,7 @@ class SymbolTable(object):
         """
         name = f.__name__
         if hasattr(self, name):
-            raise ValueError('Cannot override existing symbol', name)
+            raise ValueError("Cannot override existing symbol", name)
         return self._define(f, o_len, pure)
 
     def define_if_new(self, f, o_len=None, pure=False):
@@ -142,7 +139,7 @@ class SymbolTable(object):
         for f.__name__"""
         name = f.__name__
         if hasattr(self, name) and self._impls[name] is not f:
-            raise ValueError('Cannot redefine existing symbol', name)
+            raise ValueError("Cannot redefine existing symbol", name)
         return self._define(f, o_len, pure)
 
     def undefine(self, f):
@@ -159,6 +156,7 @@ class SymbolTable(object):
     def define_info(self, o_len=None, pure=False):
         def wrapper(f):
             return self.define(f, o_len=o_len, pure=pure)
+
         return wrapper
 
     def inject(self, *args, **kwargs):
@@ -187,6 +185,7 @@ class SymbolTable(object):
 class SymbolTableEntry(object):
     """A functools.partial-like class for adding symbol table entries.
     """
+
     def __init__(self, symbol_table, apply_name, o_len, pure):
         self.symbol_table = symbol_table
         self.apply_name = apply_name
@@ -195,11 +194,9 @@ class SymbolTableEntry(object):
 
     def __call__(self, *args, **kwargs):
         return self.symbol_table._new_apply(
-            self.apply_name,
-            args,
-            kwargs,
-            self.o_len,
-            self.pure)
+            self.apply_name, args, kwargs, self.o_len, self.pure
+        )
+
 
 scope = SymbolTable()
 
@@ -210,9 +207,9 @@ def as_apply(obj):
     if isinstance(obj, Apply):
         rval = obj
     elif isinstance(obj, tuple):
-        rval = Apply('pos_args', [as_apply(a) for a in obj], {}, len(obj))
+        rval = Apply("pos_args", [as_apply(a) for a in obj], {}, len(obj))
     elif isinstance(obj, list):
-        rval = Apply('pos_args', [as_apply(a) for a in obj], {}, None)
+        rval = Apply("pos_args", [as_apply(a) for a in obj], {}, None)
     elif isinstance(obj, dict):
         items = list(obj.items())
         # -- should be fine to allow numbers and simple things
@@ -221,10 +218,10 @@ def as_apply(obj):
         items.sort()
         if all(isinstance(k, six.string_types) for k in obj):
             named_args = [(k, as_apply(v)) for (k, v) in items]
-            rval = Apply('dict', [], named_args, len(named_args))
+            rval = Apply("dict", [], named_args, len(named_args))
         else:
             new_items = [(k, as_apply(v)) for (k, v) in items]
-            rval = Apply('dict', [as_apply(new_items)], {}, o_len=None)
+            rval = Apply("dict", [as_apply(new_items)], {}, o_len=None)
     else:
         rval = Literal(obj)
     assert isinstance(rval, Apply)
@@ -240,8 +237,9 @@ class Apply(object):
     pure - True only if the function has no relevant side-effects
     """
 
-    def __init__(self, name, pos_args, named_args,
-                 o_len=None, pure=False, define_params=None):
+    def __init__(
+        self, name, pos_args, named_args, o_len=None, pure=False, define_params=None
+    ):
         self.name = name
         # -- tuples or arrays -> lists
         self.pos_args = list(pos_args)
@@ -329,29 +327,29 @@ class Apply(object):
         try:
             if extra_args_ok and extra_kwargs_ok:
                 assert len(code.co_varnames) >= code.co_argcount + 2
-                param_names = code.co_varnames[:code.co_argcount + 2]
+                param_names = code.co_varnames[: code.co_argcount + 2]
                 args_param = param_names[code.co_argcount]
                 kwargs_param = param_names[code.co_argcount + 1]
-                pos_params = param_names[:code.co_argcount]
+                pos_params = param_names[: code.co_argcount]
             elif extra_kwargs_ok:
                 assert len(code.co_varnames) >= code.co_argcount + 1
-                param_names = code.co_varnames[:code.co_argcount + 1]
+                param_names = code.co_varnames[: code.co_argcount + 1]
                 kwargs_param = param_names[code.co_argcount]
-                pos_params = param_names[:code.co_argcount]
+                pos_params = param_names[: code.co_argcount]
             elif extra_args_ok:
                 assert len(code.co_varnames) >= code.co_argcount + 1
-                param_names = code.co_varnames[:code.co_argcount + 1]
+                param_names = code.co_varnames[: code.co_argcount + 1]
                 args_param = param_names[code.co_argcount]
-                pos_params = param_names[:code.co_argcount]
+                pos_params = param_names[: code.co_argcount]
             else:
                 assert len(code.co_varnames) >= code.co_argcount
-                param_names = code.co_varnames[:code.co_argcount]
-                pos_params = param_names[:code.co_argcount]
+                param_names = code.co_varnames[: code.co_argcount]
+                pos_params = param_names[: code.co_argcount]
         except AssertionError:
-            print('YIKES: MISUNDERSTANDING OF CALL PROTOCOL:')
+            print("YIKES: MISUNDERSTANDING OF CALL PROTOCOL:")
             print(code.co_argcount)
             print(code.co_varnames)
-            print('%x' % code.co_flags)
+            print("%x" % code.co_flags)
             raise
 
         if extra_args_ok:
@@ -361,7 +359,7 @@ class Apply(object):
             binding[kwargs_param] == {}
 
         if len(self.pos_args) > code.co_argcount and not extra_args_ok:
-            raise TypeError('Argument count exceeds number of positional params')
+            raise TypeError("Argument count exceeds number of positional params")
 
         # -- bind positional arguments
         for param_i, arg_i in zip(param_names, self.pos_args):
@@ -370,7 +368,7 @@ class Apply(object):
         if extra_args_ok:
             # XXX: THIS IS NOT BEING TESTED AND IS OBVIOUSLY BROKEN
             # TODO: 'args' does not even exist at this point
-            binding[args_param].extend(args[code.co_argcount:])
+            binding[args_param].extend(args[code.co_argcount :])
 
         # -- bind keyword arguments
         for aname, aval in self.named_args:
@@ -381,10 +379,10 @@ class Apply(object):
                     binding[kwargs_param][aname] = aval
                     continue
                 else:
-                    raise TypeError('Unrecognized keyword argument', aname)
+                    raise TypeError("Unrecognized keyword argument", aname)
             param = param_names[pos]
             if param in binding:
-                raise TypeError('Duplicate argument for parameter', param)
+                raise TypeError("Duplicate argument for parameter", param)
             binding[param] = aval
 
         assert len(binding) <= len(param_names)
@@ -403,20 +401,21 @@ class Apply(object):
                 return
         arg = self.arg
         if name in arg and arg[name] != MissingArgument:
-            raise NotImplementedError('change pos arg to kw arg')
+            raise NotImplementedError("change pos arg to kw arg")
         else:
             self.named_args.append([name, as_apply(value)])
             self.named_args.sort()
 
-    def clone_from_inputs(self, inputs, o_len='same'):
+    def clone_from_inputs(self, inputs, o_len="same"):
         if len(inputs) != len(self.inputs()):
             raise TypeError()
         L = len(self.pos_args)
         pos_args = list(inputs[:L])
-        named_args = [[kw, inputs[L + ii]]
-                      for ii, (kw, arg) in enumerate(self.named_args)]
+        named_args = [
+            [kw, inputs[L + ii]] for ii, (kw, arg) in enumerate(self.named_args)
+        ]
         # -- danger cloning with new inputs can change the o_len
-        if o_len == 'same':
+        if o_len == "same":
             o_len = self.o_len
         return self.__class__(self.name, pos_args, named_args, o_len)
 
@@ -439,16 +438,16 @@ class Apply(object):
             lineno = [0]
 
         if self in memo:
-            print(lineno[0], ' ' * indent + memo[self], file=ofile)
+            print(lineno[0], " " * indent + memo[self], file=ofile)
             lineno[0] += 1
         else:
-            memo[self] = self.name + ('  [line:%i]' % lineno[0])
-            print(lineno[0], ' ' * indent + self.name, file=ofile)
+            memo[self] = self.name + ("  [line:%i]" % lineno[0])
+            print(lineno[0], " " * indent + self.name, file=ofile)
             lineno[0] += 1
             for arg in self.pos_args:
                 arg.pprint(ofile, lineno, indent + 2, memo)
             for name, arg in self.named_args:
-                print(lineno[0], ' ' * indent + ' ' + name + ' =', file=ofile)
+                print(lineno[0], " " * indent + " " + name + " =", file=ofile)
                 lineno[0] += 1
                 arg.pprint(ofile, lineno, indent + 2, memo)
 
@@ -524,7 +523,7 @@ class Apply(object):
 
     def __len__(self):
         if self.o_len is None:
-            raise TypeError('len of pyll.Apply either undefined or unknown')
+            raise TypeError("len of pyll.Apply either undefined or unknown")
         return self.o_len
 
     def __call__(self, *args, **kwargs):
@@ -535,10 +534,7 @@ def apply(name, *args, **kwargs):
     pos_args = [as_apply(a) for a in args]
     named_args = [(k, as_apply(v)) for (k, v) in list(kwargs.items())]
     named_args.sort()
-    return Apply(name,
-                 pos_args=pos_args,
-                 named_args=named_args,
-                 o_len=None)
+    return Apply(name, pos_args=pos_args, named_args=named_args, o_len=None)
 
 
 class Literal(Apply):
@@ -547,7 +543,7 @@ class Literal(Apply):
             o_len = len(obj)
         except TypeError:
             o_len = None
-        Apply.__init__(self, 'literal', [], {}, o_len, pure=True)
+        Apply.__init__(self, "literal", [], {}, o_len, pure=True)
         self._obj = obj
 
     def eval(self, memo=None):
@@ -569,22 +565,25 @@ class Literal(Apply):
         if memo is None:
             memo = {}
         if self in memo:
-            print(lineno[0], ' ' * indent + memo[self], file=ofile)
+            print(lineno[0], " " * indent + memo[self], file=ofile)
         else:
             # TODO: set up a registry for this
             if isinstance(self._obj, np.ndarray):
-                msg = 'Literal{np.ndarray,shape=%s,min=%f,max=%f}' % (
-                      self._obj.shape, self._obj.min(), self._obj.max())
+                msg = "Literal{np.ndarray,shape=%s,min=%f,max=%f}" % (
+                    self._obj.shape,
+                    self._obj.min(),
+                    self._obj.max(),
+                )
             else:
-                msg = 'Literal{%s}' % str(self._obj)
-            memo[self] = '%s  [line:%i]' % (msg, lineno[0])
-            print(lineno[0], ' ' * indent + msg, file=ofile)
+                msg = "Literal{%s}" % str(self._obj)
+            memo[self] = "%s  [line:%i]" % (msg, lineno[0])
+            print(lineno[0], " " * indent + msg, file=ofile)
         lineno[0] += 1
 
     def replace_input(self, old_node, new_node):
         return []
 
-    def clone_from_inputs(self, inputs, o_len='same'):
+    def clone_from_inputs(self, inputs, o_len="same"):
         return self.__class__(self._obj)
 
 
@@ -597,19 +596,18 @@ class Lambda(object):
     def __init__(self, name, params, expr):
         self.__name__ = name  # like a python function
         self.params = params  # list of (name, symbol[, default_value]) tuples
-        self.expr = expr      # pyll graph defining this Lambda
+        self.expr = expr  # pyll graph defining this Lambda
 
     def __call__(self, *args, **kwargs):
         # -- return `expr` cloned from given args and kwargs
         if len(args) > len(self.params):
-            raise TypeError('too many arguments')
+            raise TypeError("too many arguments")
         memo = {}
         for arg, param in zip(args, self.params):
             # print('applying with arg', param, arg)
             memo[param[1]] = as_apply(arg)
         if len(args) != len(self.params) or kwargs:
-            raise NotImplementedError('named / default arguments',
-                                      (args, self.params))
+            raise NotImplementedError("named / default arguments", (args, self.params))
         rval = clone(self.expr, memo)
         return rval
 
@@ -670,9 +668,8 @@ def partial(name, *args, **kwargs):
     my_id = len(scope._impls)
     # -- create a function with this name
     #    the name is the string used index into scope._impls
-    temp_name = 'partial_%s_id%i' % (name, my_id)
-    l = Lambda(temp_name, [('x', p0)],
-               expr=apply(name, *(args + (p0,)), **kwargs))
+    temp_name = "partial_%s_id%i" % (name, my_id)
+    l = Lambda(temp_name, [("x", p0)], expr=apply(name, *(args + (p0,)), **kwargs))
     scope.define(l)
     # assert that the next partial will get a different id
     # XXX; THIS ASSUMES THAT SCOPE ONLY GROWS
@@ -748,7 +745,7 @@ def clone_merge(expr, memo=None, merge_literals=False):
                 node_jj = nodes[jj]
                 if node_ii.name != node_jj.name:
                     continue
-                if node_ii.name == 'literal':
+                if node_ii.name == "literal":
                     if not merge_literals:
                         continue
                     if node_ii._obj != node_jj._obj:
@@ -756,8 +753,7 @@ def clone_merge(expr, memo=None, merge_literals=False):
                 else:
                     if node_args[ii] != node_args[jj]:
                         continue
-                logger.debug('clone_merge %s %i <- %i' % (
-                    node_ii.name, jj, ii))
+                logger.debug("clone_merge %s %i <- %i" % (node_ii.name, jj, ii))
                 new_ii = node_jj
                 break
         if new_ii is None:
@@ -773,15 +769,18 @@ def clone_merge(expr, memo=None, merge_literals=False):
 
 
 class GarbageCollected(object):
-    '''Placeholder representing a garbage-collected value '''
+    """Placeholder representing a garbage-collected value """
 
 
-def rec_eval(expr, deepcopy_inputs=False, memo=None,
-             max_program_len=None,
-             memo_gc=True,
-             print_trace=False,
-             print_node_on_error=True,
-             ):
+def rec_eval(
+    expr,
+    deepcopy_inputs=False,
+    memo=None,
+    max_program_len=None,
+    memo_gc=True,
+    print_trace=False,
+    print_node_on_error=True,
+):
     """
     expr - pyll Apply instance to be evaluated
 
@@ -803,7 +802,7 @@ def rec_eval(expr, deepcopy_inputs=False, memo=None,
     if deepcopy_inputs not in (0, 1, False, True):
         # -- I've been calling rec_eval(expr, memo) by accident a few times
         #    this error would have been appreciated.
-        raise ValueError('deepcopy_inputs should be bool', deepcopy_inputs)
+        raise ValueError("deepcopy_inputs should be bool", deepcopy_inputs)
 
     node = as_apply(expr)
     topnode = node
@@ -842,24 +841,26 @@ def rec_eval(expr, deepcopy_inputs=False, memo=None,
                 #    with a dummy symbol
                 if all(iic in memo for iic in clients[ii]):
                     memo[ii] = GarbageCollected
+
     else:
+
         def set_memo(k, v):
             memo[k] = v
 
     todo = deque([topnode])
     while todo:
         if len(todo) > max_program_len:
-            raise RuntimeError('Probably infinite loop in document')
+            raise RuntimeError("Probably infinite loop in document")
         node = todo.pop()
         if print_trace:
-            print('rec_eval:print_trace', len(todo), node.name)
+            print("rec_eval:print_trace", len(todo), node.name)
 
         if node in memo:
             # -- we've already computed this, move on.
             continue
 
         # -- different kinds of nodes are treated differently:
-        if node.name == 'switch':
+        if node.name == "switch":
             # -- switch is the conditional evaluation node
             switch_i_var = node.pos_args[0]
             if switch_i_var in memo:
@@ -867,10 +868,9 @@ def rec_eval(expr, deepcopy_inputs=False, memo=None,
                 try:
                     int(switch_i)
                 except:
-                    raise TypeError('switch argument was', switch_i)
+                    raise TypeError("switch argument was", switch_i)
                 if switch_i != int(switch_i) or switch_i < 0:
-                    raise ValueError('switch pos must be positive int',
-                                     switch_i)
+                    raise ValueError("switch pos must be positive int", switch_i)
                 rval_var = node.pos_args[int(switch_i) + 1]
                 if rval_var in memo:
                     set_memo(node, memo[rval_var])
@@ -897,9 +897,7 @@ def rec_eval(expr, deepcopy_inputs=False, memo=None,
             # -- not waiting on anything;
             #    this instruction can be evaluated.
             args = _args = [memo[v] for v in node.pos_args]
-            kwargs = _kwargs = dict(
-                [(k, memo[v]) for (k, v) in node.named_args]
-            )
+            kwargs = _kwargs = dict([(k, memo[v]) for (k, v) in node.named_args])
 
             if memo_gc:
                 for aa in args + list(kwargs.values()):
@@ -914,12 +912,12 @@ def rec_eval(expr, deepcopy_inputs=False, memo=None,
 
             except Exception as e:
                 if print_node_on_error:
-                    print('=' * 80)
-                    print('ERROR in rec_eval')
-                    print('EXCEPTION', type(e), str(e))
-                    print('NODE')
+                    print("=" * 80)
+                    print("ERROR in rec_eval")
+                    print("EXCEPTION", type(e), str(e))
+                    print("NODE")
                     print(node)  # -- typically a multi-line string
-                    print('=' * 80)
+                    print("=" * 80)
                 raise
 
             if isinstance(rval, Apply):
@@ -928,8 +926,7 @@ def rec_eval(expr, deepcopy_inputs=False, memo=None,
                 #
                 # XXX: consider if it is desirable, efficient, buggy
                 #      etc. to keep using the same memo dictionary
-                foo = rec_eval(rval, deepcopy_inputs, memo,
-                               memo_gc=memo_gc)
+                foo = rec_eval(rval, deepcopy_inputs, memo, memo_gc=memo_gc)
                 set_memo(node, foo)
             else:
                 set_memo(node, rval)
@@ -939,6 +936,7 @@ def rec_eval(expr, deepcopy_inputs=False, memo=None,
 
 ############################################################################
 ############################################################################
+
 
 @scope.define_pure
 def pos_args(*args):
@@ -1060,7 +1058,7 @@ def _bincount_slow(x, weights=None, minlength=None):
         rlen = np.max(x) + 1
     else:
         rlen = max(np.max(x) + 1, minlength)
-    rval = np.zeros(rlen, dtype='int')
+    rval = np.zeros(rlen, dtype="int")
     for xi in np.asarray(x).flatten():
         rval[xi] += 1
     return rval
@@ -1077,7 +1075,7 @@ def bincount(x, weights=None, minlength=None):
         else:
             # -- currently numpy rejects this case,
             #    but it seems sensible enough to me.
-            return np.zeros(minlength, dtype='int')
+            return np.zeros(minlength, dtype="int")
 
 
 @scope.define_pure
@@ -1125,8 +1123,9 @@ def _kwswitch(kw, **kwargs):
     """conditional evaluation according to string value"""
     # Get the index of the string in kwargs to use switch
     keys, values = list(zip(*sorted(kwargs.items())))
-    match_idx = scope.call_method_pure(keys, 'index', kw)
+    match_idx = scope.call_method_pure(keys, "index", kw)
     return scope.switch(match_idx, *values)
+
 
 scope.kwswitch = _kwswitch
 
@@ -1144,5 +1143,6 @@ def curtime(obj):
 @scope.define
 def pdb_settrace(obj):
     import pdb
+
     pdb.set_trace()
     return obj

--- a/hyperopt/pyll/stochastic.py
+++ b/hyperopt/pyll/stochastic.py
@@ -32,6 +32,7 @@ def rng_from_seed(seed):
 
 # -- UNIFORM
 
+
 @implicit_stochastic
 @scope.define
 def uniform(low, high, rng=None, size=()):
@@ -60,6 +61,7 @@ def qloguniform(low, high, q, rng=None, size=()):
 
 
 # -- NORMAL
+
 
 @implicit_stochastic
 @scope.define
@@ -136,10 +138,11 @@ def categorical(p, upper=None, rng=None, size=()):
         return rval
     elif p.ndim == 2:
         n_draws_, n_choices = p.shape
-        n_draws, = size
+        (n_draws,) = size
         assert n_draws == n_draws_
-        rval = [np.where(rng.multinomial(pvals=p[ii], n=1))[0][0]
-                for ii in range(n_draws)]
+        rval = [
+            np.where(rng.multinomial(pvals=p[ii], n=1))[0][0] for ii in range(n_draws)
+        ]
         rval = np.asarray(rval)
         rval.shape = size
         return rval
@@ -149,12 +152,16 @@ def categorical(p, upper=None, rng=None, size=()):
 
 def choice(args):
     return scope.one_of(*args)
+
+
 scope.choice = choice
 
 
 def one_of(*args):
     ii = scope.randint(len(args))
     return scope.switch(ii, *args)
+
+
 scope.one_of = one_of
 
 
@@ -170,11 +177,11 @@ def recursive_set_rng_kwarg(expr, rng=None):
     for node in dfs(expr):
         if node.name in implicit_stochastic_symbols:
             for ii, (name, arg) in enumerate(list(node.named_args)):
-                if name == 'rng':
-                    node.named_args[ii] = ('rng', lrng)
+                if name == "rng":
+                    node.named_args[ii] = ("rng", lrng)
                     break
             else:
-                node.named_args.append(('rng', lrng))
+                node.named_args.append(("rng", lrng))
     return expr
 
 

--- a/hyperopt/pyll/tests/test_base.py
+++ b/hyperopt/pyll/tests/test_base.py
@@ -1,7 +1,15 @@
 from __future__ import division
 from hyperopt.pyll import base
 from hyperopt.pyll.base import (
-    Literal, as_apply, Apply, dfs, scope, rec_eval, p0, Lambda, clone_merge
+    Literal,
+    as_apply,
+    Apply,
+    dfs,
+    scope,
+    rec_eval,
+    p0,
+    Lambda,
+    clone_merge,
 )
 
 from nose import SkipTest
@@ -12,20 +20,20 @@ import numpy as np
 def test_literal_pprint():
     l = Literal(5)
     print(str(l))
-    assert str(l) == '0 Literal{5}'
+    assert str(l) == "0 Literal{5}"
 
 
 def test_literal_apply():
     l0 = Literal([1, 2, 3])
     print(str(l0))
-    assert str(l0) == '0 Literal{[1, 2, 3]}'
+    assert str(l0) == "0 Literal{[1, 2, 3]}"
 
 
 def test_literal_unpacking():
     l0 = Literal([1, 2, 3])
     a, b, c = l0
     print(a)
-    assert c.name == 'getitem'
+    assert c.name == "getitem"
     assert c.pos_args[0] is l0
     assert isinstance(c.pos_args[1], Literal)
     assert c.pos_args[1]._obj == 2
@@ -44,7 +52,7 @@ def test_as_apply_list_of_literals():
     l = [9, 3]
     al = as_apply(l)
     assert isinstance(al, Apply)
-    assert al.name == 'pos_args'
+    assert al.name == "pos_args"
     assert isinstance(al.pos_args[0], Literal)
     assert isinstance(al.pos_args[1], Literal)
     al.pos_args[0]._obj == 9
@@ -55,7 +63,7 @@ def test_as_apply_tuple_of_literals():
     l = (9, 3)
     al = as_apply(l)
     assert isinstance(al, Apply)
-    assert al.name == 'pos_args'
+    assert al.name == "pos_args"
     assert isinstance(al.pos_args[0], Literal)
     assert isinstance(al.pos_args[1], Literal)
     al.pos_args[0]._obj == 9
@@ -68,65 +76,65 @@ def test_as_apply_list_of_applies():
 
     al = as_apply(alist)
     assert isinstance(al, Apply)
-    assert al.name == 'pos_args'
+    assert al.name == "pos_args"
     # -- have to come back to this if Literal copies args
     assert al.pos_args == alist
 
 
 def test_as_apply_dict_of_literals():
-    d = {'a': 9, 'b': 10}
+    d = {"a": 9, "b": 10}
     ad = as_apply(d)
     assert isinstance(ad, Apply)
-    assert ad.name == 'dict'
+    assert ad.name == "dict"
     assert len(ad) == 2
-    assert ad.named_args[0][0] == 'a'
+    assert ad.named_args[0][0] == "a"
     assert ad.named_args[0][1]._obj == 9
-    assert ad.named_args[1][0] == 'b'
+    assert ad.named_args[1][0] == "b"
     assert ad.named_args[1][1]._obj == 10
 
 
 def test_as_apply_dict_of_applies():
-    d = {'a': as_apply(9), 'b': as_apply(10)}
+    d = {"a": as_apply(9), "b": as_apply(10)}
     ad = as_apply(d)
     assert isinstance(ad, Apply)
-    assert ad.name == 'dict'
+    assert ad.name == "dict"
     assert len(ad) == 2
-    assert ad.named_args[0][0] == 'a'
+    assert ad.named_args[0][0] == "a"
     assert ad.named_args[0][1]._obj == 9
-    assert ad.named_args[1][0] == 'b'
+    assert ad.named_args[1][0] == "b"
     assert ad.named_args[1][1]._obj == 10
 
 
 def test_as_apply_nested_dict():
-    d = {'a': 9, 'b': {'c': 11, 'd': 12}}
+    d = {"a": 9, "b": {"c": 11, "d": 12}}
     ad = as_apply(d)
     assert isinstance(ad, Apply)
-    assert ad.name == 'dict'
+    assert ad.name == "dict"
     assert len(ad) == 2
-    assert ad.named_args[0][0] == 'a'
+    assert ad.named_args[0][0] == "a"
     assert ad.named_args[0][1]._obj == 9
-    assert ad.named_args[1][0] == 'b'
-    assert ad.named_args[1][1].name == 'dict'
-    assert ad.named_args[1][1].named_args[0][0] == 'c'
+    assert ad.named_args[1][0] == "b"
+    assert ad.named_args[1][1].name == "dict"
+    assert ad.named_args[1][1].named_args[0][0] == "c"
     assert ad.named_args[1][1].named_args[0][1]._obj == 11
-    assert ad.named_args[1][1].named_args[1][0] == 'd'
+    assert ad.named_args[1][1].named_args[1][0] == "d"
     assert ad.named_args[1][1].named_args[1][1]._obj == 12
 
 
 def test_dfs():
-    dd = as_apply({'c': 11, 'd': 12})
+    dd = as_apply({"c": 11, "d": 12})
 
-    d = {'a': 9, 'b': dd, 'y': dd, 'z': dd + 1}
+    d = {"a": 9, "b": dd, "y": dd, "z": dd + 1}
     ad = as_apply(d)
     order = dfs(ad)
     print([str(o) for o in order])
     assert order[0]._obj == 9
     assert order[1]._obj == 11
     assert order[2]._obj == 12
-    assert order[3].named_args[0][0] == 'c'
+    assert order[3].named_args[0][0] == "c"
     assert order[4]._obj == 1
-    assert order[5].name == 'add'
-    assert order[6].named_args[0][0] == 'a'
+    assert order[5].name == "add"
+    assert order[6].named_args[0][0] == "a"
     assert len(order) == 7
 
 
@@ -138,7 +146,7 @@ def _test_foo():
 def test_o_len():
     obj = scope._test_foo()
     x, y = obj
-    assert x.name == 'getitem'
+    assert x.name == "getitem"
     assert x.pos_args[1]._obj == 0
     assert y.pos_args[1]._obj == 1
 
@@ -156,8 +164,8 @@ def test_eval_arithmetic():
     assert (a - b).eval() == -1
     assert (a - b * c).eval() == -10
 
-    assert (a // b).eval() == 0   # int div
-    assert (b // a).eval() == 1   # int div
+    assert (a // b).eval() == 0  # int div
+    assert (b // a).eval() == 1  # int div
     assert (c / a).eval() == 2
     assert (4 / a).eval() == 2
     assert (a / 4.0).eval() == 0.5
@@ -201,43 +209,48 @@ def test_bincount():
         test_f(base._bincount_slow)
         test_f(base.bincount)
     except TypeError as e:
-        if 'function takes at most 2 arguments' in str(e):
+        if "function takes at most 2 arguments" in str(e):
             raise SkipTest()
         raise
 
 
 def test_switch_and_Raise():
     i = Literal()
-    ab = scope.switch(i, 'a', 'b', scope.Raise(Exception))
-    assert rec_eval(ab, memo={i: 0}) == 'a'
-    assert rec_eval(ab, memo={i: 1}) == 'b'
+    ab = scope.switch(i, "a", "b", scope.Raise(Exception))
+    assert rec_eval(ab, memo={i: 0}) == "a"
+    assert rec_eval(ab, memo={i: 1}) == "b"
     assert_raises(Exception, rec_eval, ab, memo={i: 2})
 
 
 def test_kwswitch():
     i = Literal()
-    ab = scope.kwswitch(i, k1='a', k2='b', err=scope.Raise(Exception))
-    assert rec_eval(ab, memo={i: 'k1'}) == 'a'
-    assert rec_eval(ab, memo={i: 'k2'}) == 'b'
-    assert_raises(Exception, rec_eval, ab, memo={i: 'err'})
+    ab = scope.kwswitch(i, k1="a", k2="b", err=scope.Raise(Exception))
+    assert rec_eval(ab, memo={i: "k1"}) == "a"
+    assert rec_eval(ab, memo={i: "k2"}) == "b"
+    assert_raises(Exception, rec_eval, ab, memo={i: "err"})
 
 
 def test_recursion():
-    scope.define(Lambda('Fact', [('x', p0)],
-                 expr=scope.switch(p0 > 1, 1, p0 * base.apply('Fact', p0 - 1))))
+    scope.define(
+        Lambda(
+            "Fact",
+            [("x", p0)],
+            expr=scope.switch(p0 > 1, 1, p0 * base.apply("Fact", p0 - 1)),
+        )
+    )
     print(scope.Fact(3))
     assert rec_eval(scope.Fact(3)) == 6
 
 
 def test_partial():
-    add2 = scope.partial('add', 2)
+    add2 = scope.partial("add", 2)
     print(add2)
-    assert len(str(add2).split('\n')) == 3
+    assert len(str(add2).split("\n")) == 3
 
     # add2 evaluates to a scope method
     thing = rec_eval(add2)
     print(thing)
-    assert 'SymbolTableEntry' in str(thing)
+    assert "SymbolTableEntry" in str(thing)
 
     # add2() evaluates to a failure because it's only a partial application
     assert_raises(NotImplementedError, rec_eval, add2())
@@ -251,8 +264,8 @@ def test_partial():
 def test_callpipe():
 
     # -- set up some 1-variable functions
-    a2 = scope.partial('add', 2)
-    a3 = scope.partial('add', 3)
+    a2 = scope.partial("add", 2)
+    a3 = scope.partial("add", 3)
 
     def s9(a):
         return scope.sub(a, 9)

--- a/hyperopt/pyll/tests/test_stochastic.py
+++ b/hyperopt/pyll/tests/test_stochastic.py
@@ -26,16 +26,21 @@ def test_lnorm():
 
     inker_size = quantized_uniform(low=0, high=7.99, q=2) + 3
     # -- test that it runs
-    lnorm = as_apply({'kwargs': {'inker_shape': (inker_size, inker_size),
-                                 'outker_shape': (inker_size, inker_size),
-                                 'remove_mean': choice([0, 1]),
-                                 'stretch': uniform(low=0, high=10),
-                                 'threshold': uniform(
-        low=old_div(.1, np.sqrt(10.)),
-        high=10 * np.sqrt(10))
-    }})
+    lnorm = as_apply(
+        {
+            "kwargs": {
+                "inker_shape": (inker_size, inker_size),
+                "outker_shape": (inker_size, inker_size),
+                "remove_mean": choice([0, 1]),
+                "stretch": uniform(low=0, high=10),
+                "threshold": uniform(
+                    low=old_div(0.1, np.sqrt(10.0)), high=10 * np.sqrt(10)
+                ),
+            }
+        }
+    )
     print(lnorm)
-    print(('len', len(str(lnorm))))
+    print(("len", len(str(lnorm))))
     # not sure what to assert
     # ... this is too fagile
     # assert len(str(lnorm)) == 980
@@ -50,10 +55,7 @@ def test_sample_deterministic():
 
 def test_repeatable():
     u = scope.uniform(0, 1)
-    aa = as_apply(dict(
-        u=u,
-        n=scope.normal(5, 0.1),
-        l=[0, 1, scope.one_of(2, 3), u]))
+    aa = as_apply(dict(u=u, n=scope.normal(5, 0.1), l=[0, 1, scope.one_of(2, 3), u]))
     dd1 = sample(aa, np.random.RandomState(3))
     dd2 = sample(aa, np.random.RandomState(3))
     dd3 = sample(aa, np.random.RandomState(4))
@@ -63,14 +65,11 @@ def test_repeatable():
 
 def test_sample():
     u = scope.uniform(0, 1)
-    aa = as_apply(dict(
-        u=u,
-        n=scope.normal(5, 0.1),
-        l=[0, 1, scope.one_of(2, 3), u]))
+    aa = as_apply(dict(u=u, n=scope.normal(5, 0.1), l=[0, 1, scope.one_of(2, 3), u]))
     print(aa)
     dd = sample(aa, np.random.RandomState(3))
-    assert 0 < dd['u'] < 1
-    assert 4 < dd['n'] < 6
-    assert dd['u'] == dd['l'][3]
-    assert dd['l'][:2] == (0, 1)
-    assert dd['l'][2] in (2, 3)
+    assert 0 < dd["u"] < 1
+    assert 4 < dd["n"] < 6
+    assert dd["u"] == dd["l"][3]
+    assert dd["l"][:2] == (0, 1)
+    assert dd["l"][2] in (2, 3)

--- a/hyperopt/pyll_utils.py
+++ b/hyperopt/pyll_utils.py
@@ -15,17 +15,20 @@ def validate_label(f):
     @wraps(f)
     def wrapper(label, *args, **kwargs):
         is_real_string = isinstance(label, basestring)
-        is_literal_string = (isinstance(label, Literal) and
-                             isinstance(label.obj, basestring))
+        is_literal_string = isinstance(label, Literal) and isinstance(
+            label.obj, basestring
+        )
         if not is_real_string and not is_literal_string:
-            raise TypeError('require string label')
+            raise TypeError("require string label")
         return f(label, *args, **kwargs)
+
     return wrapper
 
 
 #
 # Hyperparameter Types
 #
+
 
 @scope.define
 def hyperopt_param(label, obj):
@@ -46,31 +49,24 @@ def hp_pchoice(label, p_options):
     """
     p, options = list(zip(*p_options))
     n_options = len(options)
-    ch = scope.hyperopt_param(label,
-                              scope.categorical(
-                                  p,
-                                  upper=n_options))
+    ch = scope.hyperopt_param(label, scope.categorical(p, upper=n_options))
     return scope.switch(ch, *options)
 
 
 @validate_label
 def hp_choice(label, options):
-    ch = scope.hyperopt_param(label,
-                              scope.randint(len(options)))
+    ch = scope.hyperopt_param(label, scope.randint(len(options)))
     return scope.switch(ch, *options)
 
 
 @validate_label
 def hp_randint(label, *args, **kwargs):
-    return scope.hyperopt_param(label,
-                                scope.randint(*args, **kwargs))
+    return scope.hyperopt_param(label, scope.randint(*args, **kwargs))
 
 
 @validate_label
 def hp_uniform(label, *args, **kwargs):
-    return scope.float(
-        scope.hyperopt_param(label,
-                             scope.uniform(*args, **kwargs)))
+    return scope.float(scope.hyperopt_param(label, scope.uniform(*args, **kwargs)))
 
 
 @validate_label
@@ -81,51 +77,37 @@ def hp_uniformint(label, *args, **kwargs):
 
 @validate_label
 def hp_quniform(label, *args, **kwargs):
-    return scope.float(
-        scope.hyperopt_param(label,
-                             scope.quniform(*args, **kwargs)))
+    return scope.float(scope.hyperopt_param(label, scope.quniform(*args, **kwargs)))
 
 
 @validate_label
 def hp_loguniform(label, *args, **kwargs):
-    return scope.float(
-        scope.hyperopt_param(label,
-                             scope.loguniform(*args, **kwargs)))
+    return scope.float(scope.hyperopt_param(label, scope.loguniform(*args, **kwargs)))
 
 
 @validate_label
 def hp_qloguniform(label, *args, **kwargs):
-    return scope.float(
-        scope.hyperopt_param(label,
-                             scope.qloguniform(*args, **kwargs)))
+    return scope.float(scope.hyperopt_param(label, scope.qloguniform(*args, **kwargs)))
 
 
 @validate_label
 def hp_normal(label, *args, **kwargs):
-    return scope.float(
-        scope.hyperopt_param(label,
-                             scope.normal(*args, **kwargs)))
+    return scope.float(scope.hyperopt_param(label, scope.normal(*args, **kwargs)))
 
 
 @validate_label
 def hp_qnormal(label, *args, **kwargs):
-    return scope.float(
-        scope.hyperopt_param(label,
-                             scope.qnormal(*args, **kwargs)))
+    return scope.float(scope.hyperopt_param(label, scope.qnormal(*args, **kwargs)))
 
 
 @validate_label
 def hp_lognormal(label, *args, **kwargs):
-    return scope.float(
-        scope.hyperopt_param(label,
-                             scope.lognormal(*args, **kwargs)))
+    return scope.float(scope.hyperopt_param(label, scope.lognormal(*args, **kwargs)))
 
 
 @validate_label
 def hp_qlognormal(label, *args, **kwargs):
-    return scope.float(
-        scope.hyperopt_param(label,
-                             scope.qlognormal(*args, **kwargs)))
+    return scope.float(scope.hyperopt_param(label, scope.qlognormal(*args, **kwargs)))
 
 
 #
@@ -134,14 +116,13 @@ def hp_qlognormal(label, *args, **kwargs):
 
 
 class Cond(object):
-
     def __init__(self, name, val, op):
         self.op = op
         self.name = name
         self.val = val
 
     def __str__(self):
-        return 'Cond{%s %s %s}' % (self.name, self.op, self.val)
+        return "Cond{%s %s %s}" % (self.name, self.op, self.val)
 
     def __eq__(self, other):
         return self.op == other.op and self.name == other.name and self.val == other.val
@@ -152,34 +133,34 @@ class Cond(object):
     def __repr__(self):
         return str(self)
 
-EQ = partial(Cond, op='=')
+
+EQ = partial(Cond, op="=")
 
 
 def _expr_to_config(expr, conditions, hps):
-    if expr.name == 'switch':
+    if expr.name == "switch":
         idx = expr.inputs()[0]
         options = expr.inputs()[1:]
-        assert idx.name == 'hyperopt_param'
-        assert idx.arg['obj'].name in (
-            'randint',     # -- in case of hp.choice
-            'categorical',  # -- in case of hp.pchoice
+        assert idx.name == "hyperopt_param"
+        assert idx.arg["obj"].name in (
+            "randint",  # -- in case of hp.choice
+            "categorical",  # -- in case of hp.pchoice
         )
         _expr_to_config(idx, conditions, hps)
         for ii, opt in enumerate(options):
-            _expr_to_config(opt,
-                            conditions + (EQ(idx.arg['label'].obj, ii),),
-                            hps)
-    elif expr.name == 'hyperopt_param':
-        label = expr.arg['label'].obj
+            _expr_to_config(opt, conditions + (EQ(idx.arg["label"].obj, ii),), hps)
+    elif expr.name == "hyperopt_param":
+        label = expr.arg["label"].obj
         if label in hps:
-            if hps[label]['node'] != expr.arg['obj']:
+            if hps[label]["node"] != expr.arg["obj"]:
                 raise DuplicateLabel(label)
-            hps[label]['conditions'].add(conditions)
+            hps[label]["conditions"].add(conditions)
         else:
-            hps[label] = {'node': expr.arg['obj'],
-                          'conditions': set((conditions,)),
-                          'label': label,
-                          }
+            hps[label] = {
+                "node": expr.arg["obj"],
+                "conditions": set((conditions,)),
+                "label": label,
+            }
     else:
         for ii in expr.inputs():
             _expr_to_config(ii, conditions, hps)
@@ -216,27 +197,27 @@ def _remove_allpaths(hps, conditions):
     """
     potential_conds = {}
     for k, v in list(hps.items()):
-        if v['node'].name in ('randint', 'categorical'):
-            upper = v['node'].arg['upper'].obj
+        if v["node"].name in ("randint", "categorical"):
+            upper = v["node"].arg["upper"].obj
             potential_conds[k] = frozenset([EQ(k, ii) for ii in range(upper)])
 
     for k, v in list(hps.items()):
-        if len(v['conditions']) > 1:
-            all_conds = [[c for c in cond if c is not True]
-                         for cond in v['conditions']]
+        if len(v["conditions"]) > 1:
+            all_conds = [[c for c in cond if c is not True] for cond in v["conditions"]]
             all_conds = [cond for cond in all_conds if len(cond) >= 1]
             if len(all_conds) == 0:
-                v['conditions'] = set([conditions])
+                v["conditions"] = set([conditions])
                 continue
 
             depvar = all_conds[0][0].name
 
-            all_one_var = all(len(cond) == 1 and cond[0].name == depvar
-                              for cond in all_conds)
+            all_one_var = all(
+                len(cond) == 1 and cond[0].name == depvar for cond in all_conds
+            )
             if all_one_var:
                 conds = [cond[0] for cond in all_conds]
                 if frozenset(conds) == potential_conds[depvar]:
-                    v['conditions'] = set([conditions])
+                    v["conditions"] = set([conditions])
                     continue
 
 

--- a/hyperopt/rand.py
+++ b/hyperopt/rand.py
@@ -18,16 +18,12 @@ def suggest(new_ids, domain, trials, seed):
     for ii, new_id in enumerate(new_ids):
         # -- sample new specs, idxs, vals
         idxs, vals = pyll.rec_eval(
-            domain.s_idxs_vals,
-            memo={
-                domain.s_new_ids: [new_id],
-                domain.s_rng: rng,
-            })
+            domain.s_idxs_vals, memo={domain.s_new_ids: [new_id], domain.s_rng: rng}
+        )
         new_result = domain.new_result()
         new_misc = dict(tid=new_id, cmd=domain.cmd, workdir=domain.workdir)
         miscs_update_idxs_vals([new_misc], idxs, vals)
-        rval.extend(trials.new_trial_docs([new_id],
-                    [None], [new_result], [new_misc]))
+        rval.extend(trials.new_trial_docs([new_id], [None], [new_result], [new_misc]))
     return rval
 
 
@@ -36,11 +32,8 @@ def suggest_batch(new_ids, domain, trials, seed):
     rng = np.random.RandomState(seed)
     # -- sample new specs, idxs, vals
     idxs, vals = pyll.rec_eval(
-        domain.s_idxs_vals,
-        memo={
-            domain.s_new_ids: new_ids,
-            domain.s_rng: rng,
-        })
+        domain.s_idxs_vals, memo={domain.s_new_ids: new_ids, domain.s_rng: rng}
+    )
     return idxs, vals
 
 

--- a/hyperopt/rdists.py
+++ b/hyperopt/rdists.py
@@ -18,30 +18,26 @@ class loguniform_gen(rv_continuous):
     """
 
     def __init__(self, low=0, high=1):
-        rv_continuous.__init__(self,
-                               a=np.exp(low),
-                               b=np.exp(high))
+        rv_continuous.__init__(self, a=np.exp(low), b=np.exp(high))
         self._low = low
         self._high = high
 
     def _rvs(self):
-        rval = np.exp(mtrand.uniform(
-            self._low,
-            self._high,
-            self._size))
+        rval = np.exp(mtrand.uniform(self._low, self._high, self._size))
         return rval
 
     def _pdf(self, x):
         return old_div(1.0, (x * (self._high - self._low)))
 
     def _logpdf(self, x):
-        return - np.log(x) - np.log(self._high - self._low)
+        return -np.log(x) - np.log(self._high - self._low)
 
     def _cdf(self, x):
         return old_div((np.log(x) - self._low), (self._high - self._low))
 
 
 from scipy.stats._continuous_distns import lognorm_gen as scipy_lognorm_gen
+
 
 class lognorm_gen(scipy_lognorm_gen):
     def __init__(self, mu, sigma):
@@ -51,9 +47,9 @@ class lognorm_gen(scipy_lognorm_gen):
 
         # I still don't understand what scipy stats objects are
         # doing re: this stuff
-        del self.__dict__['_parse_args']
-        del self.__dict__['_parse_args_stats']
-        del self.__dict__['_parse_args_rvs']
+        del self.__dict__["_parse_args"]
+        del self.__dict__["_parse_args_stats"]
+        del self.__dict__["_parse_args_rvs"]
 
     def _parse_args(self, *args, **kwds):
         assert not args, args
@@ -105,12 +101,12 @@ class quniform_gen(object):
             xs = [qlow]
             ps = [1.0]
         else:
-            lowmass = 1 - (old_div((low - qlow + .5 * q), q))
+            lowmass = 1 - (old_div((low - qlow + 0.5 * q), q))
             assert 0 <= lowmass <= 1.0, (lowmass, low, qlow, q)
-            highmass = old_div((high - qhigh + .5 * q), q)
+            highmass = old_div((high - qhigh + 0.5 * q), q)
             assert 0 <= highmass <= 1.0, (highmass, high, qhigh, q)
             # -- xs: qlow to qhigh inclusive
-            xs = np.arange(qlow, qhigh + .5 * q, q)
+            xs = np.arange(qlow, qhigh + 0.5 * q, q)
             ps = np.ones(len(xs))
             ps[0] = lowmass
             ps[-1] = highmass
@@ -140,6 +136,7 @@ class qloguniform_gen(quniform_gen):
     """ Stats for Y = q * round(e^X / q) where X ~ U(low, high).
 
     """
+
     # -- not inheriting from scipy.stats.rv_discrete
     #    because I don't understand the design of those rv classes
 
@@ -154,8 +151,9 @@ class qloguniform_gen(quniform_gen):
         lu = loguniform_gen(low=low, high=high)
 
         cut_low = np.exp(low)  # -- lowest possible pre-round value
-        cut_high = min(qlow + .5 * q,  # -- highest value that would ...
-                       ehigh)         # -- round to qlow
+        cut_high = min(
+            qlow + 0.5 * q, ehigh  # -- highest value that would ...
+        )  # -- round to qlow
         xs = [qlow]
         ps = [lu.cdf(cut_high)]
         ii = 0
@@ -218,7 +216,7 @@ class qnormal_gen(object):
         lbound = x_in_domain - self.q * 0.5
         # -- reflect intervals right of mu to other side
         #    for more accurate calculation
-        flip = (lbound > self.mu)
+        flip = lbound > self.mu
         tmp = lbound[flip].copy()
         lbound[flip] = self.mu - (ubound[flip] - self.mu)
         ubound[flip] = self.mu - (tmp - self.mu)
@@ -226,7 +224,7 @@ class qnormal_gen(object):
         assert np.all(ubound > lbound)
         a = self._norm_logcdf(ubound)
         b = self._norm_logcdf(lbound)
-        rval[in_domain] = a + np.log1p(- np.exp(b - a))
+        rval[in_domain] = a + np.log1p(-np.exp(b - a))
         if isinstance(x, np.ndarray):
             return rval
         else:
@@ -249,8 +247,10 @@ class qlognormal_gen(object):
         self._norm_cdf = scipy.stats.norm(loc=mu, scale=sigma).cdf
 
     def in_domain(self, x):
-        return np.logical_and((x >= 0),
-                              np.isclose(x, safe_int_cast(np.round(old_div(x, self.q))) * self.q))
+        return np.logical_and(
+            (x >= 0),
+            np.isclose(x, safe_int_cast(np.round(old_div(x, self.q))) * self.q),
+        )
 
     def pmf(self, x):
         x1 = np.atleast_1d(x)
@@ -259,7 +259,8 @@ class qlognormal_gen(object):
         rval = np.zeros_like(x1, dtype=np.float)
         rval_in_domain = self._norm_cdf(np.log(x1_in_domain + 0.5 * self.q))
         rval_in_domain[x1_in_domain != 0] -= self._norm_cdf(
-            np.log(x1_in_domain[x1_in_domain != 0] - 0.5 * self.q))
+            np.log(x1_in_domain[x1_in_domain != 0] - 0.5 * self.q)
+        )
         rval[in_domain] = rval_in_domain
         if isinstance(x, np.ndarray):
             return rval
@@ -284,10 +285,11 @@ class qlognormal_gen(object):
 
 def safe_int_cast(obj):
     if isinstance(obj, np.ndarray):
-        return obj.astype('int')
+        return obj.astype("int")
     elif isinstance(obj, list):
         return [int(i) for i in obj]
     else:
         return int(obj)
+
 
 # -- non-empty last line for flake8

--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -11,11 +11,12 @@ from hyperopt.utils import coarse_utcnow, _get_logger, _get_random_id
 
 try:
     from pyspark.sql import SparkSession
+
     _have_spark = True
 except ModuleNotFoundError as e:
     _have_spark = False
 
-logger = _get_logger('hyperopt-spark')
+logger = _get_logger("hyperopt-spark")
 
 
 class SparkTrials(Trials):
@@ -67,27 +68,41 @@ class SparkTrials(Trials):
         """
         super(SparkTrials, self).__init__(exp_key=None, refresh=False)
         if not _have_spark:
-            raise Exception("SparkTrials cannot import pyspark classes.  Make sure that PySpark "
-                            "is available in your environment.  E.g., try running 'import pyspark'")
-        if timeout is not None and (not isinstance(timeout, numbers.Number) or timeout <= 0 or
-                                    isinstance(timeout, bool)):
-            raise Exception("The timeout argument should be None or a positive value. "
-                            "Given value: {timeout}".format(timeout=timeout))
-        self._spark_context = SparkSession.builder.getOrCreate().sparkContext if spark_session is None \
-                                  else spark_session.sparkContext
+            raise Exception(
+                "SparkTrials cannot import pyspark classes.  Make sure that PySpark "
+                "is available in your environment.  E.g., try running 'import pyspark'"
+            )
+        if timeout is not None and (
+            not isinstance(timeout, numbers.Number)
+            or timeout <= 0
+            or isinstance(timeout, bool)
+        ):
+            raise Exception(
+                "The timeout argument should be None or a positive value. "
+                "Given value: {timeout}".format(timeout=timeout)
+            )
+        self._spark_context = (
+            SparkSession.builder.getOrCreate().sparkContext
+            if spark_session is None
+            else spark_session.sparkContext
+        )
         # The feature to support controlling jobGroupIds is in SPARK-22340
-        self._spark_supports_job_cancelling = hasattr(self._spark_context.parallelize([1]),
-                                                      "collectWithJobGroup")
+        self._spark_supports_job_cancelling = hasattr(
+            self._spark_context.parallelize([1]), "collectWithJobGroup"
+        )
         # maxNumConcurrentTasks() is a package private API
         max_num_concurrent_tasks = self._spark_context._jsc.sc().maxNumConcurrentTasks()
-        self.parallelism = self._decide_parallelism(max_num_concurrent_tasks, parallelism)
+        self.parallelism = self._decide_parallelism(
+            max_num_concurrent_tasks, parallelism
+        )
 
         if not self._spark_supports_job_cancelling and timeout is not None:
             logger.warning(
                 "SparkTrials was constructed with a timeout specified, but this Apache "
                 "Spark version does not support job group-based cancellation. The timeout will be "
                 "respected when starting new Spark jobs, but SparkTrials will not be able to "
-                "cancel running Spark jobs which exceed the timeout.")
+                "cancel running Spark jobs which exceed the timeout."
+            )
 
         self.timeout = timeout
         self._fmin_cancelled = False
@@ -101,25 +116,36 @@ class SparkTrials(Trials):
         See the docstring for `parallelism` in the constructor for expected behavior.
         """
         if max_num_concurrent_tasks == 0:
-            raise Exception("There are no available spark executors.  "
-                            "Add workers to your Spark cluster to use SparkTrials.")
+            raise Exception(
+                "There are no available spark executors.  "
+                "Add workers to your Spark cluster to use SparkTrials."
+            )
         if parallelism is None:
             parallelism = max_num_concurrent_tasks
         elif parallelism <= 0:
-            logger.warning("User-specified parallelism was invalid value ({p}), so parallelism will"
-                           " be set to max_num_concurrent_tasks ({c})."
-                           .format(p=parallelism, c=max_num_concurrent_tasks))
+            logger.warning(
+                "User-specified parallelism was invalid value ({p}), so parallelism will"
+                " be set to max_num_concurrent_tasks ({c}).".format(
+                    p=parallelism, c=max_num_concurrent_tasks
+                )
+            )
             parallelism = max_num_concurrent_tasks
         elif parallelism > max_num_concurrent_tasks:
-            logger.warning("User-specified parallelism ({p}) is greater than "
-                           "max_num_concurrent_tasks ({c}), so parallelism will be set to "
-                           "max_num_concurrent_tasks."
-                           .format(p=parallelism, c=max_num_concurrent_tasks))
+            logger.warning(
+                "User-specified parallelism ({p}) is greater than "
+                "max_num_concurrent_tasks ({c}), so parallelism will be set to "
+                "max_num_concurrent_tasks.".format(
+                    p=parallelism, c=max_num_concurrent_tasks
+                )
+            )
             parallelism = max_num_concurrent_tasks
         if parallelism > SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED:
-            logger.warning("Parallelism ({p}) is being decreased to the hard cap of "
-                           "SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED ({c})"
-                           .format(p=parallelism, c=SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED))
+            logger.warning(
+                "Parallelism ({p}) is being decreased to the hard cap of "
+                "SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED ({c})".format(
+                    p=parallelism, c=SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED
+                )
+            )
             parallelism = SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED
         return parallelism
 
@@ -146,7 +172,11 @@ class SparkTrials(Trials):
         """
         Returns the current number of all successful, failed, and cancelled trial runs
         """
-        total_states = [base.JOB_STATE_DONE, base.JOB_STATE_ERROR, base.JOB_STATE_CANCEL]
+        total_states = [
+            base.JOB_STATE_DONE,
+            base.JOB_STATE_ERROR,
+            base.JOB_STATE_CANCEL,
+        ]
         return self.count_by_state_unsynced(total_states)
 
     def delete_all(self):
@@ -160,22 +190,31 @@ class SparkTrials(Trials):
     def trial_attachments(self, trial):
         raise NotImplementedError("SparkTrials does not support trial attachments.")
 
-    def fmin(self, fn, space, algo, max_evals,
-             max_queue_len,
-             rstate,
-             verbose,
-             pass_expr_memo_ctrl,
-             catch_eval_exceptions,
-             return_argmin,
-             show_progressbar,
-             ):
+    def fmin(
+        self,
+        fn,
+        space,
+        algo,
+        max_evals,
+        max_queue_len,
+        rstate,
+        verbose,
+        pass_expr_memo_ctrl,
+        catch_eval_exceptions,
+        return_argmin,
+        show_progressbar,
+    ):
         """
         This should not be called directly but is called via :func:`hyperopt.fmin`
         Refer to :func:`hyperopt.fmin` for docs on each argument
         """
 
-        assert not pass_expr_memo_ctrl, "SparkTrials does not support `pass_expr_memo_ctrl`"
-        assert not catch_eval_exceptions, "SparkTrials does not support `catch_eval_exceptions`"
+        assert (
+            not pass_expr_memo_ctrl
+        ), "SparkTrials does not support `pass_expr_memo_ctrl`"
+        assert (
+            not catch_eval_exceptions
+        ), "SparkTrials does not support `catch_eval_exceptions`"
 
         state = _SparkFMinState(self._spark_context, fn, space, self)
 
@@ -183,17 +222,22 @@ class SparkTrials(Trials):
         state.launch_dispatcher()
 
         try:
-            res = fmin(fn, space, algo, max_evals,
-                       max_queue_len=max_queue_len,
-                       trials=self,
-                       allow_trials_fmin=False,  # -- prevent recursion
-                       rstate=rstate,
-                       pass_expr_memo_ctrl=None,  # not support
-                       catch_eval_exceptions=catch_eval_exceptions,
-                       verbose=verbose,
-                       return_argmin=return_argmin,
-                       points_to_evaluate=None,  # not support
-                       show_progressbar=show_progressbar)
+            res = fmin(
+                fn,
+                space,
+                algo,
+                max_evals,
+                max_queue_len=max_queue_len,
+                trials=self,
+                allow_trials_fmin=False,  # -- prevent recursion
+                rstate=rstate,
+                pass_expr_memo_ctrl=None,  # not support
+                catch_eval_exceptions=catch_eval_exceptions,
+                verbose=verbose,
+                return_argmin=return_argmin,
+                points_to_evaluate=None,  # not support
+                show_progressbar=show_progressbar,
+            )
         except BaseException as e:
             logger.debug("fmin thread exits with an exception raised.")
             raise e
@@ -203,12 +247,14 @@ class SparkTrials(Trials):
         finally:
             state.wait_for_all_threads()
 
-            logger.info("Total Trials: {t}: {s} succeeded, {f} failed, {c} cancelled.".format(
-                t=self.count_total_trials(),
-                s=self.count_successful_trials(),
-                f=self.count_failed_trials(),
-                c=self.count_cancelled_trials()
-            ))
+            logger.info(
+                "Total Trials: {t}: {s} succeeded, {f} failed, {c} cancelled.".format(
+                    t=self.count_total_trials(),
+                    s=self.count_successful_trials(),
+                    f=self.count_failed_trials(),
+                    c=self.count_cancelled_trials(),
+                )
+            )
 
 
 class _SparkFMinState:
@@ -219,11 +265,7 @@ class _SparkFMinState:
     Each trial's thread runs 1 Spark job with 1 task.
     """
 
-    def __init__(self,
-                 spark_context,
-                 eval_function,
-                 space,
-                 trials):
+    def __init__(self, spark_context, eval_function, space, trials):
         self.spark_context = spark_context
         self.eval_function = eval_function
         self.space = space
@@ -235,7 +277,9 @@ class _SparkFMinState:
         if self.trials._spark_supports_job_cancelling:
             self._job_group_id = spark_context.getLocalProperty("spark.jobGroup.id")
             self._job_desc = spark_context.getLocalProperty("spark.job.description")
-            interrupt_on_cancel = spark_context.getLocalProperty("spark.job.interruptOnCancel")
+            interrupt_on_cancel = spark_context.getLocalProperty(
+                "spark.job.interruptOnCancel"
+            )
             if interrupt_on_cancel is None:
                 self._job_interrupt_on_cancel = False
             else:
@@ -246,21 +290,24 @@ class _SparkFMinState:
                 self._job_group_id = "Hyperopt_SparkTrials_" + _get_random_id()
             if self._job_desc is None:
                 self._job_desc = "Trial evaluation jobs launched by hyperopt fmin"
-            logger.debug("Job group id: {g}, job desc: {d}, job interrupt on cancel: {i}"
-                         .format(g=self._job_group_id,
-                                 d=self._job_desc,
-                                 i=self._job_interrupt_on_cancel))
+            logger.debug(
+                "Job group id: {g}, job desc: {d}, job interrupt on cancel: {i}".format(
+                    g=self._job_group_id,
+                    d=self._job_desc,
+                    i=self._job_interrupt_on_cancel,
+                )
+            )
 
     def running_trial_count(self):
         return self.trials.count_by_state_unsynced(base.JOB_STATE_RUNNING)
 
     @staticmethod
     def _begin_trial_run(trial):
-        trial['state'] = base.JOB_STATE_RUNNING
+        trial["state"] = base.JOB_STATE_RUNNING
         now = coarse_utcnow()
-        trial['book_time'] = now
-        trial['refresh_time'] = now
-        logger.debug("trial task {tid} started".format(tid=trial['tid']))
+        trial["book_time"] = now
+        trial["refresh_time"] = now
+        logger.debug("trial task {tid} started".format(tid=trial["tid"]))
 
     def _finish_trial_run(self, is_success, is_cancelled, trial, data):
         """
@@ -272,16 +319,25 @@ class _SparkFMinState:
                      Otherwise, this is the exception raised when running the trial task.
         """
         if is_cancelled:
-            logger.debug("trial task {tid} cancelled, exception is {e}"
-                         .format(tid=trial['tid'], e=str(data)))
+            logger.debug(
+                "trial task {tid} cancelled, exception is {e}".format(
+                    tid=trial["tid"], e=str(data)
+                )
+            )
             self._write_cancellation_back(trial, e=data)
         elif is_success:
-            logger.debug("trial task {tid} succeeded, result is {r}"
-                         .format(tid=trial['tid'], r=data))
+            logger.debug(
+                "trial task {tid} succeeded, result is {r}".format(
+                    tid=trial["tid"], r=data
+                )
+            )
             self._write_result_back(trial, result=data)
         else:
-            logger.debug("trial task {tid} failed, exception is {e}"
-                         .format(tid=trial['tid'], e=str(data)))
+            logger.debug(
+                "trial task {tid} failed, exception is {e}".format(
+                    tid=trial["tid"], e=str(data)
+                )
+            )
             self._write_exception_back(trial, e=data)
 
     def launch_dispatcher(self):
@@ -300,12 +356,18 @@ class _SparkFMinState:
                 # When a timeout happens:
                 #  - Set `trials._fmin_cancelled` flag to be True.
                 #  - FMinIter checks this flag and exits if it is set to True.
-                if self.trials.timeout is not None and elapsed_time > self.trials.timeout and\
-                        not self.trials._fmin_cancelled:
+                if (
+                    self.trials.timeout is not None
+                    and elapsed_time > self.trials.timeout
+                    and not self.trials._fmin_cancelled
+                ):
                     self.trials._fmin_cancelled = True
                     self.trials._fmin_cancelled_reason = "fmin run timeout"
                     self._cancel_running_trials()
-                    logger.warning("fmin cancelled because of " + self.trials._fmin_cancelled_reason)
+                    logger.warning(
+                        "fmin cancelled because of "
+                        + self.trials._fmin_cancelled_reason
+                    )
                 time.sleep(1)
 
             if self.trials._fmin_cancelled:
@@ -321,25 +383,25 @@ class _SparkFMinState:
 
     @staticmethod
     def _get_spec_from_trial(trial):
-        return base.spec_from_misc(trial['misc'])
+        return base.spec_from_misc(trial["misc"])
 
     @staticmethod
     def _write_result_back(trial, result):
-        trial['state'] = base.JOB_STATE_DONE
-        trial['result'] = result
-        trial['refresh_time'] = coarse_utcnow()
+        trial["state"] = base.JOB_STATE_DONE
+        trial["result"] = result
+        trial["refresh_time"] = coarse_utcnow()
 
     @staticmethod
     def _write_exception_back(trial, e):
-        trial['state'] = base.JOB_STATE_ERROR
-        trial['misc']['error'] = (str(type(e)), str(e))
-        trial['refresh_time'] = coarse_utcnow()
+        trial["state"] = base.JOB_STATE_ERROR
+        trial["misc"]["error"] = (str(type(e)), str(e))
+        trial["refresh_time"] = coarse_utcnow()
 
     @staticmethod
     def _write_cancellation_back(trial, e):
-        trial['state'] = base.JOB_STATE_CANCEL
-        trial['misc']['error'] = (str(type(e)), str(e))
-        trial['refresh_time'] = coarse_utcnow()
+        trial["state"] = base.JOB_STATE_CANCEL
+        trial["misc"]["error"] = (str(type(e)), str(e))
+        trial["refresh_time"] = coarse_utcnow()
 
     def _run_trial_async(self, trial):
         def run_task_thread():
@@ -347,15 +409,24 @@ class _SparkFMinState:
             params = self._get_spec_from_trial(trial)
 
             def run_task_on_executor(_):
-                domain = base.Domain(local_eval_function, local_space, pass_expr_memo_ctrl=None)
+                domain = base.Domain(
+                    local_eval_function, local_space, pass_expr_memo_ctrl=None
+                )
                 result = domain.evaluate(params, ctrl=None, attach_attachments=False)
                 yield result
+
             try:
                 worker_rdd = self.spark_context.parallelize([0], 1)
                 if self.trials._spark_supports_job_cancelling:
-                    result = worker_rdd.mapPartitions(run_task_on_executor).collectWithJobGroup(
-                        self._job_group_id, self._job_desc, self._job_interrupt_on_cancel
-                    )[0]
+                    result = worker_rdd.mapPartitions(
+                        run_task_on_executor
+                    ).collectWithJobGroup(
+                        self._job_group_id,
+                        self._job_desc,
+                        self._job_interrupt_on_cancel,
+                    )[
+                        0
+                    ]
                 else:
                     result = worker_rdd.mapPartitions(run_task_on_executor).collect()[0]
             except BaseException as e:
@@ -365,17 +436,27 @@ class _SparkFMinState:
                 #
                 # If cancelled flag is set, it represent we need to cancel all running tasks,
                 # Otherwise it represent the task failed.
-                self._finish_trial_run(is_success=False, is_cancelled=self.trials._fmin_cancelled,
-                                       trial=trial, data=e)
-                logger.debug("trial {tid} task thread catches an exception and writes the "
-                             "info back correctly."
-                             .format(tid=trial['tid']))
+                self._finish_trial_run(
+                    is_success=False,
+                    is_cancelled=self.trials._fmin_cancelled,
+                    trial=trial,
+                    data=e,
+                )
+                logger.debug(
+                    "trial {tid} task thread catches an exception and writes the "
+                    "info back correctly.".format(tid=trial["tid"])
+                )
             else:
-                self._finish_trial_run(is_success=True, is_cancelled=self.trials._fmin_cancelled,
-                                       trial=trial, data=result)
-                logger.debug("trial {tid} task thread exits normally and writes results "
-                             "back correctly."
-                             .format(tid=trial['tid']))
+                self._finish_trial_run(
+                    is_success=True,
+                    is_cancelled=self.trials._fmin_cancelled,
+                    trial=trial,
+                    data=result,
+                )
+                logger.debug(
+                    "trial {tid} task thread exits normally and writes results "
+                    "back correctly.".format(tid=trial["tid"])
+                )
 
         task_thread = threading.Thread(target=run_task_thread)
         task_thread.setDaemon(True)
@@ -385,7 +466,7 @@ class _SparkFMinState:
     def _poll_new_tasks(self):
         new_task_list = []
         for trial in copy.copy(self.trials.trials):
-            if trial['state'] == base.JOB_STATE_NEW:
+            if trial["state"] == base.JOB_STATE_NEW:
                 # check parallelism limit
                 if self.running_trial_count() >= self.trials.parallelism:
                     break
@@ -395,17 +476,22 @@ class _SparkFMinState:
 
     def _cancel_running_trials(self):
         if self.trials._spark_supports_job_cancelling:
-            logger.debug("Cancelling all running jobs in job group {g}"
-                         .format(g=self._job_group_id))
+            logger.debug(
+                "Cancelling all running jobs in job group {g}".format(
+                    g=self._job_group_id
+                )
+            )
             self.spark_context.cancelJobGroup(self._job_group_id)
             # Make a copy of trials by slicing
             for trial in self.trials.trials[:]:
-                if trial['state'] in [base.JOB_STATE_NEW, base.JOB_STATE_RUNNING]:
-                    trial['state'] = base.JOB_STATE_CANCEL
+                if trial["state"] in [base.JOB_STATE_NEW, base.JOB_STATE_RUNNING]:
+                    trial["state"] = base.JOB_STATE_CANCEL
         else:
-            logger.info("Because the current Apache PySpark version does not support "
-                        "cancelling jobs by job group ID, SparkTrials will block until all of "
-                        "its running Spark jobs finish.")
+            logger.info(
+                "Because the current Apache PySpark version does not support "
+                "cancelling jobs by job group ID, SparkTrials will block until all of "
+                "its running Spark jobs finish."
+            )
 
     def wait_for_all_threads(self):
         """

--- a/hyperopt/std_out_err_redirect_tqdm.py
+++ b/hyperopt/std_out_err_redirect_tqdm.py
@@ -7,9 +7,12 @@ import contextlib
 import sys
 from tqdm import tqdm
 
+
 class DummyTqdmFile(object):
     """Dummy file-like that will write to tqdm."""
+
     file = None
+
     def __init__(self, file):
         self.file = file
 
@@ -20,6 +23,7 @@ class DummyTqdmFile(object):
 
     def flush(self):
         return getattr(self.file, "flush", lambda: None)()
+
 
 @contextlib.contextmanager
 def std_out_err_redirect_tqdm():

--- a/hyperopt/tests/test_anneal.py
+++ b/hyperopt/tests/test_anneal.py
@@ -22,7 +22,6 @@ def passthrough(x):
 
 
 class TestItJustRuns(unittest.TestCase, CasePerDomain):
-
     def work(self):
         trials = Trials()
         space = self.bandit.expr
@@ -31,7 +30,8 @@ class TestItJustRuns(unittest.TestCase, CasePerDomain):
             space=space,
             trials=trials,
             algo=anneal.suggest,
-            max_evals=10)
+            max_evals=10,
+        )
 
 
 class TestItAtLeastSortOfWorks(unittest.TestCase, CasePerDomain):
@@ -43,7 +43,7 @@ class TestItAtLeastSortOfWorks(unittest.TestCase, CasePerDomain):
         gauss_wave=-2.0,
         gauss_wave2=-2.0,
         n_arms=-2.5,
-        many_dists=.0005,
+        many_dists=0.0005,
         branin=0.7,
     )
 
@@ -59,8 +59,8 @@ class TestItAtLeastSortOfWorks(unittest.TestCase, CasePerDomain):
     )
 
     def setUp(self):
-        self.olderr = np.seterr('raise')
-        np.seterr(under='ignore')
+        self.olderr = np.seterr("raise")
+        np.seterr(under="ignore")
 
     def tearDown(self, *args):
         np.seterr(**self.olderr)
@@ -68,52 +68,52 @@ class TestItAtLeastSortOfWorks(unittest.TestCase, CasePerDomain):
     def work(self):
         bandit = self.bandit
         assert bandit.name is not None
-        algo = partial(
-            anneal.suggest,
-        )
+        algo = partial(anneal.suggest)
         LEN = self.LEN.get(bandit.name, 50)
 
         trials = Trials()
-        fmin(fn=passthrough,
-             space=self.bandit.expr,
-             trials=trials,
-             algo=algo,
-             max_evals=LEN)
+        fmin(
+            fn=passthrough,
+            space=self.bandit.expr,
+            trials=trials,
+            algo=algo,
+            max_evals=LEN,
+        )
         assert len(trials) == LEN
 
         if 1:
             rtrials = Trials()
-            fmin(fn=passthrough,
-                 space=self.bandit.expr,
-                 trials=rtrials,
-                 algo=rand.suggest,
-                 max_evals=LEN)
-            print('RANDOM BEST 6:', list(sorted(rtrials.losses()))[:6])
+            fmin(
+                fn=passthrough,
+                space=self.bandit.expr,
+                trials=rtrials,
+                algo=rand.suggest,
+                max_evals=LEN,
+            )
+            print("RANDOM BEST 6:", list(sorted(rtrials.losses()))[:6])
 
         if 0:
             plt.subplot(2, 2, 1)
             plt.scatter(list(range(LEN)), trials.losses())
-            plt.title('TPE losses')
+            plt.title("TPE losses")
             plt.subplot(2, 2, 2)
-            plt.scatter(list(range(LEN)), ([s['x'] for s in trials.specs]))
-            plt.title('TPE x')
+            plt.scatter(list(range(LEN)), ([s["x"] for s in trials.specs]))
+            plt.title("TPE x")
             plt.subplot(2, 2, 3)
-            plt.title('RND losses')
+            plt.title("RND losses")
             plt.scatter(list(range(LEN)), rtrials.losses())
             plt.subplot(2, 2, 4)
-            plt.title('RND x')
-            plt.scatter(list(range(LEN)), ([s['x'] for s in rtrials.specs]))
+            plt.title("RND x")
+            plt.scatter(list(range(LEN)), ([s["x"] for s in rtrials.specs]))
             plt.show()
         if 0:
-            plt.hist(
-                [t['x'] for t in self.experiment.trials],
-                bins=20)
+            plt.hist([t["x"] for t in self.experiment.trials], bins=20)
 
         # print trials.losses()
-        print('ANNEAL BEST 6:', list(sorted(trials.losses()))[:6])
+        print("ANNEAL BEST 6:", list(sorted(trials.losses()))[:6])
         # logx = np.log([s['x'] for s in trials.specs])
         # print 'TPE MEAN', np.mean(logx)
         # print 'TPE STD ', np.std(logx)
         thresh = self.thresholds[bandit.name]
-        print('Thresh', thresh)
+        print("Thresh", thresh)
         assert min(trials.losses()) < thresh

--- a/hyperopt/tests/test_atpe_basic.py
+++ b/hyperopt/tests/test_atpe_basic.py
@@ -6,25 +6,28 @@ from hyperopt import rand
 
 
 class TestATPE(unittest.TestCase):
-
     def test_run_basic_search(self):
         def objective(args):
             case, val = args
-            if case == 'case 1':
+            if case == "case 1":
                 return val
             else:
                 return val ** 2
 
         # define a search space
         from hyperopt import hp
-        space = hp.choice('a',
+
+        space = hp.choice(
+            "a",
             [
-                ('case 1', 1 + hp.lognormal('c1', 0, 1)),
-                ('case 2', hp.uniform('c2', -10, 10))
-            ])
+                ("case 1", 1 + hp.lognormal("c1", 0, 1)),
+                ("case 2", hp.uniform("c2", -10, 10)),
+            ],
+        )
 
         # minimize the objective over the space
         from hyperopt import fmin, atpe, space_eval
+
         best = fmin(objective, space, algo=atpe.suggest, max_evals=10)
 
         print(best)

--- a/hyperopt/tests/test_base.py
+++ b/hyperopt/tests/test_base.py
@@ -28,14 +28,15 @@ one_of = scope.one_of
 def ok_trial(tid, *args, **kwargs):
     return dict(
         tid=tid,
-        result={'status': 'algo, ok'},
-        spec={'a': 1, 'foo': (args, kwargs)},
+        result={"status": "algo, ok"},
+        spec={"a": 1, "foo": (args, kwargs)},
         misc={
-            'tid': tid,
-            'cmd': ("some cmd",),
-            'idxs': {'z': [tid]},
-            'vals': {'z': [1]}},
-        extra='extra',  # -- more stuff here is ok
+            "tid": tid,
+            "cmd": ("some cmd",),
+            "idxs": {"z": [tid]},
+            "vals": {"z": [1]},
+        },
+        extra="extra",  # -- more stuff here is ok
         owner=None,
         state=JOB_STATE_NEW,
         version=0,
@@ -48,14 +49,17 @@ def ok_trial(tid, *args, **kwargs):
 def create_fake_trial(tid, loss=None, status=STATUS_OK, state=JOB_STATE_DONE):
     return dict(
         tid=tid,
-        result={'status': status, 'loss': loss} if loss is not None else {'status': status},
-        spec={'a': 1},
+        result={"status": status, "loss": loss}
+        if loss is not None
+        else {"status": status},
+        spec={"a": 1},
         misc={
-            'tid': tid,
-            'cmd': ("some cmd",),
-            'idxs': {'z': [tid]},
-            'vals': {'z': [1]}},
-        extra='extra',  # -- more stuff here is ok
+            "tid": tid,
+            "cmd": ("some cmd",),
+            "idxs": {"z": [tid]},
+            "vals": {"z": [1]},
+        },
+        extra="extra",  # -- more stuff here is ok
         owner=None,
         state=state,
         version=0,
@@ -79,13 +83,13 @@ class Suggest_API(object):
     @classmethod
     def make_tst_class(cls, suggest, domain, name):
         class Tester(unittest.TestCase, cls):
-
             def suggest(self, *args, **kwargs):
                 print(args, kwargs)
                 return suggest(*args, **kwargs)
 
             def setUp(self):
                 self.domain = domain
+
         Tester.__name__ = name
         return Tester
 
@@ -101,8 +105,8 @@ class Suggest_API(object):
         # -- suggest implementations should work for arbitrary ID
         #    values (possibly assuming they are hashable), and the
         #    ID values should have no effect on the return values.
-        ids_1 = [-2, 0, 7, 'a', '007', 66, 'a3', '899', 23, 2333]
-        ids_2 = ['a', 'b', 'c', 'd', 1, 2, 3, 0.1, 0.2, 0.3]
+        ids_1 = [-2, 0, 7, "a", "007", 66, "a3", "899", 23, 2333]
+        ids_2 = ["a", "b", "c", "d", 1, 2, 3, 0.1, 0.2, 0.3]
         idxs_1, vals_1 = self.idxs_vals_from_ids(ids=ids_1, seed=45)
         idxs_2, vals_2 = self.idxs_vals_from_ids(ids=ids_2, seed=45)
         all_ids_1 = set()
@@ -133,14 +137,13 @@ class Suggest_API(object):
 
 
 class TestTrials(unittest.TestCase):
-
     def setUp(self):
         self.trials = Trials()
 
     def test_valid(self):
         trials = self.trials
         f = trials.insert_trial_doc
-        fine = ok_trial('ID', 1, 2, 3)
+        fine = ok_trial("ID", 1, 2, 3)
 
         # --original runs fine
         f(fine)
@@ -150,26 +153,27 @@ class TestTrials(unittest.TestCase):
             rval = copy.deepcopy(fine)
             del rval[key]
             return rval
+
         for key in TRIAL_KEYS:
             self.assertRaises(InvalidTrial, f, knockout(key))
 
         # -- take out each mandatory misc key
         def knockout2(key):
             rval = copy.deepcopy(fine)
-            del rval['misc'][key]
+            del rval["misc"][key]
             return rval
+
         for key in TRIAL_MISC_KEYS:
             self.assertRaises(InvalidTrial, f, knockout2(key))
 
     def test_insert_sync(self):
         trials = self.trials
         assert len(trials) == 0
-        trials.insert_trial_doc(ok_trial('a', 8))
+        trials.insert_trial_doc(ok_trial("a", 8))
         assert len(trials) == 0
         trials.insert_trial_doc(ok_trial(5, a=1, b=3))
         assert len(trials) == 0
-        trials.insert_trial_docs(
-            [ok_trial(tid=4, a=2, b=3), ok_trial(tid=9, a=4, b=3)])
+        trials.insert_trial_docs([ok_trial(tid=4, a=2, b=3), ok_trial(tid=9, a=4, b=3)])
         assert len(trials) == 0
         trials.refresh()
 
@@ -180,11 +184,15 @@ class TestTrials(unittest.TestCase):
 
         trials.insert_trial_docs(
             trials.new_trial_docs(
-                ['id0', 'id1'],
+                ["id0", "id1"],
                 [dict(a=1), dict(a=2)],
-                [dict(status='new'), dict(status='new')],
-                [dict(tid='id0', idxs={}, vals={}, cmd=None),
-                 dict(tid='id1', idxs={}, vals={}, cmd=None)],))
+                [dict(status="new"), dict(status="new")],
+                [
+                    dict(tid="id0", idxs={}, vals={}, cmd=None),
+                    dict(tid="id1", idxs={}, vals={}, cmd=None),
+                ],
+            )
+        )
 
         assert len(trials) == 4
         assert len(trials) == len(trials.specs)
@@ -213,11 +221,10 @@ class TestTrials(unittest.TestCase):
         trials.refresh()
 
         best_trial = trials.best_trial
-        self.assertEquals(best_trial['tid'], 3)
+        self.assertEquals(best_trial["tid"], 3)
 
 
 class TestSONify(unittest.TestCase):
-
     def SONify(self, foo):
         rval = SONify(foo)
         assert bson.BSON.encode(dict(a=rval))
@@ -236,25 +243,20 @@ class TestSONify(unittest.TestCase):
         assert self.SONify(np.float(1.1)) == 1.1
 
     def test_np_1d_int(self):
-        assert np.all(self.SONify(np.asarray([1, 2, 3])) ==
-                      [1, 2, 3])
+        assert np.all(self.SONify(np.asarray([1, 2, 3])) == [1, 2, 3])
 
     def test_np_1d_float(self):
-        assert np.all(self.SONify(np.asarray([1, 2, 3.4])) ==
-                      [1, 2, 3.4])
+        assert np.all(self.SONify(np.asarray([1, 2, 3.4])) == [1, 2, 3.4])
 
     def test_np_1d_str(self):
-        assert np.all(self.SONify(np.asarray(['a', 'b', 'ccc'])) ==
-                      ['a', 'b', 'ccc'])
+        assert np.all(self.SONify(np.asarray(["a", "b", "ccc"])) == ["a", "b", "ccc"])
 
     def test_np_2d_int(self):
-        assert np.all(self.SONify(np.asarray([[1, 2], [3, 4]])) ==
-                      [[1, 2], [3, 4]])
+        assert np.all(self.SONify(np.asarray([[1, 2], [3, 4]])) == [[1, 2], [3, 4]])
 
     def test_np_2d_float(self):
-        assert np.all(self.SONify(np.asarray([[1, 2], [3, 4.5]])) ==
-                      [[1, 2], [3, 4.5]])
+        assert np.all(self.SONify(np.asarray([[1, 2], [3, 4.5]])) == [[1, 2], [3, 4.5]])
 
     def test_nested_w_bool(self):
-        thing = dict(a=1, b='2', c=True, d=False, e=np.int(3), f=[1])
+        thing = dict(a=1, b="2", c=True, d=False, e=np.int(3), f=[1])
         assert thing == SONify(thing)

--- a/hyperopt/tests/test_criteria.py
+++ b/hyperopt/tests/test_criteria.py
@@ -9,12 +9,13 @@ import hyperopt.criteria as crit
 def test_ei():
     rng = np.random.RandomState(123)
     for mean, var in [(0, 1), (-4, 9)]:
-        thresholds = np.arange(-5, 5, .25) * np.sqrt(var) + mean
+        thresholds = np.arange(-5, 5, 0.25) * np.sqrt(var) + mean
 
-        v_n = [crit.EI_gaussian_empirical(mean, var, thresh, rng, 10000)
-               for thresh in thresholds]
-        v_a = [crit.EI_gaussian(mean, var, thresh)
-               for thresh in thresholds]
+        v_n = [
+            crit.EI_gaussian_empirical(mean, var, thresh, rng, 10000)
+            for thresh in thresholds
+        ]
+        v_a = [crit.EI_gaussian(mean, var, thresh) for thresh in thresholds]
 
         # import matplotlib.pyplot as plt
         # plt.plot(thresholds, v_n)
@@ -30,14 +31,12 @@ def test_ei():
 
 def test_log_ei():
     for mean, var in [(0, 1), (-4, 9)]:
-        thresholds = np.arange(-5, 30, .25) * np.sqrt(var) + mean
+        thresholds = np.arange(-5, 30, 0.25) * np.sqrt(var) + mean
 
-        ei = np.asarray(
-            [crit.EI_gaussian(mean, var, thresh)
-             for thresh in thresholds])
+        ei = np.asarray([crit.EI_gaussian(mean, var, thresh) for thresh in thresholds])
         nlei = np.asarray(
-            [crit.logEI_gaussian(mean, var, thresh)
-             for thresh in thresholds])
+            [crit.logEI_gaussian(mean, var, thresh) for thresh in thresholds]
+        )
         naive = np.log(ei)
         # import matplotlib.pyplot as plt
         # plt.plot(thresholds, ei, label='ei')
@@ -53,8 +52,12 @@ def test_log_ei():
 def test_log_ei_range():
     assert np.all(
         np.isfinite(
-            [crit.logEI_gaussian(0, 1, thresh)
-             for thresh in [-500, 0, 50, 100, 500, 5000]]))
+            [
+                crit.logEI_gaussian(0, 1, thresh)
+                for thresh in [-500, 0, 50, 100, 500, 5000]
+            ]
+        )
+    )
 
 
 def test_ucb():
@@ -62,5 +65,6 @@ def test_ucb():
     assert np.allclose(crit.UCB(0, 1, 2), 2)
     assert np.allclose(crit.UCB(0, 4, 1), 2)
     assert np.allclose(crit.UCB(1, 4, 1), 3)
+
 
 # -- flake8

--- a/hyperopt/tests/test_domains.py
+++ b/hyperopt/tests/test_domains.py
@@ -24,17 +24,20 @@ def domain_constructor(**b_kwargs):
         return {'loss': hp.uniform('x', low, high) ** 2 }
 
     """
+
     def deco(f):
         def wrapper(*args, **kwargs):
-            if 'name' in b_kwargs:
+            if "name" in b_kwargs:
                 _b_kwargs = b_kwargs
             else:
                 _b_kwargs = dict(b_kwargs, name=f.__name__)
             f_rval = f(*args, **kwargs)
             domain = Domain(lambda x: x, f_rval, **_b_kwargs)
             return domain
+
         wrapper.__name__ = f.__name__
         return wrapper
+
     return deco
 
 
@@ -42,7 +45,7 @@ def domain_constructor(**b_kwargs):
 def coin_flip():
     """ Possibly the simplest possible Bandit implementation
     """
-    return {'loss': hp.choice('flip', [0.0, 1.0]), 'status': base.STATUS_OK}
+    return {"loss": hp.choice("flip", [0.0, 1.0]), "status": base.STATUS_OK}
 
 
 @domain_constructor(loss_target=0)
@@ -51,16 +54,15 @@ def quadratic1():
     About the simplest problem you could ask for:
     optimize a one-variable quadratic function.
     """
-    return {'loss': (hp.uniform('x', -5, 5) - 3) ** 2, 'status': base.STATUS_OK}
+    return {"loss": (hp.uniform("x", -5, 5) - 3) ** 2, "status": base.STATUS_OK}
 
 
 @domain_constructor(loss_target=0)
 def q1_choice():
-    o_x = hp.choice('o_x', [
-        (-3, hp.uniform('x_neg', -5, 5)),
-        (3, hp.uniform('x_pos', -5, 5)),
-    ])
-    return {'loss': (o_x[0] - o_x[1]) ** 2, 'status': base.STATUS_OK}
+    o_x = hp.choice(
+        "o_x", [(-3, hp.uniform("x_neg", -5, 5)), (3, hp.uniform("x_pos", -5, 5))]
+    )
+    return {"loss": (o_x[0] - o_x[1]) ** 2, "status": base.STATUS_OK}
 
 
 @domain_constructor(loss_target=0)
@@ -69,9 +71,10 @@ def q1_lognormal():
     About the simplest problem you could ask for:
     optimize a one-variable quadratic function.
     """
-    return {'loss': scope.min(0.1 * (hp.lognormal('x', 0, 2) - 10) ** 2,
-                              10),
-            'status': base.STATUS_OK}
+    return {
+        "loss": scope.min(0.1 * (hp.lognormal("x", 0, 2) - 10) ** 2, 10),
+        "status": base.STATUS_OK,
+    }
 
 
 @domain_constructor(loss_target=-2)
@@ -83,12 +86,14 @@ def n_arms(N=2):
 
     """
     rng = np.random.RandomState(123)
-    x = hp.choice('x', [0, 1])
+    x = hp.choice("x", [0, 1])
     reward_mus = as_apply([-1] + [0] * (N - 1))
     reward_sigmas = as_apply([1] * N)
-    return {'loss': scope.normal(reward_mus[x], reward_sigmas[x], rng=rng),
-            'loss_variance': 1.0,
-            'status': base.STATUS_OK}
+    return {
+        "loss": scope.normal(reward_mus[x], reward_sigmas[x], rng=rng),
+        "loss_variance": 1.0,
+        "status": base.STATUS_OK,
+    }
 
 
 @domain_constructor(loss_target=-2)
@@ -102,10 +107,10 @@ def distractor():
     The prior mean is 0.
     """
 
-    x = hp.uniform('x', -15, 15)
-    f1 = old_div(1.0, (1.0 + scope.exp(-x)))    # climbs rightward from 0.0 to 1.0
-    f2 = 2 * scope.exp(-(x + 10) ** 2)  # bump with height 2 at (x=-10)
-    return {'loss': -f1 - f2, 'status': base.STATUS_OK}
+    x = hp.uniform("x", -15, 15)
+    f1 = old_div(1.0, (1.0 + scope.exp(-x)))  # climbs rightward from 0.0 to 1.0
+    f2 = 2 * scope.exp(-((x + 10) ** 2))  # bump with height 2 at (x=-10)
+    return {"loss": -f1 - f2, "status": base.STATUS_OK}
 
 
 @domain_constructor(loss_target=-1)
@@ -121,11 +126,11 @@ def gauss_wave():
 
     """
 
-    x = hp.uniform('x', -20, 20)
-    t = hp.choice('curve', [x, x + np.pi])
+    x = hp.uniform("x", -20, 20)
+    t = hp.choice("curve", [x, x + np.pi])
     f1 = scope.sin(t)
-    f2 = 2 * scope.exp(-(old_div(t, 5.0)) ** 2)
-    return {'loss': - (f1 + f2), 'status': base.STATUS_OK}
+    f2 = 2 * scope.exp(-((old_div(t, 5.0)) ** 2))
+    return {"loss": -(f1 + f2), "status": base.STATUS_OK}
 
 
 @domain_constructor(loss_target=-2.5)
@@ -141,30 +146,32 @@ def gauss_wave2():
     """
 
     rng = np.random.RandomState(123)
-    var = .1
-    x = hp.uniform('x', -20, 20)
-    amp = hp.uniform('amp', 0, 1)
-    t = (scope.normal(0, var, rng=rng) + 2 * scope.exp(-(old_div(x, 5.0)) ** 2))
-    return {'loss': - hp.choice('hf', [t, t + scope.sin(x) * amp]),
-            'loss_variance': var, 'status': base.STATUS_OK}
+    var = 0.1
+    x = hp.uniform("x", -20, 20)
+    amp = hp.uniform("amp", 0, 1)
+    t = scope.normal(0, var, rng=rng) + 2 * scope.exp(-((old_div(x, 5.0)) ** 2))
+    return {
+        "loss": -hp.choice("hf", [t, t + scope.sin(x) * amp]),
+        "loss_variance": var,
+        "status": base.STATUS_OK,
+    }
 
 
 @domain_constructor(loss_target=0)
 def many_dists():
-    a = hp.choice('a', [0, 1, 2])
-    b = hp.randint('b', 10)
-    c = hp.uniform('c', 4, 7)
-    d = hp.loguniform('d', -2, 0)
-    e = hp.quniform('e', 0, 10, 3)
-    f = hp.qloguniform('f', 0, 3, 2)
-    g = hp.normal('g', 4, 7)
-    h = hp.lognormal('h', -2, 2)
-    i = hp.qnormal('i', 0, 10, 2)
-    j = hp.qlognormal('j', 0, 2, 1)
-    k = hp.pchoice('k', [(.1, 0), (.9, 1)])
+    a = hp.choice("a", [0, 1, 2])
+    b = hp.randint("b", 10)
+    c = hp.uniform("c", 4, 7)
+    d = hp.loguniform("d", -2, 0)
+    e = hp.quniform("e", 0, 10, 3)
+    f = hp.qloguniform("f", 0, 3, 2)
+    g = hp.normal("g", 4, 7)
+    h = hp.lognormal("h", -2, 2)
+    i = hp.qnormal("i", 0, 10, 2)
+    j = hp.qlognormal("j", 0, 2, 1)
+    k = hp.pchoice("k", [(0.1, 0), (0.9, 1)])
     z = a + b + c + d + e + f + g + h + i + j + k
-    return {'loss': scope.float(scope.log(1e-12 + z ** 2)),
-            'status': base.STATUS_OK}
+    return {"loss": scope.float(scope.log(1e-12 + z ** 2)), "status": base.STATUS_OK}
 
 
 @domain_constructor(loss_target=0.398)
@@ -190,37 +197,40 @@ def branin():
 
     Source: http://www.sfu.ca/~ssurjano/branin.html
     """
-    x = hp.uniform('x', -5., 10.)
-    y = hp.uniform('y', 0., 15.)
+    x = hp.uniform("x", -5.0, 10.0)
+    y = hp.uniform("y", 0.0, 15.0)
     pi = float(np.pi)
-    loss = ((y - (old_div(5.1, (4 * pi ** 2))) * x ** 2 + 5 * x / pi - 6) ** 2 +
-            10 * (1 - old_div(1, (8 * pi))) * scope.cos(x) + 10)
-    return {'loss': loss,
-            'loss_variance': 0,
-            'status': base.STATUS_OK}
+    loss = (
+        (y - (old_div(5.1, (4 * pi ** 2))) * x ** 2 + 5 * x / pi - 6) ** 2
+        + 10 * (1 - old_div(1, (8 * pi))) * scope.cos(x)
+        + 10
+    )
+    return {"loss": loss, "loss_variance": 0, "status": base.STATUS_OK}
 
 
 class DomainExperimentMixin(object):
-
     def test_basic(self):
         domain = self._domain_cls()
         # print 'domain params', domain.params, domain
         # print 'algo params', algo.vh.params
         trials = Trials()
-        fmin(lambda x: x, domain.expr,
-             trials=trials,
-             algo=suggest,
-             max_evals=self._n_steps)
-        assert trials.average_best_error(domain) - domain.loss_target < .2
+        fmin(
+            lambda x: x,
+            domain.expr,
+            trials=trials,
+            algo=suggest,
+            max_evals=self._n_steps,
+        )
+        assert trials.average_best_error(domain) - domain.loss_target < 0.2
 
     @classmethod
     def make(cls, domain_cls, n_steps=500):
         class Tester(unittest.TestCase, cls):
-
             def setUp(self):
                 self._n_steps = n_steps
                 self._domain_cls = domain_cls
-        Tester.__name__ = domain_cls.__name__ + 'Tester'
+
+        Tester.__name__ = domain_cls.__name__ + "Tester"
         return Tester
 
 
@@ -230,8 +240,7 @@ q1_choiceTester = DomainExperimentMixin.make(q1_choice)
 n_armsTester = DomainExperimentMixin.make(n_arms)
 distractorTester = DomainExperimentMixin.make(distractor)
 gauss_waveTester = DomainExperimentMixin.make(gauss_wave)
-gauss_wave2Tester = DomainExperimentMixin.make(gauss_wave2,
-                                               n_steps=5000)
+gauss_wave2Tester = DomainExperimentMixin.make(gauss_wave2, n_steps=5000)
 many_distsTester = DomainExperimentMixin.make(many_dists)
 braninTester = DomainExperimentMixin.make(branin)
 
@@ -296,5 +305,6 @@ class NonCategoricalCasePerDomain(object):
     def test_branin(self):
         self.bandit = branin()
         self.work()
+
 
 # -- non-blank last line for flake8

--- a/hyperopt/tests/test_fmin.py
+++ b/hyperopt/tests/test_fmin.py
@@ -3,7 +3,17 @@ import unittest
 import numpy as np
 import nose.tools
 
-from hyperopt import fmin, rand, tpe, hp, Trials, exceptions, space_eval, STATUS_FAIL, STATUS_OK
+from hyperopt import (
+    fmin,
+    rand,
+    tpe,
+    hp,
+    Trials,
+    exceptions,
+    space_eval,
+    STATUS_FAIL,
+    STATUS_OK,
+)
 from hyperopt.base import JOB_STATE_ERROR
 
 
@@ -12,26 +22,28 @@ def test_quadratic1_rand():
 
     argmin = fmin(
         fn=lambda x: (x - 3) ** 2,
-        space=hp.uniform('x', -5, 5),
+        space=hp.uniform("x", -5, 5),
         algo=rand.suggest,
         max_evals=500,
-        trials=trials)
+        trials=trials,
+    )
 
     assert len(trials) == 500
-    assert abs(argmin['x'] - 3.0) < .25
+    assert abs(argmin["x"] - 3.0) < 0.25
 
 
 def test_quadratic1_tpe(trials=Trials()):
 
     argmin = fmin(
         fn=lambda x: (x - 3) ** 2,
-        space=hp.uniform('x', -5, 5),
+        space=hp.uniform("x", -5, 5),
         algo=tpe.suggest,
         max_evals=50,
-        trials=trials)
+        trials=trials,
+    )
 
     assert len(trials) == 50, len(trials)
-    assert abs(argmin['x'] - 3.0) < .25, argmin
+    assert abs(argmin["x"] - 3.0) < 0.25, argmin
 
 
 def test_quadratic1_anneal():
@@ -45,15 +57,16 @@ def test_quadratic1_anneal():
 
     argmin = fmin(
         fn=fn,
-        space=hp.uniform('x', -5, 5),
+        space=hp.uniform("x", -5, 5),
         algo=hyperopt.anneal.suggest,
         max_evals=N,
-        trials=trials)
+        trials=trials,
+    )
 
     print(argmin)
 
     assert len(trials) == N
-    assert abs(argmin['x'] - 3.0) < .25
+    assert abs(argmin["x"] - 3.0) < 0.25
 
 
 @nose.tools.raises(exceptions.DuplicateLabel)
@@ -64,54 +77,58 @@ def test_duplicate_label_is_error():
         x, y = xy
         return x ** 2 + y ** 2
 
-    fmin(fn=fn,
-         space=[
-             hp.uniform('x', -5, 5),
-             hp.uniform('x', -5, 5),
-         ],
-         algo=rand.suggest,
-         max_evals=500,
-         trials=trials)
+    fmin(
+        fn=fn,
+        space=[hp.uniform("x", -5, 5), hp.uniform("x", -5, 5)],
+        algo=rand.suggest,
+        max_evals=500,
+        trials=trials,
+    )
 
 
 def test_space_eval():
-    space = hp.choice('a',
-                      [
-                          ('case 1', 1 + hp.lognormal('c1', 0, 1)),
-                          ('case 2', hp.uniform('c2', -10, 10))
-                      ])
+    space = hp.choice(
+        "a",
+        [
+            ("case 1", 1 + hp.lognormal("c1", 0, 1)),
+            ("case 2", hp.uniform("c2", -10, 10)),
+        ],
+    )
 
-    assert space_eval(space, {'a': 0, 'c1': 1.0}) == ('case 1', 2.0)
-    assert space_eval(space, {'a': 1, 'c2': 3.5}) == ('case 2', 3.5)
+    assert space_eval(space, {"a": 0, "c1": 1.0}) == ("case 1", 2.0)
+    assert space_eval(space, {"a": 1, "c2": 3.5}) == ("case 2", 3.5)
 
 
 def test_set_fmin_rstate():
     def lossfn(x):
         return (x - 3) ** 2
+
     trials_seed0 = Trials()
     argmin_seed0 = fmin(
         fn=lossfn,
-        space=hp.uniform('x', -5, 5),
+        space=hp.uniform("x", -5, 5),
         algo=rand.suggest,
         max_evals=1,
         trials=trials_seed0,
-        rstate=np.random.RandomState(0))
+        rstate=np.random.RandomState(0),
+    )
     assert len(trials_seed0) == 1
     trials_seed1 = Trials()
     argmin_seed1 = fmin(
         fn=lossfn,
-        space=hp.uniform('x', -5, 5),
+        space=hp.uniform("x", -5, 5),
         algo=rand.suggest,
         max_evals=1,
         trials=trials_seed1,
-        rstate=np.random.RandomState(1))
+        rstate=np.random.RandomState(1),
+    )
     assert len(trials_seed1) == 1
     assert argmin_seed0 != argmin_seed1
 
 
 def test_fmin_return_argmin():
     fn = lambda x: x
-    space = hp.choice('x', [100, 5, 10])
+    space = hp.choice("x", [100, 5, 10])
 
     # With return_argmin=False it should return the
     # best parameter values
@@ -121,7 +138,7 @@ def test_fmin_return_argmin():
         max_evals=10,
         algo=rand.suggest,
         return_argmin=False,
-        rstate=np.random.RandomState(0)
+        rstate=np.random.RandomState(0),
     )
     assert best_parameter == 5
 
@@ -133,13 +150,12 @@ def test_fmin_return_argmin():
         max_evals=10,
         algo=rand.suggest,
         return_argmin=True,
-        rstate=np.random.RandomState(0)
+        rstate=np.random.RandomState(0),
     )
-    assert best_args['x'] == 1
+    assert best_args["x"] == 1
 
 
 class TestFmin(unittest.TestCase):
-
     class SomeError(Exception):
         # XXX also test domain.exceptions mechanism that actually catches this
         pass
@@ -154,29 +170,33 @@ class TestFmin(unittest.TestCase):
 
         # -- should go to max_evals, catching all exceptions, so all jobs
         #    should have JOB_STATE_ERROR
-        fmin(self.eval_fn,
-             space=hp.uniform('x', 0, 1),
-             algo=rand.suggest,
-             trials=self.trials,
-             max_evals=2,
-             catch_eval_exceptions=True,
-             return_argmin=False,)
+        fmin(
+            self.eval_fn,
+            space=hp.uniform("x", 0, 1),
+            algo=rand.suggest,
+            trials=self.trials,
+            max_evals=2,
+            catch_eval_exceptions=True,
+            return_argmin=False,
+        )
         trials = self.trials
         assert len(trials) == 0
         assert len(trials._dynamic_trials) == 2
-        assert trials._dynamic_trials[0]['state'] == JOB_STATE_ERROR
-        assert trials._dynamic_trials[0]['misc']['error'] != None
-        assert trials._dynamic_trials[1]['state'] == JOB_STATE_ERROR
-        assert trials._dynamic_trials[1]['misc']['error'] != None
+        assert trials._dynamic_trials[0]["state"] == JOB_STATE_ERROR
+        assert trials._dynamic_trials[0]["misc"]["error"] != None
+        assert trials._dynamic_trials[1]["state"] == JOB_STATE_ERROR
+        assert trials._dynamic_trials[1]["misc"]["error"] != None
 
     def test_catch_eval_exceptions_False(self):
         with self.assertRaises(TestFmin.SomeError):
-            fmin(self.eval_fn,
-                 space=hp.uniform('x', 0, 1),
-                 algo=rand.suggest,
-                 trials=self.trials,
-                 max_evals=2,
-                 catch_eval_exceptions=False)
+            fmin(
+                self.eval_fn,
+                space=hp.uniform("x", 0, 1),
+                algo=rand.suggest,
+                trials=self.trials,
+                max_evals=2,
+                catch_eval_exceptions=False,
+            )
         print(len(self.trials))
         assert len(self.trials) == 0
         assert len(self.trials._dynamic_trials) == 1
@@ -186,28 +206,32 @@ def test_status_fail_tpe():
     trials = Trials()
 
     argmin = fmin(
-        fn=lambda x: ({'loss': (x - 3) ** 2, 'status': STATUS_OK} if (x < 0) else
-                      {'status': STATUS_FAIL}),
-        space=hp.uniform('x', -5, 5),
+        fn=lambda x: (
+            {"loss": (x - 3) ** 2, "status": STATUS_OK}
+            if (x < 0)
+            else {"status": STATUS_FAIL}
+        ),
+        space=hp.uniform("x", -5, 5),
         algo=tpe.suggest,
         max_evals=50,
-        trials=trials)
+        trials=trials,
+    )
 
     assert len(trials) == 50, len(trials)
-    assert argmin['x'] < 0, argmin
-    assert 'loss' in trials.best_trial['result'], 'loss' in trials.best_trial['result']
-    assert trials.best_trial['result']['loss'] >= 9, trials.best_trial['result']['loss']
+    assert argmin["x"] < 0, argmin
+    assert "loss" in trials.best_trial["result"], "loss" in trials.best_trial["result"]
+    assert trials.best_trial["result"]["loss"] >= 9, trials.best_trial["result"]["loss"]
 
 
 class TestGenerateTrialsToCalculate(unittest.TestCase):
     def test_generate_trials_to_calculate(self):
-        points = [{'x': 0.0, 'y': 0.0}, {'x': 1.0, 'y': 1.0}]
-        best = fmin(fn=lambda space: space['x'] ** 2 + space['y'] ** 2,
-                    space={'x': hp.uniform('x', -10, 10),
-                           'y': hp.uniform('y', -10, 10)},
-                    algo=tpe.suggest,
-                    max_evals=10,
-                    points_to_evaluate=points
-                    )
-        assert best['x'] == 0.0
-        assert best['y'] == 0.0
+        points = [{"x": 0.0, "y": 0.0}, {"x": 1.0, "y": 1.0}]
+        best = fmin(
+            fn=lambda space: space["x"] ** 2 + space["y"] ** 2,
+            space={"x": hp.uniform("x", -10, 10), "y": hp.uniform("y", -10, 10)},
+            algo=tpe.suggest,
+            max_evals=10,
+            points_to_evaluate=points,
+        )
+        assert best["x"] == 0.0
+        assert best["y"] == 0.0

--- a/hyperopt/tests/test_ipy.py
+++ b/hyperopt/tests/test_ipy.py
@@ -1,4 +1,4 @@
-'''
+"""
 To use this test script, there should be a cluster of ipython parallel engines
 instantiated already. Their working directory should be the current
 directory: hyperopt/tests
@@ -7,15 +7,16 @@ To start the engines in hyperopt/hyperopt/tests/
   use: $ ipcluster start --n=2
 
 
-'''
+"""
 from __future__ import print_function
 import sys
 from nose import SkipTest
+
 try:
     from IPython.parallel import Client
 except ImportError:
     print("Skipping IPython Tests (IPython not found)", file=sys.stderr)
-    raise SkipTest('IPython not present')
+    raise SkipTest("IPython not present")
 
 from hyperopt.ipy import IPythonTrials
 import hyperopt.hp
@@ -30,7 +31,7 @@ def test0():
         raise SkipTest()
 
     client[:].use_cloudpickle()
-    trials = IPythonTrials(client, 'log')
+    trials = IPythonTrials(client, "log")
 
     def simple_objective(args):
         # -- why are these imports here !?
@@ -40,14 +41,20 @@ def test0():
         # needed here. Errors on the engines can be found by
         # using debug=True when instantiating the Client.
         import hyperopt
-        return {'loss': args ** 2, 'status': hyperopt.STATUS_OK}
 
-    space = hyperopt.hp.uniform('x', 0, 1)
+        return {"loss": args ** 2, "status": hyperopt.STATUS_OK}
 
-    minval = trials.fmin(simple_objective, space=space,
-                         algo=hyperopt.tpe.suggest, max_evals=25, verbose=True)
+    space = hyperopt.hp.uniform("x", 0, 1)
+
+    minval = trials.fmin(
+        simple_objective,
+        space=space,
+        algo=hyperopt.tpe.suggest,
+        max_evals=25,
+        verbose=True,
+    )
     print(minval)
-    assert minval['x'] < .2
+    assert minval["x"] < 0.2
 
 
 def test_fmin_fn():
@@ -58,19 +65,23 @@ def test_fmin_fn():
 
     client[:].use_cloudpickle()
 
-    trials = IPythonTrials(client, 'log')
+    trials = IPythonTrials(client, "log")
     assert not trials._testing_fmin_was_called
 
     def simple_objective(args):
         import hyperopt
-        return {'loss': args ** 2, 'status': hyperopt.STATUS_OK}
 
-    space = hyperopt.hp.uniform('x', 0, 1)
+        return {"loss": args ** 2, "status": hyperopt.STATUS_OK}
 
-    minval = hyperopt.fmin(simple_objective, space=space,
-                           algo=hyperopt.tpe.suggest,
-                           max_evals=25,
-                           trials=trials)
+    space = hyperopt.hp.uniform("x", 0, 1)
 
-    assert minval['x'] < .2
+    minval = hyperopt.fmin(
+        simple_objective,
+        space=space,
+        algo=hyperopt.tpe.suggest,
+        max_evals=25,
+        trials=trials,
+    )
+
+    assert minval["x"] < 0.2
     assert trials._testing_fmin_was_called

--- a/hyperopt/tests/test_pchoice.py
+++ b/hyperopt/tests/test_pchoice.py
@@ -8,22 +8,21 @@ import hyperopt.pyll.stochastic
 
 
 class TestPChoice(unittest.TestCase):
-
     def test_basic(self):
 
-        space = hp.pchoice('naive_type',
-                           [(.14, 'gaussian'),
-                            (.02, 'multinomial'),
-                               (.84, 'bernoulli')])
+        space = hp.pchoice(
+            "naive_type",
+            [(0.14, "gaussian"), (0.02, "multinomial"), (0.84, "bernoulli")],
+        )
         a, b, c = 0, 0, 0
         rng = np.random.RandomState(123)
         for i in range(0, 1000):
             nesto = hyperopt.pyll.stochastic.sample(space, rng=rng)
-            if nesto == 'gaussian':
+            if nesto == "gaussian":
                 a += 1
-            elif nesto == 'multinomial':
+            elif nesto == "multinomial":
                 b += 1
-            elif nesto == 'bernoulli':
+            elif nesto == "bernoulli":
                 c += 1
         print((a, b, c))
         assert a + b + c == 1000
@@ -32,20 +31,20 @@ class TestPChoice(unittest.TestCase):
         assert 800 < c < 900
 
     def test_basic2(self):
-        space = hp.choice('normal_choice', [
-            hp.pchoice('fsd',
-                       [(.1, 'first'),
-                        (.8, 'second'),
-                           (.1, 2)]),
-            hp.choice('something_else', [10, 20])
-        ])
+        space = hp.choice(
+            "normal_choice",
+            [
+                hp.pchoice("fsd", [(0.1, "first"), (0.8, "second"), (0.1, 2)]),
+                hp.choice("something_else", [10, 20]),
+            ],
+        )
         a, b, c = 0, 0, 0
         rng = np.random.RandomState(123)
         for i in range(0, 1000):
             nesto = hyperopt.pyll.stochastic.sample(space, rng=rng)
-            if nesto == 'first':
+            if nesto == "first":
                 a += 1
-            elif nesto == 'second':
+            elif nesto == "second":
                 b += 1
             elif nesto == 2:
                 c += 1
@@ -58,10 +57,13 @@ class TestPChoice(unittest.TestCase):
         assert b > 2 * c
 
     def test_basic3(self):
-        space = hp.pchoice('something', [
-            (.2, hp.pchoice('number', [(.8, 2), (.2, 1)])),
-            (.8, hp.pchoice('number1', [(.7, 5), (.3, 6)]))
-        ])
+        space = hp.pchoice(
+            "something",
+            [
+                (0.2, hp.pchoice("number", [(0.8, 2), (0.2, 1)])),
+                (0.8, hp.pchoice("number1", [(0.7, 5), (0.3, 6)])),
+            ],
+        )
         a, b, c, d = 0, 0, 0, 0
         rng = np.random.RandomState(123)
         for i in range(0, 2000):
@@ -80,7 +82,7 @@ class TestPChoice(unittest.TestCase):
         assert a + b + c + d == 2000
         assert 300 < a + b < 500
         assert 1500 < c + d < 1700
-        assert a * .3 > b  # a * 1.2 > 4 * b
+        assert a * 0.3 > b  # a * 1.2 > 4 * b
         assert c * 3 * 1.2 > d * 7
 
 
@@ -91,11 +93,7 @@ class TestSimpleFMin(unittest.TestCase):
     #
 
     def setUp(self):
-        self.space = hp.pchoice('a', [
-            (.1, 0),
-            (.2, 1),
-            (.3, 2),
-            (.4, 3)])
+        self.space = hp.pchoice("a", [(0.1, 0), (0.2, 1), (0.3, 2), (0.4, 3)])
         self.trials = Trials()
 
     def objective(self, a):
@@ -106,76 +104,82 @@ class TestSimpleFMin(unittest.TestCase):
         # (a) accepted by tpe.suggest and
         # (b) handled correctly.
         N = 150
-        fmin(self.objective,
-             space=self.space,
-             trials=self.trials,
-             algo=rand.suggest,
-             max_evals=N)
+        fmin(
+            self.objective,
+            space=self.space,
+            trials=self.trials,
+            algo=rand.suggest,
+            max_evals=N,
+        )
 
-        a_vals = [t['misc']['vals']['a'][0] for t in self.trials.trials]
+        a_vals = [t["misc"]["vals"]["a"][0] for t in self.trials.trials]
         counts = np.bincount(a_vals)
         print(counts)
-        assert counts[3] > N * .35
-        assert counts[3] < N * .60
+        assert counts[3] > N * 0.35
+        assert counts[3] < N * 0.60
 
     def test_tpe(self):
         N = 100
-        fmin(self.objective,
-             space=self.space,
-             trials=self.trials,
-             algo=partial(tpe.suggest, n_startup_jobs=10),
-             max_evals=N)
+        fmin(
+            self.objective,
+            space=self.space,
+            trials=self.trials,
+            algo=partial(tpe.suggest, n_startup_jobs=10),
+            max_evals=N,
+        )
 
-        a_vals = [t['misc']['vals']['a'][0] for t in self.trials.trials]
+        a_vals = [t["misc"]["vals"]["a"][0] for t in self.trials.trials]
         counts = np.bincount(a_vals)
         print(counts)
-        assert counts[3] > N * .6
+        assert counts[3] > N * 0.6
 
     def test_anneal(self):
         N = 100
-        fmin(self.objective,
-             space=self.space,
-             trials=self.trials,
-             algo=partial(anneal.suggest),
-             max_evals=N)
+        fmin(
+            self.objective,
+            space=self.space,
+            trials=self.trials,
+            algo=partial(anneal.suggest),
+            max_evals=N,
+        )
 
-        a_vals = [t['misc']['vals']['a'][0] for t in self.trials.trials]
+        a_vals = [t["misc"]["vals"]["a"][0] for t in self.trials.trials]
         counts = np.bincount(a_vals)
         print(counts)
-        assert counts[3] > N * .6
+        assert counts[3] > N * 0.6
 
 
 def test_bug1_rand():
-    space = hp.choice('preprocess_choice', [
-        {'pwhiten': hp.pchoice('whiten_randomPCA',
-                               [(.3, False), (.7, True)])},
-        {'palgo': False},
-        {'pthree': 7}])
-    fmin(fn=lambda x: 1,
-         space=space,
-         algo=rand.suggest,
-         max_evals=50)
+    space = hp.choice(
+        "preprocess_choice",
+        [
+            {"pwhiten": hp.pchoice("whiten_randomPCA", [(0.3, False), (0.7, True)])},
+            {"palgo": False},
+            {"pthree": 7},
+        ],
+    )
+    fmin(fn=lambda x: 1, space=space, algo=rand.suggest, max_evals=50)
 
 
 def test_bug1_tpe():
-    space = hp.choice('preprocess_choice', [
-        {'pwhiten': hp.pchoice('whiten_randomPCA',
-                               [(.3, False), (.7, True)])},
-        {'palgo': False},
-        {'pthree': 7}])
-    fmin(fn=lambda x: 1,
-         space=space,
-         algo=tpe.suggest,
-         max_evals=50)
+    space = hp.choice(
+        "preprocess_choice",
+        [
+            {"pwhiten": hp.pchoice("whiten_randomPCA", [(0.3, False), (0.7, True)])},
+            {"palgo": False},
+            {"pthree": 7},
+        ],
+    )
+    fmin(fn=lambda x: 1, space=space, algo=tpe.suggest, max_evals=50)
 
 
 def test_bug1_anneal():
-    space = hp.choice('preprocess_choice', [
-        {'pwhiten': hp.pchoice('whiten_randomPCA',
-                               [(.3, False), (.7, True)])},
-        {'palgo': False},
-        {'pthree': 7}])
-    fmin(fn=lambda x: 1,
-         space=space,
-         algo=anneal.suggest,
-         max_evals=50)
+    space = hp.choice(
+        "preprocess_choice",
+        [
+            {"pwhiten": hp.pchoice("whiten_randomPCA", [(0.3, False), (0.7, True)])},
+            {"palgo": False},
+            {"pthree": 7},
+        ],
+    )
+    fmin(fn=lambda x: 1, space=space, algo=anneal.suggest, max_evals=50)

--- a/hyperopt/tests/test_plotting.py
+++ b/hyperopt/tests/test_plotting.py
@@ -12,9 +12,11 @@ import os
 
 try:
     import matplotlib
-    matplotlib.use('svg')  # -- prevents trying to connect to X server
+
+    matplotlib.use("svg")  # -- prevents trying to connect to X server
 except ImportError:
     import nose
+
     raise nose.SkipTest()
 
 from hyperopt import Trials
@@ -24,34 +26,30 @@ from .test_domains import many_dists
 
 
 def get_do_show():
-    rval = int(os.getenv('HYPEROPT_SHOW', '0'))
-    print('do_show =', rval)
+    rval = int(os.getenv("HYPEROPT_SHOW", "0"))
+    print("do_show =", rval)
     return rval
 
 
 class TestPlotting(unittest.TestCase):
-
     def setUp(self):
         domain = self.domain = many_dists()
         trials = self.trials = Trials()
-        fmin(lambda x: x,
-             space=domain.expr,
-             trials=trials,
-             algo=rand.suggest,
-             max_evals=200)
+        fmin(
+            lambda x: x,
+            space=domain.expr,
+            trials=trials,
+            algo=rand.suggest,
+            max_evals=200,
+        )
 
     def test_plot_history(self):
-        hyperopt.plotting.main_plot_history(
-            self.trials,
-            do_show=get_do_show())
+        hyperopt.plotting.main_plot_history(self.trials, do_show=get_do_show())
 
     def test_plot_histogram(self):
-        hyperopt.plotting.main_plot_histogram(
-            self.trials,
-            do_show=get_do_show())
+        hyperopt.plotting.main_plot_histogram(self.trials, do_show=get_do_show())
 
     def test_plot_vars(self):
         hyperopt.plotting.main_plot_vars(
-            self.trials,
-            self.domain,
-            do_show=get_do_show())
+            self.trials, self.domain, do_show=get_do_show()
+        )

--- a/hyperopt/tests/test_pyll_utils.py
+++ b/hyperopt/tests/test_pyll_utils.py
@@ -8,14 +8,19 @@ from hyperopt.pyll import as_apply
 
 def test_expr_to_config():
 
-    z = hp.randint('z', 10)
-    a = hp.choice('a',
-                  [
-                      hp.uniform('b', -1, 1) + z,
-                      {'c': 1, 'd': hp.choice('d',
-                                              [3 + hp.loguniform('c', 0, 1),
-                                               1 + hp.loguniform('e', 0, 1)])
-                       }])
+    z = hp.randint("z", 10)
+    a = hp.choice(
+        "a",
+        [
+            hp.uniform("b", -1, 1) + z,
+            {
+                "c": 1,
+                "d": hp.choice(
+                    "d", [3 + hp.loguniform("c", 0, 1), 1 + hp.loguniform("e", 0, 1)]
+                ),
+            },
+        ],
+    )
 
     expr = as_apply((a, z))
 
@@ -24,56 +29,54 @@ def test_expr_to_config():
 
     for label, dct in list(hps.items()):
         print(label)
-        print('  dist: %s(%s)' % (
-            dct['node'].name,
-            ', '.join(map(str, [ii.eval() for ii in dct['node'].inputs()]))))
-        if len(dct['conditions']) > 1:
-            print('  conditions (OR):')
-            for condseq in dct['conditions']:
-                print('    ', ' AND '.join(map(str, condseq)))
-        elif dct['conditions']:
-            for condseq in dct['conditions']:
-                print('  conditions :', ' AND '.join(map(str, condseq)))
+        print(
+            "  dist: %s(%s)"
+            % (
+                dct["node"].name,
+                ", ".join(map(str, [ii.eval() for ii in dct["node"].inputs()])),
+            )
+        )
+        if len(dct["conditions"]) > 1:
+            print("  conditions (OR):")
+            for condseq in dct["conditions"]:
+                print("    ", " AND ".join(map(str, condseq)))
+        elif dct["conditions"]:
+            for condseq in dct["conditions"]:
+                print("  conditions :", " AND ".join(map(str, condseq)))
 
-    assert hps['a']['node'].name == 'randint'
-    assert hps['b']['node'].name == 'uniform'
-    assert hps['c']['node'].name == 'loguniform'
-    assert hps['d']['node'].name == 'randint'
-    assert hps['e']['node'].name == 'loguniform'
-    assert hps['z']['node'].name == 'randint'
+    assert hps["a"]["node"].name == "randint"
+    assert hps["b"]["node"].name == "uniform"
+    assert hps["c"]["node"].name == "loguniform"
+    assert hps["d"]["node"].name == "randint"
+    assert hps["e"]["node"].name == "loguniform"
+    assert hps["z"]["node"].name == "randint"
 
-    assert set([(True, EQ('a', 0))]) == set([(True, EQ('a', 0))])
-    assert hps['a']['conditions'] == set([(True,)])
-    assert hps['b']['conditions'] == set([
-        (True, EQ('a', 0))]), hps['b']['conditions']
-    assert hps['c']['conditions'] == set([
-        (True, EQ('a', 1), EQ('d', 0))])
-    assert hps['d']['conditions'] == set([
-        (True, EQ('a', 1))])
-    assert hps['e']['conditions'] == set([
-        (True, EQ('a', 1), EQ('d', 1))])
-    assert hps['z']['conditions'] == set([
-        (True,),
-        (True, EQ('a', 0))])
+    assert set([(True, EQ("a", 0))]) == set([(True, EQ("a", 0))])
+    assert hps["a"]["conditions"] == set([(True,)])
+    assert hps["b"]["conditions"] == set([(True, EQ("a", 0))]), hps["b"]["conditions"]
+    assert hps["c"]["conditions"] == set([(True, EQ("a", 1), EQ("d", 0))])
+    assert hps["d"]["conditions"] == set([(True, EQ("a", 1))])
+    assert hps["e"]["conditions"] == set([(True, EQ("a", 1), EQ("d", 1))])
+    assert hps["z"]["conditions"] == set([(True,), (True, EQ("a", 0))])
 
 
 def test_remove_allpaths():
-    z = hp.uniform('z', 0, 10)
-    a = hp.choice('a', [z + 1, z - 1])
+    z = hp.uniform("z", 0, 10)
+    a = hp.choice("a", [z + 1, z - 1])
     hps = {}
     expr_to_config(a, (True,), hps)
-    aconds = hps['a']['conditions']
-    zconds = hps['z']['conditions']
+    aconds = hps["a"]["conditions"]
+    zconds = hps["z"]["conditions"]
     assert aconds == set([(True,)]), aconds
     assert zconds == set([(True,)]), zconds
 
 
 def test_remove_allpaths_int():
-    z = hp.uniformint('z', 0, 10)
-    a = hp.choice('a', [ z + 1, z - 1])
+    z = hp.uniformint("z", 0, 10)
+    a = hp.choice("a", [z + 1, z - 1])
     hps = {}
     expr_to_config(a, (True,), hps)
-    aconds = hps['a']['conditions']
-    zconds = hps['z']['conditions']
+    aconds = hps["a"]["conditions"]
+    zconds = hps["z"]["conditions"]
     assert aconds == set([(True,)]), aconds
     assert zconds == set([(True,)]), zconds

--- a/hyperopt/tests/test_rand.py
+++ b/hyperopt/tests/test_rand.py
@@ -6,11 +6,10 @@ from hyperopt import rand
 from hyperopt.tests.test_base import Suggest_API
 from .test_domains import gauss_wave2, coin_flip
 
-TestRand = Suggest_API.make_tst_class(rand.suggest, gauss_wave2(), 'TestRand')
+TestRand = Suggest_API.make_tst_class(rand.suggest, gauss_wave2(), "TestRand")
 
 
 class TestRand(unittest.TestCase):
-
     def test_seeding(self):
         # -- assert that the seeding works a particular way
 
@@ -20,8 +19,8 @@ class TestRand(unittest.TestCase):
         idxs, vals = miscs_to_idxs_vals(trials.miscs)
 
         # Passes Nov 8 / 2013
-        self.assertEqual(list(idxs['flip']), list(range(10)))
-        self.assertEqual(list(vals['flip']), [0, 1, 0, 0, 0, 0, 0, 1, 1, 0])
+        self.assertEqual(list(idxs["flip"]), list(range(10)))
+        self.assertEqual(list(vals["flip"]), [0, 1, 0, 0, 0, 0, 0, 1, 1, 0])
 
     # -- TODO: put in a test that guarantees that
     #          stochastic nodes are sampled in a paricular order.

--- a/hyperopt/tests/test_rdists.py
+++ b/hyperopt/tests/test_rdists.py
@@ -14,6 +14,7 @@ from hyperopt.rdists import (
     qlognormal_gen,
 )
 from scipy import stats
+
 try:
     from scipy.stats.tests.test_continuous_basic import (
         check_cdf_logcdf,
@@ -23,7 +24,7 @@ try:
     )
 except ImportError:
     # XXX skip-tests instead or fix the import error, why would it fail?
-    
+
     # -- This is failing because of a bug in the scipy.tests.test_continuous import.
     # https://github.com/scipy/scipy/commit/c05c6b73a0cd16c4cc12a23e7ad72742dfeb42f1 will fix it with scipy 1.2.0
 
@@ -41,22 +42,21 @@ except ImportError:
 
 
 class TestLogUniform(unittest.TestCase):
-
     def test_cdf_logcdf(self):
-        check_cdf_logcdf(loguniform_gen(0, 1), (0, 1), '')
-        check_cdf_logcdf(loguniform_gen(0, 1), (-5, 5), '')
+        check_cdf_logcdf(loguniform_gen(0, 1), (0, 1), "")
+        check_cdf_logcdf(loguniform_gen(0, 1), (-5, 5), "")
 
     def test_cdf_ppf(self):
-        check_cdf_ppf(loguniform_gen(0, 1), (0, 1), '')
-        check_cdf_ppf(loguniform_gen(-2, 1), (-5, 5), '')
+        check_cdf_ppf(loguniform_gen(0, 1), (0, 1), "")
+        check_cdf_ppf(loguniform_gen(-2, 1), (-5, 5), "")
 
     def test_pdf_logpdf(self):
-        check_pdf_logpdf(loguniform_gen(0, 1), (0, 1), '')
-        check_pdf_logpdf(loguniform_gen(low=-4, high=-0.5), (-2, 1), '')
+        check_pdf_logpdf(loguniform_gen(0, 1), (0, 1), "")
+        check_pdf_logpdf(loguniform_gen(low=-4, high=-0.5), (-2, 1), "")
 
     def test_pdf(self):
-        check_pdf(loguniform_gen(0, 1), (0, 1), '')
-        check_pdf(loguniform_gen(low=-4, high=-2), (-3, 2), '')
+        check_pdf(loguniform_gen(0, 1), (0, 1), "")
+        check_pdf(loguniform_gen(low=-4, high=-2), (-3, 2), "")
 
     def test_distribution_rvs(self):
         alpha = 0.01
@@ -65,44 +65,45 @@ class TestLogUniform(unittest.TestCase):
         arg = (loc, scale)
         distfn = loguniform_gen(0, 1)
         D, pval = stats.kstest(distfn.rvs, distfn.cdf, args=arg, N=1000)
-        if (pval < alpha):
-            npt.assert_(pval > alpha,
-                        "D = %f; pval = %f; alpha = %f; args=%s" % (
-                            D, pval, alpha, arg))
+        if pval < alpha:
+            npt.assert_(
+                pval > alpha,
+                "D = %f; pval = %f; alpha = %f; args=%s" % (D, pval, alpha, arg),
+            )
 
 
 class TestLogNormal(unittest.TestCase):
-
     def test_cdf_logcdf(self):
-        check_cdf_logcdf(lognorm_gen(0, 1), (), '')
-        check_cdf_logcdf(lognorm_gen(0, 1), (), '')
+        check_cdf_logcdf(lognorm_gen(0, 1), (), "")
+        check_cdf_logcdf(lognorm_gen(0, 1), (), "")
 
     def test_cdf_ppf(self):
-        check_cdf_ppf(lognorm_gen(0, 1), (), '')
-        check_cdf_ppf(lognorm_gen(-2, 1), (), '')
+        check_cdf_ppf(lognorm_gen(0, 1), (), "")
+        check_cdf_ppf(lognorm_gen(-2, 1), (), "")
 
     def test_pdf_logpdf(self):
-        check_pdf_logpdf(lognorm_gen(0, 1), args=(),
-                         msg='base case')
-        check_pdf_logpdf(lognorm_gen(mu=-4, sigma=0.5), args=(),
-                         msg='non-default mu, sigma')
+        check_pdf_logpdf(lognorm_gen(0, 1), args=(), msg="base case")
+        check_pdf_logpdf(
+            lognorm_gen(mu=-4, sigma=0.5), args=(), msg="non-default mu, sigma"
+        )
 
     def test_pdf(self):
-        check_pdf(lognorm_gen(0, 1), (), '')
-        check_pdf(lognorm_gen(mu=-4, sigma=2), (), '')
+        check_pdf(lognorm_gen(0, 1), (), "")
+        check_pdf(lognorm_gen(mu=-4, sigma=2), (), "")
 
     def test_distribution_rvs(self):
-        return # XXX
+        return  # XXX
         alpha = 0.01
         loc = 0
         scale = 1
         arg = (loc, scale)
         distfn = lognorm_gen(0, 1)
         D, pval = stats.kstest(distfn.rvs, distfn.cdf, args=arg, N=1000)
-        if (pval < alpha):
-            npt.assert_(pval > alpha,
-                        "D = %f; pval = %f; alpha = %f; args=%s" % (
-                            D, pval, alpha, arg))
+        if pval < alpha:
+            npt.assert_(
+                pval > alpha,
+                "D = %f; pval = %f; alpha = %f; args=%s" % (D, pval, alpha, arg),
+            )
 
 
 def check_d_samples(dfn, n, rtol=1e-2, atol=1e-2):
@@ -114,20 +115,16 @@ def check_d_samples(dfn, n, rtol=1e-2, atol=1e-2):
     for ii, p in sorted(counts.items()):
         t = np.allclose(dfn.pmf(ii), p, rtol=rtol, atol=atol)
         if not t:
-            print(('Error in sampling frequencies', ii))
-            print('value\tpmf\tfreq')
+            print(("Error in sampling frequencies", ii))
+            print("value\tpmf\tfreq")
             for jj in sorted(counts):
-                print(('%.2f\t%.3f\t%.4f' % (
-                    jj, dfn.pmf(jj), counts[jj])))
-            npt.assert_(t,
-                        "n = %i; pmf = %f; p = %f" % (
-                            n, dfn.pmf(ii), p))
+                print(("%.2f\t%.3f\t%.4f" % (jj, dfn.pmf(jj), counts[jj])))
+            npt.assert_(t, "n = %i; pmf = %f; p = %f" % (n, dfn.pmf(ii), p))
 
 
 class TestQUniform(unittest.TestCase):
-
     def test_smallq(self):
-        low, high, q = (0, 1, .1)
+        low, high, q = (0, 1, 0.1)
         qu = quniform_gen(low, high, q)
         check_d_samples(qu, n=10000)
 
@@ -145,15 +142,15 @@ class TestQUniform(unittest.TestCase):
         assert qn.pmf(-1) == 0.0
 
     def test_offgrid_float(self):
-        qn = quniform_gen(0, 1, .2)
+        qn = quniform_gen(0, 1, 0.2)
         assert qn.pmf(0) > 0.0
-        assert qn.pmf(.1) == 0.0
-        assert qn.pmf(.2) > 0.0
-        assert qn.pmf(.4) > 0.0
-        assert qn.pmf(.8) > 0.0
-        assert qn.pmf(-.2) == 0.0
-        assert qn.pmf(.99) == 0.0
-        assert qn.pmf(-.99) == 0.0
+        assert qn.pmf(0.1) == 0.0
+        assert qn.pmf(0.2) > 0.0
+        assert qn.pmf(0.4) > 0.0
+        assert qn.pmf(0.8) > 0.0
+        assert qn.pmf(-0.2) == 0.0
+        assert qn.pmf(0.99) == 0.0
+        assert qn.pmf(-0.99) == 0.0
 
     def test_output_type_int(self):
         result = quniform_gen(0, 10, 1).rvs()
@@ -164,12 +161,11 @@ class TestQUniform(unittest.TestCase):
 
 
 class TestQLogUniform(unittest.TestCase):
-
     def logp(self, x, low, high, q):
         return qloguniform_gen(low, high, q).logpmf(x)
 
     def test_smallq(self):
-        low, high, q = (0, 1, .1)
+        low, high, q = (0, 1, 0.1)
         qlu = qloguniform_gen(low, high, q)
         check_d_samples(qlu, n=10000)
 
@@ -179,35 +175,42 @@ class TestQLogUniform(unittest.TestCase):
         check_d_samples(qlu, n=10000)
 
     def test_point(self):
-        low, high, q = (np.log(.05), np.log(.15), 0.5)
+        low, high, q = (np.log(0.05), np.log(0.15), 0.5)
         qlu = qloguniform_gen(low, high, q)
         check_d_samples(qlu, n=10000)
 
     def test_2points(self):
-        low, high, q = (np.log(.05), np.log(.75), 0.5)
+        low, high, q = (np.log(0.05), np.log(0.75), 0.5)
         qlu = qloguniform_gen(low, high, q)
         check_d_samples(qlu, n=10000)
 
     def test_point_logpmf(self):
-        assert np.allclose(self.logp(0, np.log(.25), np.log(.5), 1), 0.0)
+        assert np.allclose(self.logp(0, np.log(0.25), np.log(0.5), 1), 0.0)
 
     def test_rounding_logpmf(self):
-        assert (self.logp(0, np.log(.25), np.log(.75), 1) >
-                self.logp(1, np.log(.25), np.log(.75), 1))
-        assert (self.logp(-1, np.log(.25), np.log(.75), 1) ==
-                self.logp(2, np.log(.25), np.log(.75), 1) ==
-                -np.inf)
+        assert self.logp(0, np.log(0.25), np.log(0.75), 1) > self.logp(
+            1, np.log(0.25), np.log(0.75), 1
+        )
+        assert (
+            self.logp(-1, np.log(0.25), np.log(0.75), 1)
+            == self.logp(2, np.log(0.25), np.log(0.75), 1)
+            == -np.inf
+        )
 
     def test_smallq_logpmf(self):
-        assert (self.logp(0.2, np.log(.16), np.log(.55), .1) >
-                self.logp(0.3, np.log(.16), np.log(.55), .1) >
-                self.logp(0.4, np.log(.16), np.log(.55), .1) >
-                self.logp(0.5, np.log(.16), np.log(.55), .1) >
-                -10)
+        assert (
+            self.logp(0.2, np.log(0.16), np.log(0.55), 0.1)
+            > self.logp(0.3, np.log(0.16), np.log(0.55), 0.1)
+            > self.logp(0.4, np.log(0.16), np.log(0.55), 0.1)
+            > self.logp(0.5, np.log(0.16), np.log(0.55), 0.1)
+            > -10
+        )
 
-        assert (self.logp(0.1, np.log(.16), np.log(.55), 1) ==
-                self.logp(0.6, np.log(.16), np.log(.55), 1) ==
-                -np.inf)
+        assert (
+            self.logp(0.1, np.log(0.16), np.log(0.55), 1)
+            == self.logp(0.6, np.log(0.16), np.log(0.55), 1)
+            == -np.inf
+        )
 
     def test_output_type_int(self):
         result = qloguniform_gen(0, 10, 1).rvs()
@@ -218,9 +221,8 @@ class TestQLogUniform(unittest.TestCase):
 
 
 class TestQNormal(unittest.TestCase):
-
     def test_smallq(self):
-        mu, sigma, q = (0, 1, .1)
+        mu, sigma, q = (0, 1, 0.1)
         qn = qnormal_gen(mu, sigma, q)
         check_d_samples(qn, n=10000)
 
@@ -236,15 +238,15 @@ class TestQNormal(unittest.TestCase):
         assert qn.pmf(2) > 0.0
 
     def test_offgrid_float(self):
-        qn = qnormal_gen(0, 1, .2)
+        qn = qnormal_gen(0, 1, 0.2)
         assert qn.pmf(0) > 0.0
-        assert qn.pmf(.1) == 0.0
-        assert qn.pmf(.2) > 0.0
-        assert qn.pmf(.4) > 0.0
-        assert qn.pmf(-.2) > 0.0
-        assert qn.pmf(-.4) > 0.0
-        assert qn.pmf(.99) == 0.0
-        assert qn.pmf(-.99) == 0.0
+        assert qn.pmf(0.1) == 0.0
+        assert qn.pmf(0.2) > 0.0
+        assert qn.pmf(0.4) > 0.0
+        assert qn.pmf(-0.2) > 0.0
+        assert qn.pmf(-0.4) > 0.0
+        assert qn.pmf(0.99) == 0.0
+        assert qn.pmf(-0.99) == 0.0
 
     def test_numeric(self):
         qn = qnormal_gen(0, 1, 1)
@@ -259,9 +261,8 @@ class TestQNormal(unittest.TestCase):
 
 
 class TestQLogNormal(unittest.TestCase):
-
     def test_smallq(self):
-        mu, sigma, q = (0, 1, .1)
+        mu, sigma, q = (0, 1, 0.1)
         qn = qlognormal_gen(mu, sigma, q)
         check_d_samples(qn, n=10000)
 
@@ -274,13 +275,13 @@ class TestQLogNormal(unittest.TestCase):
         mu, sigma, q = (1, 2, 2)
         qn = qlognormal_gen(mu, sigma, q)
         assert qn.pmf(0) > qn.pmf(2) > qn.pmf(20) > 0
-        assert qn.pmf(1) == qn.pmf(2 - .001) == qn.pmf(-1) == 0
+        assert qn.pmf(1) == qn.pmf(2 - 0.001) == qn.pmf(-1) == 0
 
     def test_offgrid_float(self):
-        mu, sigma, q = (-.5, 2, .2)
+        mu, sigma, q = (-0.5, 2, 0.2)
         qn = qlognormal_gen(mu, sigma, q)
-        assert qn.pmf(0) > qn.pmf(.2) > qn.pmf(2) > 0
-        assert qn.pmf(.1) == qn.pmf(.2 - .001) == qn.pmf(-.2) == 0
+        assert qn.pmf(0) > qn.pmf(0.2) > qn.pmf(2) > 0
+        assert qn.pmf(0.1) == qn.pmf(0.2 - 0.001) == qn.pmf(-0.2) == 0
 
     def test_numeric(self):
         # XXX we don't have a numerically accurate computation for this guy
@@ -295,5 +296,6 @@ class TestQLogNormal(unittest.TestCase):
 
     def test_output_type_float(self):
         assert float == type(qlognormal_gen(0, 10, 1.0).rvs())
+
 
 # -- non-empty last line for flake8

--- a/hyperopt/tests/test_tpe.py
+++ b/hyperopt/tests/test_tpe.py
@@ -13,6 +13,7 @@ import unittest
 import nose
 
 import numpy as np
+
 try:
     import matplotlib.pyplot as plt
 except ImportError:
@@ -38,11 +39,9 @@ import hyperopt.tpe as tpe
 import hyperopt.atpe as atpe
 from hyperopt import fmin
 
-from .test_domains import (
-    domain_constructor,
-    CasePerDomain, NonCategoricalCasePerDomain)
+from .test_domains import domain_constructor, CasePerDomain, NonCategoricalCasePerDomain
 
-DO_SHOW = int(os.getenv('HYPEROPT_SHOW', '0'))
+DO_SHOW = int(os.getenv("HYPEROPT_SHOW", "0"))
 
 
 def passthrough(x):
@@ -57,7 +56,8 @@ def test_adaptive_parzen_normal_orig():
     mus = rng.randn(10) + 5
 
     weights2, mus2, sigmas2 = adaptive_parzen_normal_orig(
-        mus, 3.3, prior_mu, prior_sigma)
+        mus, 3.3, prior_mu, prior_sigma
+    )
 
     print(weights2)
     print(mus2)
@@ -71,125 +71,143 @@ def test_adaptive_parzen_normal_orig():
 
 
 class TestGMM1(unittest.TestCase):
-
     def setUp(self):
         self.rng = np.random.RandomState(234)
 
     def test_mu_is_used_correctly(self):
-        assert np.allclose(10,
-                           GMM1([1], [10.0], [0.0000001], rng=self.rng))
+        assert np.allclose(10, GMM1([1], [10.0], [0.0000001], rng=self.rng))
 
     def test_sigma_is_used_correctly(self):
         samples = GMM1([1], [0.0], [10.0], size=[1000], rng=self.rng)
         assert 9 < np.std(samples) < 11
 
     def test_mus_make_variance(self):
-        samples = GMM1([.5, .5], [0.0, 1.0], [0.000001, 0.000001],
-                       rng=self.rng, size=[1000])
+        samples = GMM1(
+            [0.5, 0.5], [0.0, 1.0], [0.000001, 0.000001], rng=self.rng, size=[1000]
+        )
         print(samples.shape)
         # import matplotlib.pyplot as plt
         # plt.hist(samples)
         # plt.show()
-        assert .45 < np.mean(samples) < .55, np.mean(samples)
-        assert .2 < np.var(samples) < .3, np.var(samples)
+        assert 0.45 < np.mean(samples) < 0.55, np.mean(samples)
+        assert 0.2 < np.var(samples) < 0.3, np.var(samples)
 
     def test_weights(self):
-        samples = GMM1([.9999, .0001], [0.0, 1.0], [0.000001, 0.000001],
-                       rng=self.rng,
-                       size=[1000])
+        samples = GMM1(
+            [0.9999, 0.0001],
+            [0.0, 1.0],
+            [0.000001, 0.000001],
+            rng=self.rng,
+            size=[1000],
+        )
         assert samples.shape == (1000,)
         # import matplotlib.pyplot as plt
         # plt.hist(samples)
         # plt.show()
-        assert -.001 < np.mean(samples) < .001, np.mean(samples)
-        assert np.var(samples) < .0001, np.var(samples)
+        assert -0.001 < np.mean(samples) < 0.001, np.mean(samples)
+        assert np.var(samples) < 0.0001, np.var(samples)
 
     def test_mat_output(self):
-        samples = GMM1([.9999, .0001], [0.0, 1.0], [0.000001, 0.000001],
-                       rng=self.rng,
-                       size=[40, 20])
+        samples = GMM1(
+            [0.9999, 0.0001],
+            [0.0, 1.0],
+            [0.000001, 0.000001],
+            rng=self.rng,
+            size=[40, 20],
+        )
         assert samples.shape == (40, 20)
-        assert -.001 < np.mean(samples) < .001, np.mean(samples)
-        assert np.var(samples) < .0001, np.var(samples)
+        assert -0.001 < np.mean(samples) < 0.001, np.mean(samples)
+        assert np.var(samples) < 0.0001, np.var(samples)
 
     def test_lpdf_scalar_one_component(self):
-        llval = GMM1_lpdf(1.0,  # x
-                          [1.],           # weights
-                          [1.0],          # mu
-                          [2.0],          # sigma
-                          )
+        llval = GMM1_lpdf(1.0, [1.0], [1.0], [2.0])  # x  # weights  # mu  # sigma
         assert llval.shape == ()
-        assert np.allclose(llval,
-                           np.log(old_div(1.0, np.sqrt(2 * np.pi * 2.0 ** 2))))
+        assert np.allclose(llval, np.log(old_div(1.0, np.sqrt(2 * np.pi * 2.0 ** 2))))
 
     def test_lpdf_scalar_N_components(self):
-        llval = GMM1_lpdf(1.0,     # x
-                          [0.25, 0.25, .5],  # weights
-                          [0.0, 1.0, 2.0],   # mu
-                          [1.0, 2.0, 5.0],   # sigma
-                          )
+        llval = GMM1_lpdf(
+            1.0,  # x
+            [0.25, 0.25, 0.5],  # weights
+            [0.0, 1.0, 2.0],  # mu
+            [1.0, 2.0, 5.0],  # sigma
+        )
         print(llval)
 
-        a = (.25 / np.sqrt(2 * np.pi * 1.0 ** 2) *
-             np.exp(-.5 * (1.0) ** 2))
-        a += (old_div(.25, np.sqrt(2 * np.pi * 2.0 ** 2)))
-        a += (.5 / np.sqrt(2 * np.pi * 5.0 ** 2) *
-              np.exp(-.5 * (old_div(1.0, 5.0)) ** 2))
+        a = 0.25 / np.sqrt(2 * np.pi * 1.0 ** 2) * np.exp(-0.5 * (1.0) ** 2)
+        a += old_div(0.25, np.sqrt(2 * np.pi * 2.0 ** 2))
+        a += (
+            0.5
+            / np.sqrt(2 * np.pi * 5.0 ** 2)
+            * np.exp(-0.5 * (old_div(1.0, 5.0)) ** 2)
+        )
 
     def test_lpdf_vector_N_components(self):
-        llval = GMM1_lpdf([1.0, 0.0],     # x
-                          [0.25, 0.25, .5],         # weights
-                          [0.0, 1.0, 2.0],          # mu
-                          [1.0, 2.0, 5.0],          # sigma
-                          )
+        llval = GMM1_lpdf(
+            [1.0, 0.0],  # x
+            [0.25, 0.25, 0.5],  # weights
+            [0.0, 1.0, 2.0],  # mu
+            [1.0, 2.0, 5.0],  # sigma
+        )
 
         # case x = 1.0
-        a = (.25 / np.sqrt(2 * np.pi * 1.0 ** 2) *
-             np.exp(-.5 * (1.0) ** 2))
-        a += (old_div(.25, np.sqrt(2 * np.pi * 2.0 ** 2)))
-        a += (.5 / np.sqrt(2 * np.pi * 5.0 ** 2) *
-              np.exp(-.5 * (old_div(1.0, 5.0)) ** 2))
+        a = 0.25 / np.sqrt(2 * np.pi * 1.0 ** 2) * np.exp(-0.5 * (1.0) ** 2)
+        a += old_div(0.25, np.sqrt(2 * np.pi * 2.0 ** 2))
+        a += (
+            0.5
+            / np.sqrt(2 * np.pi * 5.0 ** 2)
+            * np.exp(-0.5 * (old_div(1.0, 5.0)) ** 2)
+        )
 
         assert llval.shape == (2,)
         assert np.allclose(llval[0], np.log(a))
 
         # case x = 0.0
-        a = (old_div(.25, np.sqrt(2 * np.pi * 1.0 ** 2)))
-        a += (.25 / np.sqrt(2 * np.pi * 2.0 ** 2) *
-              np.exp(-.5 * (old_div(1.0, 2.0)) ** 2))
-        a += (.5 / np.sqrt(2 * np.pi * 5.0 ** 2) *
-              np.exp(-.5 * (old_div(2.0, 5.0)) ** 2))
+        a = old_div(0.25, np.sqrt(2 * np.pi * 1.0 ** 2))
+        a += (
+            0.25
+            / np.sqrt(2 * np.pi * 2.0 ** 2)
+            * np.exp(-0.5 * (old_div(1.0, 2.0)) ** 2)
+        )
+        a += (
+            0.5
+            / np.sqrt(2 * np.pi * 5.0 ** 2)
+            * np.exp(-0.5 * (old_div(2.0, 5.0)) ** 2)
+        )
         assert np.allclose(llval[1], np.log(a))
 
     def test_lpdf_matrix_N_components(self):
         llval = GMM1_lpdf(
-            [
-                [1.0, 0.0, 0.0],
-                [0, 0, 1],
-                [0, 0, 1000],
-            ],
-            [0.25, 0.25, .5],  # weights
-            [0.0, 1.0, 2.0],   # mu
-            [1.0, 2.0, 5.0],   # sigma
+            [[1.0, 0.0, 0.0], [0, 0, 1], [0, 0, 1000]],
+            [0.25, 0.25, 0.5],  # weights
+            [0.0, 1.0, 2.0],  # mu
+            [1.0, 2.0, 5.0],  # sigma
         )
         print(llval)
         assert llval.shape == (3, 3)
 
-        a = (.25 / np.sqrt(2 * np.pi * 1.0 ** 2) *
-             np.exp(-.5 * (1.0) ** 2))
-        a += (old_div(.25, np.sqrt(2 * np.pi * 2.0 ** 2)))
-        a += (.5 / np.sqrt(2 * np.pi * 5.0 ** 2) *
-              np.exp(-.5 * (old_div(1.0, 5.0)) ** 2))
+        a = 0.25 / np.sqrt(2 * np.pi * 1.0 ** 2) * np.exp(-0.5 * (1.0) ** 2)
+        a += old_div(0.25, np.sqrt(2 * np.pi * 2.0 ** 2))
+        a += (
+            0.5
+            / np.sqrt(2 * np.pi * 5.0 ** 2)
+            * np.exp(-0.5 * (old_div(1.0, 5.0)) ** 2)
+        )
 
         assert np.allclose(llval[0, 0], np.log(a))
         assert np.allclose(llval[1, 2], np.log(a))
 
         # case x = 0.0
-        a = (old_div(.25, np.sqrt(2 * np.pi * 1.0 ** 2)))
-        a += (.25 / np.sqrt(2 * np.pi * 2.0 ** 2) *
-              np.exp(-.5 * (old_div(1.0, 2.0)) ** 2))
-        a += (.5 / np.sqrt(2 * np.pi * 5.0 ** 2) *
-              np.exp(-.5 * (old_div(2.0, 5.0)) ** 2))
+        a = old_div(0.25, np.sqrt(2 * np.pi * 1.0 ** 2))
+        a += (
+            0.25
+            / np.sqrt(2 * np.pi * 2.0 ** 2)
+            * np.exp(-0.5 * (old_div(1.0, 2.0)) ** 2)
+        )
+        a += (
+            0.5
+            / np.sqrt(2 * np.pi * 5.0 ** 2)
+            * np.exp(-0.5 * (old_div(2.0, 5.0)) ** 2)
+        )
 
         assert np.allclose(llval[0, 1], np.log(a))
         assert np.allclose(llval[0, 2], np.log(a))
@@ -202,12 +220,11 @@ class TestGMM1(unittest.TestCase):
 
 
 class TestGMM1Math(unittest.TestCase):
-
     def setUp(self):
         self.rng = np.random.RandomState(234)
-        self.weights = [.1, .3, .4, .2]
+        self.weights = [0.1, 0.3, 0.4, 0.2]
         self.mus = [1.0, 2.0, 3.0, 4.0]
-        self.sigmas = [.1, .4, .8, 2.0]
+        self.sigmas = [0.1, 0.4, 0.8, 2.0]
         self.q = None
         self.low = None
         self.high = None
@@ -230,11 +247,9 @@ class TestGMM1Math(unittest.TestCase):
             high=self.high,
             q=self.q,
         )
-        samples = GMM1(rng=self.rng,
-                       size=(self.n_samples,),
-                       **kwargs)
+        samples = GMM1(rng=self.rng, size=(self.n_samples,), **kwargs)
         samples = np.sort(samples)
-        edges = samples[::self.samples_per_bin]
+        edges = samples[:: self.samples_per_bin]
         # print samples
 
         pdf = np.exp(GMM1_lpdf(edges[:-1], **kwargs))
@@ -250,9 +265,9 @@ class TestGMM1Math(unittest.TestCase):
         print(np.mean(err))
         print(np.median(err))
         if not self.show:
-            assert np.max(err) < .1
-            assert np.mean(err) < .01
-            assert np.median(err) < .01
+            assert np.max(err) < 0.1
+            assert np.mean(err) < 0.01
+            assert np.median(err) < 0.01
 
     def test_basic(self):
         self.work()
@@ -264,12 +279,11 @@ class TestGMM1Math(unittest.TestCase):
 
 
 class TestQGMM1Math(unittest.TestCase):
-
     def setUp(self):
         self.rng = np.random.RandomState(234)
-        self.weights = [.1, .3, .4, .2]
+        self.weights = [0.1, 0.3, 0.4, 0.2]
         self.mus = [1.0, 2.0, 3.0, 4.0]
-        self.sigmas = [.1, .4, .8, 2.0]
+        self.sigmas = [0.1, 0.4, 0.8, 2.0]
         self.low = None
         self.high = None
         self.n_samples = 1001
@@ -292,13 +306,11 @@ class TestQGMM1Math(unittest.TestCase):
             high=self.high,
             q=self.q,
         )
-        samples = old_div(GMM1(rng=self.rng,
-                          size=(self.n_samples,),
-                          **gkwargs), self.q)
-        print('drew', len(samples), 'samples')
-        assert np.all(samples == samples.astype('int'))
+        samples = old_div(GMM1(rng=self.rng, size=(self.n_samples,), **gkwargs), self.q)
+        print("drew", len(samples), "samples")
+        assert np.all(samples == samples.astype("int"))
         min_max = int(samples.min()), int(samples.max())
-        counts = np.bincount(samples.astype('int') - min_max[0])
+        counts = np.bincount(samples.astype("int") - min_max[0])
 
         print(counts)
         xcoords = np.arange(min_max[0], min_max[1] + 1) * self.q
@@ -307,8 +319,8 @@ class TestQGMM1Math(unittest.TestCase):
         y = old_div(counts, float(self.n_samples))
 
         if self.show:
-            plt.scatter(xcoords, y, c='r', label='empirical')
-            plt.scatter(xcoords, prob, c='b', label='predicted')
+            plt.scatter(xcoords, y, c="r", label="empirical")
+            plt.scatter(xcoords, prob, c="b", label="predicted")
             plt.legend()
             plt.title(str(self.show))
             plt.show()
@@ -319,9 +331,9 @@ class TestQGMM1Math(unittest.TestCase):
         if self.show:
             raise nose.SkipTest()
         else:
-            assert np.max(err) < .1
-            assert np.mean(err) < .01
-            assert np.median(err) < .01
+            assert np.max(err) < 0.1
+            assert np.mean(err) < 0.01
+            assert np.median(err) < 0.01
 
     def test_basic_1(self):
         self.work(q=1)
@@ -347,8 +359,8 @@ class TestQGMM1Math(unittest.TestCase):
     def test_bounded_3(self):
         self.work(
             weights=[0.14285714, 0.28571429, 0.28571429, 0.28571429],
-            mus=[5.505, 7., 2., 10.],
-            sigmas=[8.99, 5., 8., 8.],
+            mus=[5.505, 7.0, 2.0, 10.0],
+            sigmas=[8.99, 5.0, 8.0, 8.0],
             q=1,
             low=1.01,
             high=10,
@@ -359,7 +371,7 @@ class TestQGMM1Math(unittest.TestCase):
     def test_bounded_3b(self):
         self.work(
             weights=[0.33333333, 0.66666667],
-            mus=[5.505, 5.],
+            mus=[5.505, 5.0],
             sigmas=[8.99, 5.19],
             q=1,
             low=1.01,
@@ -370,12 +382,11 @@ class TestQGMM1Math(unittest.TestCase):
 
 
 class TestLGMM1Math(unittest.TestCase):
-
     def setUp(self):
         self.rng = np.random.RandomState(234)
-        self.weights = [.1, .3, .4, .2]
+        self.weights = [0.1, 0.3, 0.4, 0.2]
         self.mus = [-2.0, 1.0, 0.0, 3.0]
-        self.sigmas = [.1, .4, .8, 2.0]
+        self.sigmas = [0.1, 0.4, 0.8, 2.0]
         self.low = None
         self.high = None
         self.n_samples = 10001
@@ -403,12 +414,10 @@ class TestLGMM1Math(unittest.TestCase):
     def work(self, **kwargs):
         self.__dict__.update(kwargs)
         self.worked = True
-        samples = LGMM1(rng=self.rng,
-                        size=(self.n_samples,),
-                        **self.LGMM1_kwargs)
+        samples = LGMM1(rng=self.rng, size=(self.n_samples,), **self.LGMM1_kwargs)
         samples = np.sort(samples)
-        edges = samples[::self.samples_per_bin]
-        centers = .5 * edges[:-1] + .5 * edges[1:]
+        edges = samples[:: self.samples_per_bin]
+        centers = 0.5 * edges[:-1] + 0.5 * edges[1:]
         print(edges)
 
         pdf = np.exp(LGMM1_lpdf(centers, **self.LGMM1_kwargs))
@@ -424,9 +433,9 @@ class TestLGMM1Math(unittest.TestCase):
         print(np.mean(err))
         print(np.median(err))
         if not self.show:
-            assert np.max(err) < .1
-            assert np.mean(err) < .01
-            assert np.median(err) < .01
+            assert np.max(err) < 0.1
+            assert np.mean(err) < 0.01
+            assert np.median(err) < 0.01
 
     def test_basic(self):
         self.work()
@@ -436,12 +445,11 @@ class TestLGMM1Math(unittest.TestCase):
 
 
 class TestQLGMM1Math(unittest.TestCase):
-
     def setUp(self):
         self.rng = np.random.RandomState(234)
-        self.weights = [.1, .3, .4, .2]
+        self.weights = [0.1, 0.3, 0.4, 0.2]
         self.mus = [-2, 0.0, -3.0, 1.0]
-        self.sigmas = [2.1, .4, .8, 2.1]
+        self.sigmas = [2.1, 0.4, 0.8, 2.1]
         self.low = None
         self.high = None
         self.n_samples = 1001
@@ -460,7 +468,8 @@ class TestQLGMM1Math(unittest.TestCase):
             sigmas=self.sigmas,
             low=self.low,
             high=self.high,
-            q=self.q)
+            q=self.q,
+        )
 
     def QLGMM1_lpdf(self, samples):
         return self.LGMM1(samples, **self.kwargs)
@@ -468,14 +477,14 @@ class TestQLGMM1Math(unittest.TestCase):
     def work(self, **kwargs):
         self.__dict__.update(kwargs)
         self.worked = True
-        samples = old_div(LGMM1(rng=self.rng,
-                                size=(self.n_samples,),
-                                **self.kwargs), self.q)
+        samples = old_div(
+            LGMM1(rng=self.rng, size=(self.n_samples,), **self.kwargs), self.q
+        )
         # -- we've divided the LGMM1 by self.q to get ints here
-        assert np.all(samples == samples.astype('int'))
+        assert np.all(samples == samples.astype("int"))
         min_max = int(samples.min()), int(samples.max())
-        print('SAMPLES RANGE', min_max)
-        counts = np.bincount(samples.astype('int') - min_max[0])
+        print("SAMPLES RANGE", min_max)
+        counts = np.bincount(samples.astype("int") - min_max[0])
 
         # print samples
         # print counts
@@ -487,8 +496,8 @@ class TestQLGMM1Math(unittest.TestCase):
         y = old_div(counts, float(self.n_samples))
 
         if self.show:
-            plt.scatter(xcoords, y, c='r', label='empirical')
-            plt.scatter(xcoords, prob, c='b', label='predicted')
+            plt.scatter(xcoords, y, c="r", label="empirical")
+            plt.scatter(xcoords, prob, c="b", label="predicted")
             plt.legend()
             plt.show()
         # -- calculate errors on the low end, don't take a mean
@@ -500,9 +509,9 @@ class TestQLGMM1Math(unittest.TestCase):
         if self.show:
             raise nose.SkipTest()
         else:
-            assert np.max(err) < .1
-            assert np.mean(err) < .01
-            assert np.median(err) < .01
+            assert np.max(err) < 0.1
+            assert np.mean(err) < 0.01
+            assert np.median(err) < 0.01
 
     def test_basic_1(self):
         self.work(q=1)
@@ -530,26 +539,29 @@ class TestQLGMM1Math(unittest.TestCase):
 
 
 class TestSuggest(unittest.TestCase, CasePerDomain):
-
     def work(self):
         # -- smoke test that things simply run,
         #    for each type of several search spaces.
         trials = Trials()
-        fmin(passthrough,
-             space=self.bandit.expr,
-             algo=partial(tpe.suggest, n_EI_candidates=3),
-             trials=trials,
-             max_evals=10)
+        fmin(
+            passthrough,
+            space=self.bandit.expr,
+            algo=partial(tpe.suggest, n_EI_candidates=3),
+            trials=trials,
+            max_evals=10,
+        )
 
 
 class TestSuggestAtpe(unittest.TestCase, NonCategoricalCasePerDomain):
     def work(self):
         trials = Trials()
-        fmin(passthrough,
-             space=self.bandit.expr,
-             algo=atpe.suggest,
-             trials=trials,
-             max_evals=10)
+        fmin(
+            passthrough,
+            space=self.bandit.expr,
+            algo=atpe.suggest,
+            trials=trials,
+            max_evals=10,
+        )
 
 
 class TestOpt(unittest.TestCase, CasePerDomain):
@@ -560,7 +572,7 @@ class TestOpt(unittest.TestCase, CasePerDomain):
         gauss_wave=-2.0,
         gauss_wave2=-2.0,
         n_arms=-2.5,
-        many_dists=.0005,
+        many_dists=0.0005,
         branin=0.7,
     )
 
@@ -577,13 +589,9 @@ class TestOpt(unittest.TestCase, CasePerDomain):
         branin=200,
     )
 
-    gammas = dict(
-        distractor=.05,
-    )
+    gammas = dict(distractor=0.05)
 
-    prior_weights = dict(
-        distractor=.01,
-    )
+    prior_weights = dict(distractor=0.01)
 
     n_EIs = dict(
         # XXX
@@ -596,8 +604,8 @@ class TestOpt(unittest.TestCase, CasePerDomain):
     )
 
     def setUp(self):
-        self.olderr = np.seterr('raise')
-        np.seterr(under='ignore')
+        self.olderr = np.seterr("raise")
+        np.seterr(under="ignore")
 
     def tearDown(self, *args):
         np.seterr(**self.olderr)
@@ -606,67 +614,68 @@ class TestOpt(unittest.TestCase, CasePerDomain):
 
         bandit = self.bandit
         assert bandit.name is not None
-        algo = partial(tpe.suggest,
-                       gamma=self.gammas.get(bandit.name,
-                                             tpe._default_gamma),
-                       prior_weight=self.prior_weights.get(bandit.name,
-                                                           tpe._default_prior_weight),
-                       n_EI_candidates=self.n_EIs.get(bandit.name,
-                                                      tpe._default_n_EI_candidates),
-                       )
+        algo = partial(
+            tpe.suggest,
+            gamma=self.gammas.get(bandit.name, tpe._default_gamma),
+            prior_weight=self.prior_weights.get(bandit.name, tpe._default_prior_weight),
+            n_EI_candidates=self.n_EIs.get(bandit.name, tpe._default_n_EI_candidates),
+        )
         LEN = self.LEN.get(bandit.name, 50)
 
         trials = Trials()
-        fmin(passthrough,
-             space=bandit.expr,
-             algo=algo,
-             trials=trials,
-             max_evals=LEN,
-             rstate=np.random.RandomState(123),
-             catch_eval_exceptions=False)
+        fmin(
+            passthrough,
+            space=bandit.expr,
+            algo=algo,
+            trials=trials,
+            max_evals=LEN,
+            rstate=np.random.RandomState(123),
+            catch_eval_exceptions=False,
+        )
         assert len(trials) == LEN
 
         if 1:
             rtrials = Trials()
-            fmin(passthrough,
-                 space=bandit.expr,
-                 algo=rand.suggest,
-                 trials=rtrials,
-                 max_evals=LEN)
-            print('RANDOM MINS', list(sorted(rtrials.losses()))[:6])
-
+            fmin(
+                passthrough,
+                space=bandit.expr,
+                algo=rand.suggest,
+                trials=rtrials,
+                max_evals=LEN,
+            )
+            print("RANDOM MINS", list(sorted(rtrials.losses()))[:6])
 
         if 0:
             plt.subplot(2, 2, 1)
             plt.scatter(list(range(LEN)), trials.losses())
-            plt.title('TPE losses')
+            plt.title("TPE losses")
             plt.subplot(2, 2, 2)
-            plt.scatter(list(range(LEN)), ([s['x'] for s in trials.specs]))
-            plt.title('TPE x')
+            plt.scatter(list(range(LEN)), ([s["x"] for s in trials.specs]))
+            plt.title("TPE x")
             plt.subplot(2, 2, 3)
-            plt.title('RND losses')
+            plt.title("RND losses")
             plt.scatter(list(range(LEN)), rtrials.losses())
             plt.subplot(2, 2, 4)
-            plt.title('RND x')
-            plt.scatter(list(range(LEN)), ([s['x'] for s in rtrials.specs]))
+            plt.title("RND x")
+            plt.scatter(list(range(LEN)), ([s["x"] for s in rtrials.specs]))
             plt.show()
         if 0:
-            plt.hist(
-                [t['x'] for t in self.experiment.trials],
-                bins=20)
+            plt.hist([t["x"] for t in self.experiment.trials], bins=20)
 
-        print('TPE    MINS', list(sorted(trials.losses()))[:6])
+        print("TPE    MINS", list(sorted(trials.losses()))[:6])
         thresh = self.thresholds[bandit.name]
-        print('Thresh', thresh)
+        print("Thresh", thresh)
         assert min(trials.losses()) < thresh
 
 
 @domain_constructor(loss_target=0)
 def opt_q_uniform(target):
     rng = np.random.RandomState(123)
-    x = hp.quniform('x', 1.01, 10, 1)
-    return {'loss': (x - target) ** 2 + scope.normal(0, 1, rng=rng),
-            'status': STATUS_OK}
+    x = hp.quniform("x", 1.01, 10, 1)
+    return {
+        "loss": (x - target) ** 2 + scope.normal(0, 1, rng=rng),
+        "status": STATUS_OK,
+    }
 
 
 class TestOptQUniform(object):
@@ -680,25 +689,26 @@ class TestOptQUniform(object):
         bandit = opt_q_uniform(self.target)
         prior_weight = 2.5
         gamma = 0.20
-        algo = partial(tpe.suggest,
-                       prior_weight=prior_weight,
-                       n_startup_jobs=2,
-                       n_EI_candidates=128,
-                       gamma=gamma)
+        algo = partial(
+            tpe.suggest,
+            prior_weight=prior_weight,
+            n_startup_jobs=2,
+            n_EI_candidates=128,
+            gamma=gamma,
+        )
 
         trials = Trials()
-        fmin(passthrough,
-             space=bandit.expr,
-             algo=algo,
-             trials=trials,
-             max_evals=self.LEN)
+        fmin(
+            passthrough, space=bandit.expr, algo=algo, trials=trials, max_evals=self.LEN
+        )
         if self.show_vars:
             import hyperopt.plotting
+
             hyperopt.plotting.main_plot_vars(trials, bandit, do_show=1)
 
         idxs, vals = miscs_to_idxs_vals(trials.miscs)
-        idxs = idxs['x']
-        vals = vals['x']
+        idxs = idxs["x"]
+        vals = vals["x"]
 
         losses = trials.losses()
 
@@ -706,7 +716,7 @@ class TestOptQUniform(object):
         from hyperopt.tpe import adaptive_parzen_samplers
 
         qu = scope.quniform(1.01, 10, 1)
-        fn = adaptive_parzen_samplers['quniform']
+        fn = adaptive_parzen_samplers["quniform"]
         fn_kwargs = dict(size=(4,), rng=np.random)
         s_below = pyll.Literal()
         s_above = pyll.Literal()
@@ -717,45 +727,47 @@ class TestOptQUniform(object):
 
         # print b_post
         # print a_post
-        fn_lpdf = getattr(scope, a_post.name + '_lpdf')
+        fn_lpdf = getattr(scope, a_post.name + "_lpdf")
         print(fn_lpdf)
         # calculate the llik of b_post under both distributions
-        a_kwargs = dict([(n, a) for n, a in a_post.named_args
-                         if n not in ('rng', 'size')])
-        b_kwargs = dict([(n, a) for n, a in b_post.named_args
-                         if n not in ('rng', 'size')])
+        a_kwargs = dict(
+            [(n, a) for n, a in a_post.named_args if n not in ("rng", "size")]
+        )
+        b_kwargs = dict(
+            [(n, a) for n, a in b_post.named_args if n not in ("rng", "size")]
+        )
         below_llik = fn_lpdf(*([b_post] + b_post.pos_args), **b_kwargs)
         above_llik = fn_lpdf(*([b_post] + a_post.pos_args), **a_kwargs)
         new_node = scope.broadcast_best(b_post, below_llik, above_llik)
 
-        print('=' * 80)
+        print("=" * 80)
 
         do_show = self.show_steps
 
         for ii in range(2, 9):
             if ii > len(idxs):
                 break
-            print('-' * 80)
-            print('ROUND', ii)
-            print('-' * 80)
+            print("-" * 80)
+            print("ROUND", ii)
+            print("-" * 80)
             all_vals = [2, 3, 4, 5, 6, 7, 8, 9, 10]
-            below, above = ap_filter_trials(idxs[:ii],
-                                            vals[:ii], idxs[:ii], losses[:ii], gamma)
-            below = below.astype('int')
-            above = above.astype('int')
-            print('BB0', below)
-            print('BB1', above)
+            below, above = ap_filter_trials(
+                idxs[:ii], vals[:ii], idxs[:ii], losses[:ii], gamma
+            )
+            below = below.astype("int")
+            above = above.astype("int")
+            print("BB0", below)
+            print("BB1", above)
             # print 'BELOW',  zip(range(100), np.bincount(below, minlength=11))
             # print 'ABOVE',  zip(range(100), np.bincount(above, minlength=11))
             memo = {b_post: all_vals, s_below: below, s_above: above}
-            bl, al, nv = pyll.rec_eval([below_llik, above_llik, new_node],
-                                       memo=memo)
+            bl, al, nv = pyll.rec_eval([below_llik, above_llik, new_node], memo=memo)
             # print bl - al
-            print('BB2', dict(list(zip(all_vals, bl - al))))
-            print('BB3', dict(list(zip(all_vals, bl))))
-            print('BB4', dict(list(zip(all_vals, al))))
-            print('ORIG PICKED', vals[ii])
-            print('PROPER OPT PICKS:', nv)
+            print("BB2", dict(list(zip(all_vals, bl - al))))
+            print("BB3", dict(list(zip(all_vals, bl))))
+            print("BB4", dict(list(zip(all_vals, al))))
+            print("ORIG PICKED", vals[ii])
+            print("PROPER OPT PICKS:", nv)
 
             # assert np.allclose(below, [3, 3, 9])
             # assert len(below) + len(above) == len(vals)
@@ -766,8 +778,8 @@ class TestOptQUniform(object):
                 #    np.bincount(below, minlength=11)[2:], c='b')
                 # plt.scatter(all_vals,
                 #    np.bincount(above, minlength=11)[2:], c='c')
-                plt.scatter(all_vals, bl, c='g')
-                plt.scatter(all_vals, al, c='r')
+                plt.scatter(all_vals, bl, c="g")
+                plt.scatter(all_vals, al, c="r")
         if do_show:
             plt.show()
 

--- a/hyperopt/tests/test_utils.py
+++ b/hyperopt/tests/test_utils.py
@@ -11,7 +11,7 @@ from hyperopt.utils import temp_dir, working_dir, get_closest_dir, path_split_al
 
 
 def test_fast_isin():
-    Y = np.random.randint(0, 10000, size=(100, ))
+    Y = np.random.randint(0, 10000, size=(100,))
     X = np.arange(10000)
     Z = fast_isin(X, Y)
     D = np.unique(Y)
@@ -22,9 +22,9 @@ def test_fast_isin():
     Z = fast_isin(X, Y)
     T2 = (X[Z] == np.append(D, D.copy())).all()
 
-    X = np.random.randint(0, 100, size=(40, ))
+    X = np.random.randint(0, 100, size=(40,))
     X.sort()
-    Y = np.random.randint(0, 100, size=(60, ))
+    Y = np.random.randint(0, 100, size=(60,))
     Y.sort()
 
     XinY = np.array([ind for ind in range(len(X)) if X[ind] in Y])
@@ -42,8 +42,8 @@ def test_get_most_recent_inds():
     for ind in range(300):
         k = np.random.randint(1, 6)
         for _ind in range(k):
-            test_data.append({'_id': ind, 'version': _ind})
-        most_recent_data.append({'_id': ind, 'version': _ind})
+            test_data.append({"_id": ind, "version": _ind})
+        most_recent_data.append({"_id": ind, "version": _ind})
     rng = np.random.RandomState(0)
     p = rng.permutation(len(test_data))
     test_data_rearranged = [test_data[_p] for _p in p]
@@ -52,25 +52,36 @@ def test_get_most_recent_inds():
     assert all([t in most_recent_data for t in test_data_rearranged_most_recent])
     assert len(test_data_rearranged_most_recent) == len(most_recent_data)
 
-    test_data = [{'_id': 0, 'version': 1}]
+    test_data = [{"_id": 0, "version": 1}]
 
     assert get_most_recent_inds(test_data).tolist() == [0]
 
-    test_data = [{'_id': 0, 'version': 1}, {'_id': 0, 'version': 2}]
+    test_data = [{"_id": 0, "version": 1}, {"_id": 0, "version": 2}]
     assert get_most_recent_inds(test_data).tolist() == [1]
 
-    test_data = [{'_id': 0, 'version': 1}, {'_id': 0, 'version': 2},
-                 {'_id': 1, 'version': 1}]
+    test_data = [
+        {"_id": 0, "version": 1},
+        {"_id": 0, "version": 2},
+        {"_id": 1, "version": 1},
+    ]
 
     assert get_most_recent_inds(test_data).tolist() == [1, 2]
 
-    test_data = [{'_id': -1, 'version': 1}, {'_id': 0, 'version': 1},
-                 {'_id': 0, 'version': 2}, {'_id': 1, 'version': 1}]
+    test_data = [
+        {"_id": -1, "version": 1},
+        {"_id": 0, "version": 1},
+        {"_id": 0, "version": 2},
+        {"_id": 1, "version": 1},
+    ]
 
     assert get_most_recent_inds(test_data).tolist() == [0, 2, 3]
 
-    test_data = [{'_id': -1, 'version': 1}, {'_id': 0, 'version': 1},
-                 {'_id': 0, 'version': 2}, {'_id': 0, 'version': 2}]
+    test_data = [
+        {"_id": -1, "version": 1},
+        {"_id": 0, "version": 1},
+        {"_id": 0, "version": 2},
+        {"_id": 0, "version": 2},
+    ]
 
     assert get_most_recent_inds(test_data).tolist() == [0, 3]
 
@@ -110,6 +121,7 @@ def test_path_split_all():
 
 def test_temp_dir_sentinel():
     from os.path import join, isdir, exists, abspath
+
     basedir = "test_temp_dir_sentinel"
     fn = join(basedir, "foo", "bar")
     if exists(basedir):

--- a/hyperopt/tests/test_vectorize.py
+++ b/hyperopt/tests/test_vectorize.py
@@ -24,7 +24,7 @@ def config0():
     p5 = [3, 4, p0]
     p6 = scope.one_of(-3, p1)
     d = locals()
-    d['p1'] = None  # -- don't sample p1 all the time, only if p3 says so
+    d["p1"] = None  # -- don't sample p1 all the time, only if p3 says so
     s = as_apply(d)
     return s
 
@@ -36,15 +36,10 @@ def test_clone():
     nodeset = set(dfs(config))
     assert not any(n in nodeset for n in dfs(config2))
 
-    foo = recursive_set_rng_kwarg(
-        config,
-        scope.rng_from_seed(5))
+    foo = recursive_set_rng_kwarg(config, scope.rng_from_seed(5))
     r = rec_eval(foo)
     print(r)
-    r2 = rec_eval(
-        recursive_set_rng_kwarg(
-            config2,
-            scope.rng_from_seed(5)))
+    r2 = rec_eval(recursive_set_rng_kwarg(config2, scope.rng_from_seed(5)))
 
     print(r2)
     assert r == r2
@@ -53,29 +48,24 @@ def test_clone():
 def test_vectorize_trivial():
     N = as_apply(15)
 
-    p0 = hp_uniform('p0', 0, 1)
+    p0 = hp_uniform("p0", 0, 1)
     loss = p0
     print(loss)
     expr_idxs = scope.range(N)
     vh = VectorizeHelper(loss, expr_idxs, build=True)
     vloss = vh.v_expr
 
-    full_output = as_apply([vloss,
-                            vh.idxs_by_label(),
-                            vh.vals_by_label()])
+    full_output = as_apply([vloss, vh.idxs_by_label(), vh.vals_by_label()])
     fo2 = replace_repeat_stochastic(full_output)
 
-    new_vc = recursive_set_rng_kwarg(
-        fo2,
-        as_apply(np.random.RandomState(1)),
-    )
+    new_vc = recursive_set_rng_kwarg(fo2, as_apply(np.random.RandomState(1)))
 
     # print new_vc
     losses, idxs, vals = rec_eval(new_vc)
-    print('losses', losses)
-    print('idxs p0', idxs['p0'])
-    print('vals p0', vals['p0'])
-    p0dct = dict(list(zip(idxs['p0'], vals['p0'])))
+    print("losses", losses)
+    print("idxs p0", idxs["p0"])
+    print("vals p0", vals["p0"])
+    p0dct = dict(list(zip(idxs["p0"], vals["p0"])))
     for ii, li in enumerate(losses):
         assert p0dct[ii] == li
 
@@ -83,29 +73,24 @@ def test_vectorize_trivial():
 def test_vectorize_simple():
     N = as_apply(15)
 
-    p0 = hp_uniform('p0', 0, 1)
+    p0 = hp_uniform("p0", 0, 1)
     loss = p0 ** 2
     print(loss)
     expr_idxs = scope.range(N)
     vh = VectorizeHelper(loss, expr_idxs, build=True)
     vloss = vh.v_expr
 
-    full_output = as_apply([vloss,
-                            vh.idxs_by_label(),
-                            vh.vals_by_label()])
+    full_output = as_apply([vloss, vh.idxs_by_label(), vh.vals_by_label()])
     fo2 = replace_repeat_stochastic(full_output)
 
-    new_vc = recursive_set_rng_kwarg(
-        fo2,
-        as_apply(np.random.RandomState(1)),
-    )
+    new_vc = recursive_set_rng_kwarg(fo2, as_apply(np.random.RandomState(1)))
 
     # print new_vc
     losses, idxs, vals = rec_eval(new_vc)
-    print('losses', losses)
-    print('idxs p0', idxs['p0'])
-    print('vals p0', vals['p0'])
-    p0dct = dict(list(zip(idxs['p0'], vals['p0'])))
+    print("losses", losses)
+    print("idxs p0", idxs["p0"])
+    print("vals p0", vals["p0"])
+    p0dct = dict(list(zip(idxs["p0"], vals["p0"])))
     for ii, li in enumerate(losses):
         assert p0dct[ii] ** 2 == li
 
@@ -113,31 +98,26 @@ def test_vectorize_simple():
 def test_vectorize_multipath():
     N = as_apply(15)
 
-    p0 = hp_uniform('p0', 0, 1)
-    loss = hp_choice('p1', [1, p0, -p0]) ** 2
+    p0 = hp_uniform("p0", 0, 1)
+    loss = hp_choice("p1", [1, p0, -p0]) ** 2
     expr_idxs = scope.range(N)
     vh = VectorizeHelper(loss, expr_idxs, build=True)
 
     vloss = vh.v_expr
     print(vloss)
 
-    full_output = as_apply([vloss,
-                            vh.idxs_by_label(),
-                            vh.vals_by_label()])
+    full_output = as_apply([vloss, vh.idxs_by_label(), vh.vals_by_label()])
 
-    new_vc = recursive_set_rng_kwarg(
-        full_output,
-        as_apply(np.random.RandomState(1)),
-    )
+    new_vc = recursive_set_rng_kwarg(full_output, as_apply(np.random.RandomState(1)))
 
     losses, idxs, vals = rec_eval(new_vc)
-    print('losses', losses)
-    print('idxs p0', idxs['p0'])
-    print('vals p0', vals['p0'])
-    print('idxs p1', idxs['p1'])
-    print('vals p1', vals['p1'])
-    p0dct = dict(list(zip(idxs['p0'], vals['p0'])))
-    p1dct = dict(list(zip(idxs['p1'], vals['p1'])))
+    print("losses", losses)
+    print("idxs p0", idxs["p0"])
+    print("vals p0", vals["p0"])
+    print("idxs p1", idxs["p1"])
+    print("vals p1", vals["p1"])
+    p0dct = dict(list(zip(idxs["p0"], vals["p0"])))
+    p1dct = dict(list(zip(idxs["p1"], vals["p1"])))
     for ii, li in enumerate(losses):
         print(ii, li)
         if p1dct[ii] != 0:
@@ -147,18 +127,18 @@ def test_vectorize_multipath():
 
 
 def test_vectorize_config0():
-    p0 = hp_uniform('p0', 0, 1)
-    p1 = hp_loguniform('p1', 2, 3)
-    p2 = hp_choice('p2', [-1, p0])
-    p3 = hp_choice('p3', [-2, p1])
+    p0 = hp_uniform("p0", 0, 1)
+    p1 = hp_loguniform("p1", 2, 3)
+    p2 = hp_choice("p2", [-1, p0])
+    p3 = hp_choice("p3", [-2, p1])
     p4 = 1
     p5 = [3, 4, p0]
-    p6 = hp_choice('p6', [-3, p1])
+    p6 = hp_choice("p6", [-3, p1])
     d = locals()
-    d['p1'] = None  # -- don't sample p1 all the time, only if p3 says so
+    d["p1"] = None  # -- don't sample p1 all the time, only if p3 says so
     config = as_apply(d)
 
-    N = as_apply('N:TBA')
+    N = as_apply("N:TBA")
     expr = config
     expr_idxs = scope.range(N)
     vh = VectorizeHelper(expr, expr_idxs, build=True)
@@ -167,61 +147,58 @@ def test_vectorize_config0():
     full_output = as_apply([vconfig, vh.idxs_by_label(), vh.vals_by_label()])
 
     if 1:
-        print('=' * 80)
-        print('VECTORIZED')
+        print("=" * 80)
+        print("VECTORIZED")
         print(full_output)
-        print('\n' * 1)
+        print("\n" * 1)
 
     fo2 = replace_repeat_stochastic(full_output)
     if 0:
-        print('=' * 80)
-        print('VECTORIZED STOCHASTIC')
+        print("=" * 80)
+        print("VECTORIZED STOCHASTIC")
         print(fo2)
-        print('\n' * 1)
+        print("\n" * 1)
 
-    new_vc = recursive_set_rng_kwarg(
-        fo2,
-        as_apply(np.random.RandomState(1))
-    )
+    new_vc = recursive_set_rng_kwarg(fo2, as_apply(np.random.RandomState(1)))
     if 0:
-        print('=' * 80)
-        print('VECTORIZED STOCHASTIC WITH RNGS')
+        print("=" * 80)
+        print("VECTORIZED STOCHASTIC WITH RNGS")
         print(new_vc)
 
     Nval = 10
     foo, idxs, vals = rec_eval(new_vc, memo={N: Nval})
 
-    print('foo[0]', foo[0])
-    print('foo[1]', foo[1])
+    print("foo[0]", foo[0])
+    print("foo[1]", foo[1])
     assert len(foo) == Nval
     if 0:  # XXX refresh these values to lock down sampler
         assert foo[0] == {
-            'p0': 0.39676747423066994,
-            'p1': None,
-            'p2': 0.39676747423066994,
-            'p3': 2.1281244479293568,
-            'p4': 1,
-            'p5': (3, 4, 0.39676747423066994)}
-    assert (foo[1].keys() != foo[2].keys()) or \
-           (foo[1].values() != foo[2].values())
+            "p0": 0.39676747423066994,
+            "p1": None,
+            "p2": 0.39676747423066994,
+            "p3": 2.1281244479293568,
+            "p4": 1,
+            "p5": (3, 4, 0.39676747423066994),
+        }
+    assert (foo[1].keys() != foo[2].keys()) or (foo[1].values() != foo[2].values())
 
     print(idxs)
-    print(vals['p3'])
-    print(vals['p6'])
-    print(idxs['p1'])
-    print(vals['p1'])
-    assert len(vals['p3']) == Nval
-    assert len(vals['p6']) == Nval
-    assert len(idxs['p1']) < Nval
-    p1d = dict(list(zip(idxs['p1'], vals['p1'])))
-    for ii, (p3v, p6v) in enumerate(zip(vals['p3'], vals['p6'])):
+    print(vals["p3"])
+    print(vals["p6"])
+    print(idxs["p1"])
+    print(vals["p1"])
+    assert len(vals["p3"]) == Nval
+    assert len(vals["p6"]) == Nval
+    assert len(idxs["p1"]) < Nval
+    p1d = dict(list(zip(idxs["p1"], vals["p1"])))
+    for ii, (p3v, p6v) in enumerate(zip(vals["p3"], vals["p6"])):
         if p3v == p6v == 0:
-            assert ii not in idxs['p1']
+            assert ii not in idxs["p1"]
         if p3v:
-            assert foo[ii]['p3'] == p1d[ii]
+            assert foo[ii]["p3"] == p1d[ii]
         if p6v:
-            print('p6', foo[ii]['p6'], p1d[ii])
-            assert foo[ii]['p6'] == p1d[ii]
+            print("p6", foo[ii]["p6"], p1d[ii])
+            assert foo[ii]["p6"] == p1d[ii]
 
 
 def test_distributions():
@@ -229,21 +206,25 @@ def test_distributions():
 
     # XXX: test more distributions
     space = {
-        'loss': (
-            hp_loguniform('lu', -2, 2) +
-            hp_qloguniform('qlu', np.log(1 + 0.01), np.log(20), 2) +
-            hp_quniform('qu', -4.999, 5, 1) +
-            hp_uniform('u', 0, 10)),
-        'status': 'ok'}
+        "loss": (
+            hp_loguniform("lu", -2, 2)
+            + hp_qloguniform("qlu", np.log(1 + 0.01), np.log(20), 2)
+            + hp_quniform("qu", -4.999, 5, 1)
+            + hp_uniform("u", 0, 10)
+        ),
+        "status": "ok",
+    }
     trials = base.Trials()
     N = 1000
-    fmin(lambda x: x,
-         space=space,
-         algo=rand.suggest,
-         trials=trials,
-         max_evals=N,
-         rstate=np.random.RandomState(124),
-         catch_eval_exceptions=False)
+    fmin(
+        lambda x: x,
+        space=space,
+        algo=rand.suggest,
+        trials=trials,
+        max_evals=N,
+        rstate=np.random.RandomState(124),
+        catch_eval_exceptions=False,
+    )
     assert len(trials) == N
     idxs, vals = base.miscs_to_idxs_vals(trials.miscs)
     print(list(idxs.keys()))
@@ -252,7 +233,7 @@ def test_distributions():
     COUNTMIN = 70
 
     # -- loguniform
-    log_lu = np.log(vals['lu'])
+    log_lu = np.log(vals["lu"])
     assert len(log_lu) == N
     assert -2 < np.min(log_lu)
     assert np.max(log_lu) < 2
@@ -262,7 +243,7 @@ def test_distributions():
     assert np.all(h < COUNTMAX)
 
     # -- quantized log uniform
-    qlu = vals['qlu']
+    qlu = vals["qlu"]
     assert np.all(np.fmod(qlu, 2) == 0)
     assert np.min(qlu) == 2
     assert np.max(qlu) == 20
@@ -270,18 +251,18 @@ def test_distributions():
     assert bc_qlu[2] > bc_qlu[4] > bc_qlu[6] > bc_qlu[8]
 
     # -- quantized uniform
-    qu = vals['qu']
+    qu = vals["qu"]
     assert np.min(qu) == -5
     assert np.max(qu) == 5
     assert np.all(np.fmod(qu, 1) == 0)
-    bc_qu = np.bincount(np.asarray(qu).astype('int') + 5)
+    bc_qu = np.bincount(np.asarray(qu).astype("int") + 5)
     assert np.all(40 < bc_qu), bc_qu  # XXX: how to get the distribution flat
     # with new rounding rule?
     assert np.all(bc_qu < 125), bc_qu
     assert np.all(bc_qu < COUNTMAX)
 
     # -- uniform
-    u = vals['u']
+    u = vals["u"]
     assert np.min(u) > 0
     assert np.max(u) < 10
     h = np.histogram(u)[0]

--- a/hyperopt/tests/test_webpage.py
+++ b/hyperopt/tests/test_webpage.py
@@ -6,24 +6,26 @@ def test_landing_screen():
     # define an objective function
     def objective(args):
         case, val = args
-        if case == 'case 1':
+        if case == "case 1":
             return val
         else:
             return val ** 2
 
     # define a search space
     from hyperopt import hp
-    space = hp.choice('a',
-                      [
-                          ('case 1', 1 + hp.lognormal('c1', 0, 1)),
-                          ('case 2', hp.uniform('c2', -10, 10))
-                      ])
+
+    space = hp.choice(
+        "a",
+        [
+            ("case 1", 1 + hp.lognormal("c1", 0, 1)),
+            ("case 2", hp.uniform("c2", -10, 10)),
+        ],
+    )
 
     # minimize the objective over the space
     import hyperopt
-    best = hyperopt.fmin(objective, space,
-                         algo=hyperopt.tpe.suggest,
-                         max_evals=100)
+
+    best = hyperopt.fmin(objective, space, algo=hyperopt.tpe.suggest, max_evals=100)
 
     print(best)
     # -> {'a': 1, 'c2': 0.01420615366247227}

--- a/hyperopt/utils.py
+++ b/hyperopt/utils.py
@@ -42,7 +42,9 @@ logger = _get_logger(__name__)
 try:
     import cloudpickle as pickler
 except Exception as e:
-    logger.info('Failed to load cloudpickle, try installing cloudpickle via "pip install cloudpickle" for enhanced pickling support.')
+    logger.info(
+        'Failed to load cloudpickle, try installing cloudpickle via "pip install cloudpickle" for enhanced pickling support.'
+    )
     import six.moves.cPickle as pickler
 
 
@@ -51,22 +53,22 @@ def import_tokens(tokens):
     # import as many as we can
     rval = None
     for i in range(len(tokens)):
-        modname = '.'.join(tokens[:i + 1])
+        modname = ".".join(tokens[: i + 1])
         # XXX: try using getattr, and then merge with load_tokens
         try:
-            logger.info('importing %s' % modname)
+            logger.info("importing %s" % modname)
             exec("import {}".format(modname))
             exec("rval = {}".format(modname))
         except ImportError as e:
-            logger.info('failed to import %s' % modname)
-            logger.info('reason: %s' % str(e))
+            logger.info("failed to import %s" % modname)
+            logger.info("reason: %s" % str(e))
             break
     return rval, tokens[i:]
 
 
 def load_tokens(tokens):
     # XXX: merge with import_tokens
-    logger.info('load_tokens: %s' % str(tokens))
+    logger.info("load_tokens: %s" % str(tokens))
     symbol, remainder = import_tokens(tokens)
     for attr in remainder:
         symbol = getattr(symbol, attr)
@@ -74,7 +76,7 @@ def load_tokens(tokens):
 
 
 def json_lookup(json):
-    symbol = load_tokens(json.split('.'))
+    symbol = load_tokens(json.split("."))
     return symbol
 
 
@@ -96,9 +98,9 @@ def json_call(json, args=(), kwargs=None):
         symbol = json_lookup(json)
         return symbol(*args, **kwargs)
     elif isinstance(json, dict):
-        raise NotImplementedError('dict calling convention undefined', json)
+        raise NotImplementedError("dict calling convention undefined", json)
     elif isinstance(json, (tuple, list)):
-        raise NotImplementedError('seq calling convention undefined', json)
+        raise NotImplementedError("seq calling convention undefined", json)
     else:
         raise TypeError(json)
 
@@ -115,8 +117,8 @@ def get_obj(f, argfile=None, argstr=None, args=(), kwargs=None):
         argd = pickler.loads(argstr)
     else:
         argd = {}
-    args = args + argd.get('args', ())
-    kwargs.update(argd.get('kwargs', {}))
+    args = args + argd.get("args", ())
+    kwargs.update(argd.get("kwargs", {}))
     return json_call(f, args=args, kwargs=kwargs)
 
 
@@ -137,7 +139,7 @@ def pmin_sampled(mean, var, n_samples=1000, rng=None):
     winners = (samples.T == samples.min(axis=1)).T
     wincounts = winners.sum(axis=0)
     assert wincounts.shape == mean.shape
-    return old_div(wincounts.astype('float64'), wincounts.sum())
+    return old_div(wincounts.astype("float64"), wincounts.sum())
 
 
 def fast_isin(X, Y):
@@ -155,22 +157,22 @@ def fast_isin(X, Y):
         T.sort()
         D = T.searchsorted(X)
         T = np.append(T, np.array([0]))
-        W = (T[D] == X)
+        W = T[D] == X
         if isinstance(W, bool):
             return np.zeros((len(X),), bool)
         else:
-            return (T[D] == X)
+            return T[D] == X
     else:
         return np.zeros((len(X),), bool)
 
 
 def get_most_recent_inds(obj):
-    data = numpy.rec.array([(x['_id'], int(x['version']))
-                            for x in obj],
-                           names=['_id', 'version'])
-    s = data.argsort(order=['_id', 'version'])
+    data = numpy.rec.array(
+        [(x["_id"], int(x["version"])) for x in obj], names=["_id", "version"]
+    )
+    s = data.argsort(order=["_id", "version"])
     data = data[s]
-    recent = (data['_id'][1:] != data['_id'][:-1]).nonzero()[0]
+    recent = (data["_id"][1:] != data["_id"][:-1]).nonzero()[0]
     recent = numpy.append(recent, [len(data) - 1])
     return s[recent]
 
@@ -204,8 +206,9 @@ def coarse_utcnow():
     """
     now = datetime.datetime.utcnow()
     microsec = (now.microsecond // 10 ** 3) * (10 ** 3)
-    return datetime.datetime(now.year, now.month, now.day, now.hour,
-                             now.minute, now.second, microsec)
+    return datetime.datetime(
+        now.year, now.month, now.day, now.hour, now.minute, now.second, microsec
+    )
 
 
 @contextmanager
@@ -233,7 +236,7 @@ def get_closest_dir(workdir):
     erasing work-dirs should never progress above this file.
     Also returns the name of first non-existing dir for use as filename.
     """
-    closest_dir = ''
+    closest_dir = ""
     for wdi in path_split_all(workdir):
         if os.path.isdir(os.path.join(closest_dir, wdi)):
             closest_dir = os.path.join(closest_dir, wdi)
@@ -252,7 +255,7 @@ def temp_dir(dir, erase_after=False, with_sentinel=True):
         if erase_after and with_sentinel:
             closest_dir, fn = get_closest_dir(dir)
             sentinel = os.path.join(closest_dir, fn + ".inuse")
-            open(sentinel, 'w').close()
+            open(sentinel, "w").close()
         os.makedirs(dir)
         created_by_me = True
     else:

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,9 @@ if debug:
 
 
 def find_scripts():
-    return [s for s in setuptools.findall('scripts/') if os.path.splitext(s)[1] != '.pyc']
+    return [
+        s for s in setuptools.findall("scripts/") if os.path.splitext(s)[1] != ".pyc"
+    ]
 
 
 def package_to_path(package):
@@ -46,7 +48,7 @@ def package_to_path(package):
 
     No idea if this works on windows
     """
-    return package.replace('.', '/')
+    return package.replace(".", "/")
 
 
 def find_subdirectories(package):
@@ -68,9 +70,9 @@ def subdir_findall(dir, subdir):
     This is similar to (and uses) setuptools.findall
     However, the paths returned are in the form needed for package_data
     """
-    strip_n = len(dir.split('/'))
-    path = '/'.join((dir, subdir))
-    return ['/'.join(s.split('/')[strip_n:]) for s in setuptools.findall(path)]
+    strip_n = len(dir.split("/"))
+    path = "/".join((dir, subdir))
+    return ["/".join(s.split("/")[strip_n:]) for s in setuptools.findall(path)]
 
 
 def find_package_data(packages):
@@ -87,10 +89,10 @@ def find_package_data(packages):
     for package in packages:
         package_data[package] = []
         for subdir in find_subdirectories(package):
-            if '.'.join((package, subdir)) in packages:  # skip submodules
+            if ".".join((package, subdir)) in packages:  # skip submodules
                 logging.debug("skipping submodule %s/%s" % (package, subdir))
                 continue
-            if skip_tests and (subdir == 'tests'):  # skip tests
+            if skip_tests and (subdir == "tests"):  # skip tests
                 logging.debug("skipping tests %s/%s" % (package, subdir))
                 continue
             package_data[package] += subdir_findall(package_to_path(package), subdir)
@@ -113,45 +115,53 @@ if package_data is None:
 
 setuptools.setup(
     name=package_name,
-    version='0.2.1',
+    version="0.2.1",
     packages=packages,
-    entry_points={
-        'console_scripts': [
-            'hyperopt-mongo-worker=hyperopt.mongoexp:main'
-        ],
-    },
-    url='http://hyperopt.github.com/hyperopt/',
-    author='James Bergstra',
-    author_email='james.bergstra@gmail.com',
-    description='Distributed Asynchronous Hyperparameter Optimization',
-    long_description='',
+    entry_points={"console_scripts": ["hyperopt-mongo-worker=hyperopt.mongoexp:main"]},
+    url="http://hyperopt.github.com/hyperopt/",
+    author="James Bergstra",
+    author_email="james.bergstra@gmail.com",
+    description="Distributed Asynchronous Hyperparameter Optimization",
+    long_description="",
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Education',
-        'Intended Audience :: Science/Research',
-        'Intended Audience :: Developers',
-        'Environment :: Console',
-        'License :: OSI Approved :: BSD License',
-        'Operating System :: MacOS :: MacOS X',
-        'Operating System :: Microsoft :: Windows',
-        'Operating System :: POSIX',
-        'Operating System :: Unix',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 3',
-        'Topic :: Scientific/Engineering',
-        'Topic :: Software Development',
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Education",
+        "Intended Audience :: Science/Research",
+        "Intended Audience :: Developers",
+        "Environment :: Console",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: MacOS :: MacOS X",
+        "Operating System :: Microsoft :: Windows",
+        "Operating System :: POSIX",
+        "Operating System :: Unix",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Software Development",
     ],
-    platforms=['Linux', 'OS-X', 'Windows'],
-    license='BSD',
-    keywords='Bayesian optimization hyperparameter model selection',
+    platforms=["Linux", "OS-X", "Windows"],
+    license="BSD",
+    keywords="Bayesian optimization hyperparameter model selection",
     package_data=package_data,
     include_package_data=True,
-    install_requires=['numpy', 'scipy', 'six', 'networkx==2.2', 'future', 'tqdm', 'cloudpickle', 'bson'],
+    install_requires=[
+        "numpy",
+        "scipy",
+        "six",
+        "networkx==2.2",
+        "future",
+        "tqdm",
+        "cloudpickle",
+        "bson",
+        "black",
+        "pre-commit",
+    ],
     extras_require={
-        'SparkTrials':'pyspark', 
-        'MongoTrials': 'pymongo',
-        'ATPE': ['lightgbm', 'scikit-learn']},
-    tests_require=['nose'],
-    zip_safe=False
+        "SparkTrials": "pyspark",
+        "MongoTrials": "pymongo",
+        "ATPE": ["lightgbm", "scikit-learn"],
+    },
+    tests_require=["nose"],
+    zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -153,8 +153,6 @@ setuptools.setup(
         "future",
         "tqdm",
         "cloudpickle",
-        "black",
-        "pre-commit",
     ],
     extras_require={
         "SparkTrials": "pyspark",

--- a/setup.py
+++ b/setup.py
@@ -158,6 +158,7 @@ setuptools.setup(
         "SparkTrials": "pyspark",
         "MongoTrials": "pymongo",
         "ATPE": ["lightgbm", "scikit-learn"],
+        "dev": ["black", "pre-commit"]
     },
     tests_require=["nose"],
     zip_safe=False,


### PR DESCRIPTION
This is a very straightforward PR to start using `black` to format the code

Main contribution is to apply black to the whole code

Update: Initially the idea was to force to use black but as it requires python 3.6+, all the following details in this description have been removed / postponed

Plus, I've added instructions in the README.md for contributors. Basically it's as simple as running

pre-commit install

once you clone. Then, every commit will run `black` on the modified files and fail if there are any files that needed changes. There are two options here:

* To run black and if there are files that need changes fail and do nothing. This means if you commit again the commit won't succeed, but it doesn't change your files.
* To run black and if there are files that need changes fail and modify them. This means if you commit again the commit would succeed. Good thing is you don't need to run black in every file

I chose the latter. Let me know your thoughts about this

About the tests: it passes the tests for python3.6, but not for the other 2 distros. This is because black requires 3.6+