### PR TITLE
Relax networkx requirement to >=2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,7 @@ setuptools.setup(
         "numpy",
         "scipy",
         "six",
-        "networkx==2.2",
+        "networkx>=2.2",
         "future",
         "tqdm",
         "cloudpickle",


### PR DESCRIPTION
Python3 users will get a more recent version, causing less conflicts with other packages.

As requested here.
https://github.com/hyperopt/hyperopt/issues/614