### PR TITLE
[ML-9328] Support dynamic allocation in hyperopt integration

### DIFF
--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -123,14 +123,14 @@ class SparkTrials(Trials):
         Given the user-set value of parallelism, return the value SparkTrials will actually use.
         See the docstring for `parallelism` in the constructor for expected behavior.
         """
-        default_parallelism = max(spark_default_parallelism, max_num_concurrent_tasks)
+        parallelism = max(spark_default_parallelism, max_num_concurrent_tasks)
         if requested_parallelism is None or requested_parallelism <= 0:
             if requested_parallelism <= 0:
                 logger.warning(
                     "User-specified parallelism was non-negative value ({p}), so parallelism "
                     "will be set to default parallelism ({d}, which equals to "
                     "max(spark_default_parallelism, max_num_concurrent_tasks)).".format(
-                        p=requested_parallelism, d=default_parallelism
+                        p=requested_parallelism, d=parallelism
                     )
                 )
             warnings.warn(
@@ -138,9 +138,8 @@ class SparkTrials(Trials):
                 "max_num_concurrent_tasks)) is deprecated, and in next released version, "
                 "user must specify parallelism explicitly, because default parallelism is not "
                 "stable when the cluster can auto-scale or spark executor registration comes late."
-                .format(d=default_parallelism), DeprecationWarning
+                .format(d=parallelism), DeprecationWarning
             )
-            parallelism = default_parallelism
         elif requested_parallelism > max_num_concurrent_tasks:
             logger.warning(
                 "User-specified parallelism ({p}) is greater than the max number of concurrent "

--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -126,7 +126,7 @@ class SparkTrials(Trials):
         elif parallelism <= 0:
             logger.warning(
                 "User-specified parallelism was invalid value ({p}), so parallelism "
-                "will be set to max_num_concurrent_tasks ({c}).".format(
+                "will be set to max number of concurrent tasks ({c}).".format(
                     p=parallelism, c=max_num_concurrent_tasks
                 )
             )

--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -49,12 +49,9 @@ class SparkTrials(Trials):
     # Hard cap on the number of concurrent hyperopt tasks (Spark jobs) to run. Set at 128.
     MAX_CONCURRENT_JOBS_ALLOWED = 128
 
-    def __init__(self, 
-            parallelism=None, 
-            timeout=None, 
-            loss_threshold=None, 
-            spark_session=None
-        ):
+    def __init__(
+        self, parallelism=None, timeout=None, loss_threshold=None, spark_session=None
+    ):
         """
         :param parallelism: Maximum number of parallel trials to run,
                             i.e., maximum number of concurrent Spark tasks.
@@ -97,7 +94,7 @@ class SparkTrials(Trials):
         self.parallelism = self._decide_parallelism(
             requested_parallelism=parallelism,
             spark_default_parallelism=spark_default_parallelism,
-            max_num_concurrent_tasks=max_num_concurrent_tasks
+            max_num_concurrent_tasks=max_num_concurrent_tasks,
         )
 
         if not self._spark_supports_job_cancelling and timeout is not None:
