### PR TITLE
Remove test of method which no longer exists.

### DIFF
--- a/hyperopt/pyll/tests/test_base.py
+++ b/hyperopt/pyll/tests/test_base.py
@@ -206,7 +206,6 @@ def test_bincount():
         assert list(counts) == [0, 0, 0, 4, 3, 3, 0]
 
     try:
-        test_f(base._bincount_slow)
         test_f(base.bincount)
     except TypeError as e:
         if "function takes at most 2 arguments" in str(e):


### PR DESCRIPTION
Remove this line since `_bincount_slow()` has been removed and will cause tests to fail.