### PR TITLE
typo when making losses positive

### DIFF
--- a/hyperopt/atpe.py
+++ b/hyperopt/atpe.py
@@ -1260,7 +1260,7 @@ def suggest(new_ids, domain, trials, seed):
         if minVal < 0:
             for result in results:
                 if result['loss'] is not None:
-                    result['loss'] = result['loss'] + minVal + 0.1
+                    result['loss'] = result['loss'] - minVal + 0.1
 
     hyperparameters = Hyperparameter(hyperparameterConfig)
 


### PR DESCRIPTION
When minval is negative, it needs to be subtracted out in order to make the result positive. Adding it will make the loss more negative.