### PR TITLE
Adds dist range validation to pyll expressions

### DIFF
--- a/hyperopt/pyll_utils.py
+++ b/hyperopt/pyll_utils.py
@@ -25,6 +25,25 @@ def validate_label(f):
     return wrapper
 
 
+def validate_distribution_range(f):
+    @wraps(f)
+    def wrapper(label, *args, **kwargs):
+        min_val = (
+            args[0] if len(args) > 0 else (kwargs["low"] if "low" in kwargs else None)
+        )
+        max_val = (
+            args[1] if len(args) > 1 else (kwargs["high"] if "high" in kwargs else None)
+        )
+        if min_val and max_val and not min_val < max_val:
+            raise ValueError(
+                "low should be less than high: %s is not smaller than %s"
+                % (min_val, max_val)
+            )
+        return f(label, *args, **kwargs)
+
+    return wrapper
+
+
 #
 # Hyperparameter Types
 #
@@ -64,6 +83,7 @@ def hp_randint(label, *args, **kwargs):
 
 
 @validate_label
+@validate_distribution_range
 def hp_uniform(label, *args, **kwargs):
     return scope.float(scope.hyperopt_param(label, scope.uniform(*args, **kwargs)))
 
@@ -75,16 +95,19 @@ def hp_uniformint(label, *args, **kwargs):
 
 
 @validate_label
+@validate_distribution_range
 def hp_quniform(label, *args, **kwargs):
     return scope.float(scope.hyperopt_param(label, scope.quniform(*args, **kwargs)))
 
 
 @validate_label
+@validate_distribution_range
 def hp_loguniform(label, *args, **kwargs):
     return scope.float(scope.hyperopt_param(label, scope.loguniform(*args, **kwargs)))
 
 
 @validate_label
+@validate_distribution_range
 def hp_qloguniform(label, *args, **kwargs):
     return scope.float(scope.hyperopt_param(label, scope.qloguniform(*args, **kwargs)))
 

--- a/hyperopt/tests/test_pyll_utils.py
+++ b/hyperopt/tests/test_pyll_utils.py
@@ -1,9 +1,11 @@
 from __future__ import print_function
 from builtins import map
+from hyperopt import pyll_utils
 from hyperopt.pyll_utils import EQ
 from hyperopt.pyll_utils import expr_to_config
 from hyperopt import hp
 from hyperopt.pyll import as_apply
+import unittest
 
 
 def test_expr_to_config():
@@ -80,3 +82,41 @@ def test_remove_allpaths_int():
     zconds = hps["z"]["conditions"]
     assert aconds == set([(True,)]), aconds
     assert zconds == set([(True,)]), zconds
+
+
+@pyll_utils.validate_distribution_range
+def stub_pyll_fn(label, low, high):
+    """
+    Stub function to test distribution range validation fn
+    """
+    pass
+
+
+class TestValidateDistributionRange(unittest.TestCase):
+    """
+    We can't test low being set via kwarg while high is set via arg because
+    that's not a validate fn call
+    """
+
+    def test_raises_error_for_low_arg_high_arg(self):
+        self.assertRaises(ValueError, stub_pyll_fn, "stub", 1, 1)
+
+    def test_raises_error_for_low_arg_high_kwarg(self):
+        self.assertRaises(ValueError, stub_pyll_fn, "stub", 1, high=1)
+
+    def test_raises_error_for_low_kwarg_high_kwarg(self):
+        self.assertRaises(ValueError, stub_pyll_fn, "stub", low=1, high=1)
+
+
+class TestDistributionsWithRangeValidateBoundries(unittest.TestCase):
+    def test_hp_uniform_raises_error_when_range_is_zero(self):
+        self.assertRaises(ValueError, hp.uniform, "stub", 10, 10)
+
+    def test_hp_quniform_raises_error_when_range_is_zero(self):
+        self.assertRaises(ValueError, hp.quniform, "stub", 10, 10, 1)
+
+    def test_hp_loguniform_raises_error_when_range_is_zero(self):
+        self.assertRaises(ValueError, hp.loguniform, "stub", 10, 10, 1)
+
+    def test_hp_qloguniform_raises_error_when_range_is_zero(self):
+        self.assertRaises(ValueError, hp.qloguniform, "stub", 10, 10, 1)


### PR DESCRIPTION
quniform and similar expressions have a low and high value.
When these match, parameter exploration can fail at some point.
This validation checks that the range (high - low) is positive
and raises an error when the expression is instantiated