@@ -117,9 +114,8 @@ class SparkTrials(Trials):
 
     @staticmethod
     def _decide_parallelism(
-            requested_parallelism,
-            spark_default_parallelism,
-            max_num_concurrent_tasks):
+        requested_parallelism, spark_default_parallelism, max_num_concurrent_tasks
+    ):
         """
         Given the requested parallelism, return the max parallelism SparkTrials will actually use.
         See the docstring for `parallelism` in the constructor for expected behavior.
@@ -137,24 +133,29 @@ class SparkTrials(Trials):
                 "parallelism will be set to ({d}), which is Spark's default parallelism ({s}), "
                 "or the current total of Spark task slots ({t}), or 1, whichever is greater. "
                 "We recommend setting parallelism explicitly to a positive value because "
-                "the total of Spark task slots is subject to cluster sizing."
-                .format(d=parallelism, s=spark_default_parallelism, t=max_num_concurrent_tasks)
+                "the total of Spark task slots is subject to cluster sizing.".format(
+                    d=parallelism,
+                    s=spark_default_parallelism,
+                    t=max_num_concurrent_tasks,
+                )
             )
         else:
             parallelism = requested_parallelism
 
         if parallelism > SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED:
             logger.warning(
-                "Parallelism ({p}) is capped at SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED ({c})."
-                .format(p=parallelism, c=SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED)
+                "Parallelism ({p}) is capped at SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED ({c}).".format(
+                    p=parallelism, c=SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED
+                )
             )
             parallelism = SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED
 
         if parallelism > max_num_concurrent_tasks:
             logger.warning(
                 "Parallelism ({p}) is greater than the current total of Spark task slots ({c}). "
-                "If dynamic allocation is enabled, you might see more executors allocated."
-                .format(p=requested_parallelism, c=max_num_concurrent_tasks)
+                "If dynamic allocation is enabled, you might see more executors allocated.".format(
+                    p=requested_parallelism, c=max_num_concurrent_tasks
+                )
             )
         return parallelism
 
@@ -231,7 +232,7 @@ class SparkTrials(Trials):
 
         if loss_threshold is not None:
             validate_loss_threshold(loss_threshold)
-            self.loss_threshold=loss_threshold
+            self.loss_threshold = loss_threshold
 
         assert (
             not pass_expr_memo_ctrl

--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -59,10 +59,10 @@ class SparkTrials(Trials):
         """
         :param parallelism: Maximum number of parallel trials to run,
                             i.e., maximum number of concurrent Spark tasks.
-                            If set to None or and invalid value, this will be set to the number of
-                            executors in your Spark cluster.
+                            If set to None or negative value, this will be set to
+                            max(spark_default_parallelism, spark_max_num_concurrent_tasks)).
                             Hard cap at `MAX_CONCURRENT_JOBS_ALLOWED`.
-                            Default: None (= number of Spark executors).
+                            Default: None.
         :param timeout: Maximum time (in seconds) which fmin is allowed to take.
                         If this timeout is hit, then fmin will cancel running and proposed trials.
                         It will retain all completed trial runs and return the best result found
@@ -120,14 +120,14 @@ class SparkTrials(Trials):
             spark_default_parallelism,
             max_num_concurrent_tasks):
         """
-        Given the user-set value of parallelism, return the value SparkTrials will actually use.
+        Given the requested parallelism, return the value SparkTrials will actually use.
         See the docstring for `parallelism` in the constructor for expected behavior.
         """
         #
         if requested_parallelism is None or requested_parallelism <= 0:
             parallelism = max(spark_default_parallelism, max_num_concurrent_tasks)
             warnings.warn(
-                "Because user-specified parallelism was None or was non-negative value, "
+                "Because user-specified parallelism was None or was negative value, "
                 "parallelism will be set to default parallelism ({d}), which equals to "
                 "max(spark_default_parallelism, max_num_concurrent_tasks)), "
                 "this feature is deprecated, and in next released version, "

--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -124,8 +124,6 @@ class SparkTrials(Trials):
         See the docstring for `parallelism` in the constructor for expected behavior.
         """
         default_parallelism = max(spark_default_parallelism, max_num_concurrent_tasks)
-        if default_parallelism > SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED:
-            default_parallelism = SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED
         if requested_parallelism is None or requested_parallelism <= 0:
             if requested_parallelism <= 0:
                 logger.warning(
@@ -151,7 +149,9 @@ class SparkTrials(Trials):
                     p=requested_parallelism, c=max_num_concurrent_tasks
                 )
             )
-        if requested_parallelism > SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED:
+            parallelism = requested_parallelism
+
+        if parallelism > SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED:
             logger.warning(
                 "Parallelism ({p}) is being decreased to the hard cap of "
                 "SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED ({c})".format(

--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -133,13 +133,12 @@ class SparkTrials(Trials):
             parallelism = max_num_concurrent_tasks
         elif parallelism > max_num_concurrent_tasks:
             logger.warning(
-                "User-specified parallelism ({p}) is greater than "
-                "max_num_concurrent_tasks ({c}), so parallelism will be set to "
-                "max_num_concurrent_tasks.".format(
+                "User-specified parallelism ({p}) is greater than the max number of concurrent "
+                "tasks ({c}) this cluster can run now. If dynamic allocation is enabled for the "
+                "cluster, you might see more executors allocated.".format(
                     p=parallelism, c=max_num_concurrent_tasks
                 )
             )
-            parallelism = max_num_concurrent_tasks
         if parallelism > SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED:
             logger.warning(
                 "Parallelism ({p}) is being decreased to the hard cap of "

--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -124,6 +124,8 @@ class SparkTrials(Trials):
         See the docstring for `parallelism` in the constructor for expected behavior.
         """
         default_parallelism = max(spark_default_parallelism, max_num_concurrent_tasks)
+        if default_parallelism > SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED:
+            default_parallelism = SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED
         if requested_parallelism is None or requested_parallelism <= 0:
             if requested_parallelism <= 0:
                 logger.warning(
@@ -149,7 +151,7 @@ class SparkTrials(Trials):
                     p=requested_parallelism, c=max_num_concurrent_tasks
                 )
             )
