### PR TITLE
Fix tqdm error on close call

### DIFF
--- a/hyperopt/std_out_err_redirect_tqdm.py
+++ b/hyperopt/std_out_err_redirect_tqdm.py
@@ -21,6 +21,9 @@ class DummyTqdmFile(object):
     def flush(self):
         return getattr(self.file, "flush", lambda: None)()
 
+    def close(self):
+        return getattr(self.file, "close", lambda: None)()
+
     def isatty(self):
         return getattr(self.file, "isatty", lambda: False)()
 


### PR DESCRIPTION
When hyperopt fails with exception and python logging is used the following error occurs:

```
Error in atexit._run_exitfuncs:                                                                                            
Traceback (most recent call last):                       
  File "/usr/lib/python3.7/logging/__init__.py", line 2039, in shutdown     
    h.close()                                                                                                                       
  File "/home/tony/.local/lib/python3.7/site-packages/absl/logging/__init__.py", line 854, in close
    self.stream.close()                                                                                                
AttributeError: 'DummyTqdmFile' object has no attribute 'close'      
```                