### PR TITLE
Make tqdm progress optional

### DIFF
--- a/hyperopt/base.py
+++ b/hyperopt/base.py
@@ -42,7 +42,7 @@ try:
 except ImportError:
     have_bson = False
 
-from . import pyll
+from . import pyll, progress
 from .pyll.stochastic import recursive_set_rng_kwarg
 
 from .exceptions import (
@@ -641,8 +641,8 @@ class Trials(object):
             error jobs (JOB_STATE_ERROR).  If set to False, such exceptions
             will not be caught, and so they will propagate to calling code.
 
-        show_progressbar : bool, default True
-            Show a progressbar.
+        show_progressbar : bool or context manager, default True.
+            Show a progressbar. See `hyperopt.progress` for customizing progress reporting.
 
         """
         # -- Stop-gap implementation!

--- a/hyperopt/progress.py
+++ b/hyperopt/progress.py
@@ -1,0 +1,40 @@
+"""
+Progress is reported using context managers.
+
+A progress context manager takes an `initial` and a `total` argument
+and should yield an object with an `update(n)` method.
+"""
+from __future__ import print_function
+from __future__ import absolute_import
+
+import contextlib
+
+from tqdm import tqdm
+from .std_out_err_redirect_tqdm import std_out_err_redirect_tqdm
+
+
+@contextlib.contextmanager
+def tqdm_progress_callback(initial, total):
+    with std_out_err_redirect_tqdm() as wrapped_stdout, tqdm(
+        total=total,
+        file=wrapped_stdout,
+        postfix={"best loss": "?"},
+        disable=False,
+        dynamic_ncols=True,
+        unit="trial",
+        initial=initial,
+    ) as pbar:
+        yield pbar
+
+
+@contextlib.contextmanager
+def no_progress_callback(initial, total):
+    class NoProgressContext:
+        def update(self, n):
+            pass
+
+    yield NoProgressContext()
+
+
+default_callback = tqdm_progress_callback
+"""Use tqdm for progress by default"""

--- a/hyperopt/tests/test_progress.py
+++ b/hyperopt/tests/test_progress.py
@@ -1,6 +1,4 @@
-from __future__ import print_function
-from builtins import range
-from unittest.mock import patch
+from future import standard_library
 import sys
 import io
 
@@ -14,13 +12,3 @@ def test_tqdm_progress_callback_restores_stdout():
         ctx.postfix = "best loss: 4711"
         ctx.update(42)
     assert sys.stdout == real_stdout
-
-
-def test_no_progress_callback_no_output():
-    output = io.StringIO()
-    with patch("sys.stdout", new=output) as stdout, no_progress_callback(
-        initial=0, total=100
-    ) as ctx:
-        ctx.postfix = "best loss: 4711"
-        ctx.update(42)
-    assert output.getvalue() == ""

--- a/hyperopt/tests/test_progress.py
+++ b/hyperopt/tests/test_progress.py
@@ -1,0 +1,26 @@
+from __future__ import print_function
+from builtins import range
+from unittest.mock import patch
+import sys
+import io
+
+from hyperopt.progress import tqdm_progress_callback, no_progress_callback
+
+
+def test_tqdm_progress_callback_restores_stdout():
+    real_stdout = sys.stdout
+    with tqdm_progress_callback(initial=0, total=100) as ctx:
+        assert sys.stdout != real_stdout
+        ctx.postfix = "best loss: 4711"
+        ctx.update(42)
+    assert sys.stdout == real_stdout
+
+
+def test_no_progress_callback_no_output():
+    output = io.StringIO()
+    with patch("sys.stdout", new=output) as stdout, no_progress_callback(
+        initial=0, total=100
+    ) as ctx:
+        ctx.postfix = "best loss: 4711"
+        ctx.update(42)
+    assert output.getvalue() == ""


### PR DESCRIPTION
This change makes the progress reporting customizable, and makes it possible to avoid the call to `std_out_err_redirect_tqdm`.

I believe it can also solve the problem described in https://github.com/hyperopt/hyperopt/issues/476#issuecomment-560026977

I kept the show_progressbar argument to be backwards compat, but I'm not sure it is necessary?

Due to the indent change, the diff might look strange on GH. `git diff master..progress-callback -w -- hyperopt/fmin.py` is a bit easier to read.