-        if parallelism > SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED:
+        if requested_parallelism > SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED:
             logger.warning(
                 "Parallelism ({p}) is being decreased to the hard cap of "
                 "SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED ({c})".format(

--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -4,7 +4,6 @@ import copy
 import threading
 import time
 import timeit
-import warnings
 
 from hyperopt import base, fmin, Trials
 from hyperopt.base import validate_timeout, validate_loss_threshold
@@ -126,14 +125,14 @@ class SparkTrials(Trials):
         #
         if requested_parallelism is None or requested_parallelism <= 0:
             parallelism = max(spark_default_parallelism, max_num_concurrent_tasks)
-            warnings.warn(
+            logger.warning(
                 "Because user-specified parallelism was None or was negative value, "
                 "parallelism will be set to default parallelism ({d}), which equals to "
                 "max(spark_default_parallelism, max_num_concurrent_tasks)), "
                 "this feature is deprecated, and in next released version, "
                 "user must specify parallelism explicitly, because default parallelism is not "
                 "stable when the cluster can auto-scale or spark executor registration comes late."
-                .format(d=parallelism), DeprecationWarning
+                .format(d=parallelism)
             )
         else:
             parallelism = requested_parallelism

--- a/hyperopt/tests/test_spark.py
+++ b/hyperopt/tests/test_spark.py
@@ -291,8 +291,8 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
                     )
                     log_output = output.getvalue().strip()
                     self.assertIn(
-                        "Because user-specified parallelism was None or was negative value, "
-                        "parallelism will be set to default parallelism ({d})"
+                        "Because the requested parallelism was None or a non-positive value, "
+                        "parallelism will be set to ({d})"
                         .format(d=default_parallelism),
                         log_output,
                         """set to default parallelism missing from log: {log_output}"""

--- a/hyperopt/tests/test_spark.py
+++ b/hyperopt/tests/test_spark.py
@@ -306,7 +306,7 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
             )
             self.assertEqual(
                 parallelism,
-                max_num_concurrent_tasks,
+                max_num_concurrent_tasks + 1,
                 "Failed to limit parallelism ({p}) to max_num_concurrent_tasks"
                 " ({e})".format(p=parallelism, e=max_num_concurrent_tasks),
             )

--- a/hyperopt/tests/test_spark.py
+++ b/hyperopt/tests/test_spark.py
@@ -291,7 +291,7 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
                     )
                     log_output = output.getvalue().strip()
                     self.assertIn(
-                        "Because user-specified parallelism was None or was non-negative value, "
+                        "Because user-specified parallelism was None or was negative value, "
                         "parallelism will be set to default parallelism ({d})"
                         .format(d=default_parallelism),
                         log_output,

--- a/hyperopt/tests/test_spark.py
+++ b/hyperopt/tests/test_spark.py
@@ -274,7 +274,9 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
         )
 
         for spark_default_parallelism, max_num_concurrent_tasks in [(2, 4), (2, 0)]:
-            default_parallelism = max(spark_default_parallelism, max_num_concurrent_tasks)
+            default_parallelism = max(
+                spark_default_parallelism, max_num_concurrent_tasks
+            )
 
             # Test requested_parallelism is None or negative values.
             for requested_parallelism in [None, -1]:
@@ -282,7 +284,8 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
                     parallelism = SparkTrials._decide_parallelism(
                         requested_parallelism=requested_parallelism,
                         spark_default_parallelism=spark_default_parallelism,
-                        max_num_concurrent_tasks=max_num_concurrent_tasks)
+                        max_num_concurrent_tasks=max_num_concurrent_tasks,
+                    )
                     self.assertEqual(
                         parallelism,
                         default_parallelism,
@@ -292,11 +295,13 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
                     log_output = output.getvalue().strip()
                     self.assertIn(
                         "Because the requested parallelism was None or a non-positive value, "
-                        "parallelism will be set to ({d})"
-                        .format(d=default_parallelism),
+                        "parallelism will be set to ({d})".format(
+                            d=default_parallelism
+                        ),
                         log_output,
-                        """set to default parallelism missing from log: {log_output}"""
-                        .format(log_output=log_output),
+                        """set to default parallelism missing from log: {log_output}""".format(
+                            log_output=log_output
+                        ),
                     )
 
             # Test requested_parallelism which will trigger spark executor dynamic allocation.
@@ -304,20 +309,24 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
                 parallelism = SparkTrials._decide_parallelism(
                     requested_parallelism=max_num_concurrent_tasks + 1,
                     spark_default_parallelism=spark_default_parallelism,
-                    max_num_concurrent_tasks=max_num_concurrent_tasks
+                    max_num_concurrent_tasks=max_num_concurrent_tasks,
                 )
                 self.assertEqual(
                     parallelism,
                     max_num_concurrent_tasks + 1,
-                    "Expect parallelism to be ({e}) but get ({p})"
-                    .format(p=parallelism, e=max_num_concurrent_tasks + 1),
+                    "Expect parallelism to be ({e}) but get ({p})".format(
+                        p=parallelism, e=max_num_concurrent_tasks + 1
+                    ),
                 )
                 log_output = output.getvalue().strip()
                 self.assertIn(
-                    "Parallelism ({p}) is greater".format(p=max_num_concurrent_tasks + 1),
+                    "Parallelism ({p}) is greater".format(
+                        p=max_num_concurrent_tasks + 1
+                    ),
                     log_output,
-                    """Parallelism ({p}) missing from log: {log_output}"""
-                    .format(p=max_num_concurrent_tasks + 1, log_output=log_output),
+                    """Parallelism ({p}) missing from log: {log_output}""".format(
+                        p=max_num_concurrent_tasks + 1, log_output=log_output
+                    ),
                 )
 
             # Test requested_parallelism exceeds hard cap
@@ -330,8 +339,9 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
                 self.assertEqual(
                     parallelism,
                     SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED,
-                    "Failed to limit parallelism ({p}) to MAX_CONCURRENT_JOBS_ALLOWED ({e})"
-                    .format(p=parallelism, e=SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED),
+                    "Failed to limit parallelism ({p}) to MAX_CONCURRENT_JOBS_ALLOWED ({e})".format(
+                        p=parallelism, e=SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED
+                    ),
                 )
                 log_output = output.getvalue().strip()
                 self.assertIn(
@@ -339,8 +349,9 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
                         c=SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED
                     ),
                     log_output,
-                    """MAX_CONCURRENT_JOBS_ALLOWED value missing from log: {log_output}"""
-                    .format(log_output=log_output),
+                    """MAX_CONCURRENT_JOBS_ALLOWED value missing from log: {log_output}""".format(
+                        log_output=log_output
+                    ),
                 )
 
     def test_all_successful_trials(self):

