### PR TITLE
[ML-10384] Replace the retry warnings for long running tasks in SparkTrials

### DIFF
--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -490,7 +490,7 @@ class _SparkFMinState:
             try:
                 worker_rdd = self.spark.sparkContext.parallelize([0], 1)
                 if self.trials._spark_supports_job_cancelling:
-                    result = worker_rdd.mapPartitions(
+                    result_or_e = worker_rdd.mapPartitions(
                         run_task_on_executor
                     ).collectWithJobGroup(
                         self._job_group_id,
@@ -498,7 +498,7 @@ class _SparkFMinState:
                         self._job_interrupt_on_cancel,
                     )[0]
                 else:
-                    result = worker_rdd.mapPartitions(run_task_on_executor).collect()[0]
+                    result_or_e = worker_rdd.mapPartitions(run_task_on_executor).collect()[0]
             except BaseException as e:
                 # I recommend to catch all exceptions here, it can make the program more robust.
                 # There're several possible reasons lead to raising exception here.
@@ -508,7 +508,7 @@ class _SparkFMinState:
                 # Otherwise it represent the task failed.
                 finish_trial_run(e)
             else:
-                finish_trial_run(result)
+                finish_trial_run(result_or_e)
 
         task_thread = threading.Thread(target=run_task_thread)
         task_thread.setDaemon(True)

--- a/hyperopt/tests/test_spark.py
+++ b/hyperopt/tests/test_spark.py
@@ -223,7 +223,7 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
                     ),
                 )
             elif trial["state"] == base.JOB_STATE_ERROR:
-                err_message = trial["misc"]["error"][1]
+                err_message = trial["misc"]["error"][0]
                 self.assertIn(
                     "RuntimeError",
                     err_message,

--- a/hyperopt/tests/test_spark.py
+++ b/hyperopt/tests/test_spark.py
@@ -627,32 +627,3 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
                     log_output=log_output
                 ),
             )
-
-        # With slow trials, print warning.
-        ORIG_LONG_TRIAL_DEFINITION_SECONDS = (
-            _SparkFMinState._LONG_TRIAL_DEFINITION_SECONDS
-        )
-        try:
-            _SparkFMinState._LONG_TRIAL_DEFINITION_SECONDS = 0
-            with patch_logger("hyperopt-spark", logging.DEBUG) as output:
-                fmin(
-                    fn=fn_succeed_within_range,
-                    space=hp.uniform("x", -1, 1),
-                    algo=anneal.suggest,
-                    max_evals=1,
-                    trials=SparkTrials(),
-                    rstate=np.random.RandomState(4),
-                )
-                log_output = output.getvalue().strip()
-                self.assertIn(
-                    "spark.task.maxFailures",
-                    log_output,
-                    """ "spark.task.maxFailures" warning missing from log: 
-                    {log_output}""".format(
-                        log_output=log_output
-                    ),
-                )
-        finally:
-            _SparkFMinState._LONG_TRIAL_DEFINITION_SECONDS = (
-                ORIG_LONG_TRIAL_DEFINITION_SECONDS
-            )


### PR DESCRIPTION
### Problem
In SparkTrials, the long-running tasks will trigger the following warning message:
```
Consider setting `spark.conf.set('spark.task.maxFailures', '1')` to prevent retries.
```
However, this spark conf cannot be changed after the spark session is initialized, and it's tricky to find the correct way to set it. If the user simply follows the instruction in the warning messages and update the spark conf in their code, they would get:
```
org.apache.spark.sql.AnalysisException: Cannot modify the value of a Spark config: spark.task.maxFailures;
```
### Proposed fix
1. Remove the `Consider setting spark.conf.set('spark.task.maxFailures', '1')` warning.
2. Capture the exception in `run_task_on_executor()`, handle the exception and return normally. This is to prevent Spark from retrying the failed task.
3. Refactor the code for `finish_trial_run` logic.

### Test
unittest