### PR TITLE
Fix verbosity for fmin with tpe.suggest

### DIFF
--- a/hyperopt/base.py
+++ b/hyperopt/base.py
@@ -684,7 +684,7 @@ class Ctrl(object):
     """
 
     info = logger.info
-    warn = logger.warn
+    warn = logger.warning
     error = logger.error
     debug = logger.debug
 

--- a/hyperopt/main.py
+++ b/hyperopt/main.py
@@ -19,7 +19,8 @@ try:
     import cloudpickle as pickler
 except Exception as e:
     logger.info(
-        'Failed to load cloudpickle, try installing cloudpickle via "pip install cloudpickle" for enhanced pickling support.'
+        'Failed to load cloudpickle, try installing cloudpickle via "pip install '
+        'cloudpickle" for enhanced pickling support.'
     )
     import six.moves.cPickle as pickler
 

--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -100,9 +100,10 @@ class SparkTrials(Trials):
         if not self._spark_supports_job_cancelling and timeout is not None:
             logger.warning(
                 "SparkTrials was constructed with a timeout specified, but this Apache "
-                "Spark version does not support job group-based cancellation. The timeout will be "
-                "respected when starting new Spark jobs, but SparkTrials will not be able to "
-                "cancel running Spark jobs which exceed the timeout."
+                "Spark version does not support job group-based cancellation. The "
+                "timeout will be respected when starting new Spark jobs, but "
+                "SparkTrials will not be able to cancel running Spark jobs which exceed"
+                " the timeout."
             )
 
         self.timeout = timeout
@@ -125,8 +126,8 @@ class SparkTrials(Trials):
             parallelism = max_num_concurrent_tasks
         elif parallelism <= 0:
             logger.warning(
-                "User-specified parallelism was invalid value ({p}), so parallelism will"
-                " be set to max_num_concurrent_tasks ({c}).".format(
+                "User-specified parallelism was invalid value ({p}), so parallelism "
+                "will be set to max_num_concurrent_tasks ({c}).".format(
                     p=parallelism, c=max_num_concurrent_tasks
                 )
             )
@@ -289,8 +290,8 @@ class _SparkFMinState:
                 self._job_interrupt_on_cancel = False
             else:
                 self._job_interrupt_on_cancel = "true" == interrupt_on_cancel.lower()
-            # In certain Spark deployments, the local property "spark.jobGroup.id" value is None,
-            # so we create one to use for SparkTrials.
+            # In certain Spark deployments, the local property "spark.jobGroup.id"
+            # value is None, so we create one to use for SparkTrials.
             if self._job_group_id is None:
                 self._job_group_id = "Hyperopt_SparkTrials_" + _get_random_id()
             if self._job_desc is None:
@@ -316,12 +317,13 @@ class _SparkFMinState:
 
     def _finish_trial_run(self, is_success, is_cancelled, trial, data):
         """
-        Call this method when a trial evaluation finishes. It will save results to the trial object
-        and update task counters.
+        Call this method when a trial evaluation finishes. It will save results to the
+        trial object and update task counters.
         :param is_success: whether the trial succeeded
         :param is_cancelled: whether the trial was cancelled
-        :param data: If the trial succeeded, this is the return value from the trial task function.
-                     Otherwise, this is the exception raised when running the trial task.
+        :param data: If the trial succeeded, this is the return value from the trial
+        task function. Otherwise, this is the exception raised when running the trial
+        task.
         """
         if is_cancelled:
             logger.debug(

--- a/hyperopt/tpe.py
+++ b/hyperopt/tpe.py
@@ -368,10 +368,6 @@ def adaptive_parzen_normal_orig(mus, prior_weight, prior_mu, prior_sigma):
     weights[0] = prior_weight
 
     weights = old_div(weights, weights.sum())
-    if 0:
-        print("WEIGHTS", weights)
-        print("MUS", mus)
-        print("SIGMA", sigma)
 
     return weights, mus, sigma
 
@@ -837,7 +833,7 @@ def suggest(
     n_startup_jobs=_default_n_startup_jobs,
     n_EI_candidates=_default_n_EI_candidates,
     gamma=_default_gamma,
-    linear_forgetting=_default_linear_forgetting,
+    verbose=True,
 ):
 
     new_id = new_ids[0]
@@ -852,7 +848,8 @@ def suggest(
         opt_vals,
     ) = tpe_transform(domain, prior_weight, gamma)
     tt = time.time() - t0
-    logger.info("tpe_transform took %f seconds" % tt)
+    if verbose:
+        logger.info("tpe_transform took %f seconds" % tt)
 
     best_docs = dict()
     best_docs_loss = dict()
@@ -878,13 +875,14 @@ def suggest(
     tids = [k for k, v in tid_docs]
     docs = [v for k, v in tid_docs]
 
-    if docs:
-        logger.info(
-            "TPE using %i/%i trials with best loss %f"
-            % (len(docs), len(trials), min(best_docs_loss.values()))
-        )
-    else:
-        logger.info("TPE using 0 trials")
+    if verbose:
+        if docs:
+            logger.info(
+                "TPE using %i/%i trials with best loss %f"
+                % (len(docs), len(trials), min(best_docs_loss.values()))
+            )
+        else:
+            logger.info("TPE using 0 trials")
 
     if len(docs) < n_startup_jobs:
         # N.B. THIS SEEDS THE RNG BASED ON THE new_id


### PR DESCRIPTION
fmin used to have an unused argument `verbose`. With this PR all the messages can be removed with verbose=False. Doing this also removes the progressbar.
I also introduced a verbose argument for `tpe.suggest`

As a byproduct of this PR:
- Some pieces of code in `if 0` were removed
- Some strings exceeding max line length were split