--- a/hyperopt/tests/test_spark.py
+++ b/hyperopt/tests/test_spark.py
@@ -296,9 +296,9 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
                     ),
                 )
                 self.assertIn(
-                    "max number of concurrent tasks ({c})".format(c=max_num_concurrent_tasks),
+                    "be set to default parallelism ({c},".format(c=max_num_concurrent_tasks),
                     log_output,
-                    """max number of concurrent tasks value missing from log: {log_output}"""
+                    """set to default parallelism missing from log: {log_output}"""
                     .format(log_output=log_output),
                 )
 
@@ -323,9 +323,9 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
                     .format(p=max_num_concurrent_tasks + 1, log_output=log_output),
                 )
                 self.assertIn(
-                    "max number of concurrent tasks ({c})".format(c=max_num_concurrent_tasks),
+                    "be set to default parallelism ({c},".format(c=max_num_concurrent_tasks),
                     log_output,
-                    """max number of concurrent tasks value missing from log: {log_output}"""
+                    """set to default parallelism missing from log: {log_output}"""
                     .format(log_output=log_output),
                 )
 

--- a/hyperopt/tests/test_spark.py
+++ b/hyperopt/tests/test_spark.py
@@ -292,9 +292,9 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
                 ),
             )
             self.assertIn(
-                "max_num_concurrent_tasks ({c})".format(c=max_num_concurrent_tasks),
+                "max number of concurrent tasks ({c})".format(c=max_num_concurrent_tasks),
                 log_output,
-                """max_num_concurrent_tasks value missing from log: {log_output}""".format(
+                """max number of concurrent tasks value missing from log: {log_output}""".format(
                     log_output=log_output
                 ),
             )
@@ -319,9 +319,9 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
                 ),
             )
             self.assertIn(
-                "max_num_concurrent_tasks ({c})".format(c=max_num_concurrent_tasks),
+                "max number of concurrent tasks ({c})".format(c=max_num_concurrent_tasks),
                 log_output,
-                """max_num_concurrent_tasks value missing from log: {log_output}""".format(
+                """max number of concurrent tasks value missing from log: {log_output}""".format(
                     log_output=log_output
                 ),
             )

--- a/hyperopt/tests/test_spark.py
+++ b/hyperopt/tests/test_spark.py
@@ -273,73 +273,80 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
             ),
         )
 
