### PR TITLE
Improving tests

### DIFF
--- a/hyperopt/rdists.py
+++ b/hyperopt/rdists.py
@@ -10,6 +10,7 @@ import numpy as np
 import numpy.random as mtrand
 import scipy.stats
 from scipy.stats import rv_continuous  # , rv_discrete
+from scipy.stats._continuous_distns import lognorm_gen as scipy_lognorm_gen
 
 
 class loguniform_gen(rv_continuous):
@@ -36,24 +37,21 @@ class loguniform_gen(rv_continuous):
         return old_div((np.log(x) - self._low), (self._high - self._low))
 
 
-from scipy.stats._continuous_distns import lognorm_gen as scipy_lognorm_gen
-
-
 class lognorm_gen(scipy_lognorm_gen):
     def __init__(self, mu, sigma):
         self.mu_ = mu
         self.s_ = sigma
         scipy_lognorm_gen.__init__(self)
 
-        # I still don't understand what scipy stats objects are
-        # doing re: this stuff
+        # I still don't understand what scipy stats objects are doing
+        # re: this stuff
         del self.__dict__["_parse_args"]
         del self.__dict__["_parse_args_stats"]
         del self.__dict__["_parse_args_rvs"]
 
-    def _parse_args(self, *args, **kwds):
+    def _parse_args(self, *args, **kwargs):
         assert not args, args
-        assert not kwds, kwds
+        assert not kwargs, kwargs
         args = (self.s_,)
         loc = 0
         scale = np.exp(self.mu_)

--- a/hyperopt/tests/test_domains.py
+++ b/hyperopt/tests/test_domains.py
@@ -219,6 +219,7 @@ class DomainExperimentMixin(object):
             domain.expr,
             trials=trials,
             algo=suggest,
+            rstate=np.random.RandomState(4),
             max_evals=self._n_steps,
         )
         assert trials.average_best_error(domain) - domain.loss_target < 0.2

--- a/hyperopt/tests/test_rdists.py
+++ b/hyperopt/tests/test_rdists.py
@@ -74,6 +74,9 @@ class TestLogNormal(unittest.TestCase):
         check_pdf(lognorm_gen(mu=-4, sigma=2), (), "")
 
     def test_distribution_rvs(self):
+        import warnings
+
+        warnings.warn("test_distribution_rvs is being skipped!")
         return  # XXX
         alpha = 0.01
         loc = 0

--- a/hyperopt/tests/test_rdists.py
+++ b/hyperopt/tests/test_rdists.py
@@ -15,30 +15,12 @@ from hyperopt.rdists import (
 )
 from scipy import stats
 
-try:
-    from scipy.stats.tests.test_continuous_basic import (
-        check_cdf_logcdf,
-        check_pdf_logpdf,
-        check_pdf,
-        check_cdf_ppf,
-    )
-except ImportError:
-    # XXX skip-tests instead or fix the import error, why would it fail?
-
-    # -- This is failing because of a bug in the scipy.tests.test_continuous import.
-    # https://github.com/scipy/scipy/commit/c05c6b73a0cd16c4cc12a23e7ad72742dfeb42f1 will fix it with scipy 1.2.0
-
-    def check_cdf_logcdf(*args):
-        pass
-
-    def check_pdf_logpdf(*args):
-        pass
-
-    def check_pdf(*args):
-        pass
-
-    def check_cdf_ppf(*args):
-        pass
+from scipy.stats.tests.test_continuous_basic import (
+    check_cdf_logcdf,
+    check_pdf_logpdf,
+    check_pdf,
+    check_cdf_ppf,
+)
 
 
 class TestLogUniform(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -158,8 +158,8 @@ setuptools.setup(
         "SparkTrials": "pyspark",
         "MongoTrials": "pymongo",
         "ATPE": ["lightgbm", "scikit-learn"],
-        "dev": ["black", "pre-commit"]
+        "dev": ["black", "pre-commit"],
     },
-    tests_require=["nose"],
+    tests_require=["nose", "pytest"],
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,7 @@ setuptools.setup(
         "SparkTrials": "pyspark",
         "MongoTrials": "pymongo",
         "ATPE": ["lightgbm", "scikit-learn"],
-        "dev": ["black", "pre-commit"],
+        "dev": ["black", "pre-commit", "nose", "pytest"],
     },
     tests_require=["nose", "pytest"],
     zip_safe=False,


### PR DESCRIPTION
This PR improves tests a bit by removing a try/except in `test_rdists`. This was failing because the new versions of scipy require pytest for the submodules imported

I also added [nose, pytest] to the dev list, so that devs get them when following the README instructions. Let me know if you have a better solution for this

As a byproduct I refactored some of the code and fixed one seed for fmin in `test_domains` so that tests should be totally/more deterministic

Finally, added a warning as one of the tests was skipped. I don't know how to fix it, so at least this will be there and someone will eventually work on it. Happy to get advice on this