-        max_num_concurrent_tasks = 4
-        # Given invalidly small parallelism
-        with patch_logger("hyperopt-spark") as output:
-            parallelism = SparkTrials._decide_parallelism(max_num_concurrent_tasks, -1)
-            self.assertEqual(
-                parallelism,
-                max_num_concurrent_tasks,
-                "Failed to default parallelism ({p}) to max_num_concurrent_tasks"
-                " ({e})".format(p=parallelism, e=max_num_concurrent_tasks),
-            )
-            log_output = output.getvalue().strip()
-            self.assertIn(
-                "invalid value (-1)",
-                log_output,
-                """Invalid parallelism value -1 missing from log: {log_output}""".format(
-                    log_output=log_output
-                ),
-            )
-            self.assertIn(
-                "max number of concurrent tasks ({c})".format(c=max_num_concurrent_tasks),
-                log_output,
-                """max number of concurrent tasks value missing from log: {log_output}""".format(
-                    log_output=log_output
-                ),
-            )
+        for spark_default_parallelism, max_num_concurrent_tasks in [(2, 4), (2, 0)]:
+            default_parallelism = max(spark_default_parallelism, max_num_concurrent_tasks)
+            # Given invalidly small parallelism
+            with patch_logger("hyperopt-spark") as output:
+                parallelism = SparkTrials._decide_parallelism(
+                    requested_parallelism=-1,
+                    spark_default_parallelism=spark_default_parallelism,
+                    max_num_concurrent_tasks=max_num_concurrent_tasks)
+                self.assertEqual(
+                    parallelism,
+                    default_parallelism,
+                    "Failed to set parallelism to be default parallelism ({p})"
+                    " ({e})".format(p=parallelism, e=default_parallelism),
+                )
+                log_output = output.getvalue().strip()
+                self.assertIn(
+                    "invalid value (-1)",
+                    log_output,
+                    """Invalid parallelism value -1 missing from log: {log_output}""".format(
+                        log_output=log_output
+                    ),
+                )
+                self.assertIn(
+                    "max number of concurrent tasks ({c})".format(c=max_num_concurrent_tasks),
+                    log_output,
+                    """max number of concurrent tasks value missing from log: {log_output}"""
+                    .format(log_output=log_output),
+                )
 
-        # Given invalidly large parallelism
-        with patch_logger("hyperopt-spark") as output:
+            # Given invalidly large parallelism
+            with patch_logger("hyperopt-spark") as output:
+                parallelism = SparkTrials._decide_parallelism(
+                    requested_parallelism=max_num_concurrent_tasks + 1,
+                    spark_default_parallelism=spark_default_parallelism,
+                    max_num_concurrent_tasks=max_num_concurrent_tasks
+                )
+                self.assertEqual(
+                    parallelism,
+                    max_num_concurrent_tasks + 1,
+                    "Expect parallelism to be ({e}) but get ({p})"
+                    .format(p=parallelism, e=max_num_concurrent_tasks + 1),
+                )
+                log_output = output.getvalue().strip()
+                self.assertIn(
+                    "parallelism ({p}) is greater".format(p=max_num_concurrent_tasks + 1),
+                    log_output,
+                    """User-specified parallelism ({p}) missing from log: {log_output}"""
+                    .format(p=max_num_concurrent_tasks + 1, log_output=log_output),
+                )
+                self.assertIn(
+                    "max number of concurrent tasks ({c})".format(c=max_num_concurrent_tasks),
+                    log_output,
+                    """max number of concurrent tasks value missing from log: {log_output}"""
+                    .format(log_output=log_output),
+                )
+
+            # Given valid parallelism
             parallelism = SparkTrials._decide_parallelism(
-                max_num_concurrent_tasks, max_num_concurrent_tasks + 1
-            )
+                requested_parallelism=None,
+                spark_default_parallelism=spark_default_parallelism,
+                max_num_concurrent_tasks=max_num_concurrent_tasks)
             self.assertEqual(
                 parallelism,
-                max_num_concurrent_tasks + 1,
-                "Failed to limit parallelism ({p}) to max_num_concurrent_tasks"
-                " ({e})".format(p=parallelism, e=max_num_concurrent_tasks),
+                default_parallelism,
+                "Failed to set parallelism to be default parallelism ({p})"
+                " ({e})".format(p=parallelism, e=default_parallelism),
             )
-            log_output = output.getvalue().strip()
-            self.assertIn(
-                "parallelism ({p}) is greater".format(p=max_num_concurrent_tasks + 1),
-                log_output,
-                """User-specified parallelism ({p}) missing from log: {log_output}""".format(
-                    p=max_num_concurrent_tasks + 1, log_output=log_output
-                ),
-            )
-            self.assertIn(
-                "max number of concurrent tasks ({c})".format(c=max_num_concurrent_tasks),
-                log_output,
-                """max number of concurrent tasks value missing from log: {log_output}""".format(
-                    log_output=log_output
-                ),
-            )
-
-        # Given valid parallelism
-        parallelism = SparkTrials._decide_parallelism(max_num_concurrent_tasks, None)
-        self.assertEqual(
-            parallelism,
-            max_num_concurrent_tasks,
-            "The default parallelism ({p}) did not equal max_num_concurrent_tasks"
-            " ({e})".format(p=parallelism, e=max_num_concurrent_tasks),
-        )
 
         # Given invalid parallelism relative to hard cap
         with patch_logger("hyperopt-spark") as output:
             parallelism = SparkTrials._decide_parallelism(
-                max_num_concurrent_tasks=SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED + 1,
                 parallelism=None,
+                spark_default_parallelism=2,
+                max_num_concurrent_tasks=SparkTrials.MAX_CONCURRENT_JOBS_ALLOWED + 1,
             )
             self.assertEqual(
                 parallelism,

--- a/hyperopt/tests/test_spark.py
+++ b/hyperopt/tests/test_spark.py
@@ -289,7 +289,7 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
                 )
                 log_output = output.getvalue().strip()
                 self.assertIn(
-                    "invalid value (-1)",
+                    "non-negative value (-1)",
                     log_output,
                     """Invalid parallelism value -1 missing from log: {log_output}""".format(
                         log_output=log_output


### PR DESCRIPTION
Support dynamic allocation in hyperopt integration. Only throw a warning when current task slots is smaller than requested parallelism.

When user specify parallelism to be greater than `max_num_concurrent_tasks`, print a warning notify user that this will trigger spark executor dynamic allocation (if spark configured with dynamic allocation mode).

When user do not specify parallelism, it will be set to `max(spark_default_parallelism, max_num_concurrent_tasks)` as default behavior, and print a deprecation warning, next released version will remove this default behavior.