### PR TITLE
[#449] add early stop parameter and default implementation

### DIFF
--- a/hyperopt/base.py
+++ b/hyperopt/base.py
@@ -644,7 +644,7 @@ class Trials(object):
         catch_eval_exceptions=False,
         return_argmin=True,
         show_progressbar=True,
-        early_stop=None,
+        early_stop_fn=None,
     ):
         """Minimize a function over a hyperparameter space.
 
@@ -685,7 +685,7 @@ class Trials(object):
             catch_eval_exceptions=catch_eval_exceptions,
             return_argmin=return_argmin,
             show_progressbar=show_progressbar,
-            early_stop=early_stop,
+            early_stop_fn=early_stop_fn,
         )
 
 

--- a/hyperopt/base.py
+++ b/hyperopt/base.py
@@ -644,6 +644,7 @@ class Trials(object):
         catch_eval_exceptions=False,
         return_argmin=True,
         show_progressbar=True,
+        early_stop=None,
     ):
         """Minimize a function over a hyperparameter space.
 
@@ -684,6 +685,7 @@ class Trials(object):
             catch_eval_exceptions=catch_eval_exceptions,
             return_argmin=return_argmin,
             show_progressbar=show_progressbar,
+            early_stop=early_stop,
         )
 
 

--- a/hyperopt/early_stop.py
+++ b/hyperopt/early_stop.py
@@ -1,0 +1,35 @@
+import logging
+import math
+
+logger = logging.getLogger(__name__)
+
+
+def no_progress_loss(iteration_stop_count=20, percent_increase=0.0):
+    """
+    Stop function that will stop after X iteration if the loss doesn't increase
+
+    Parameters
+    ----------
+    iteration_stop_count: int
+        search will stop if the loss doesn't improve after this number of iteration
+    percent_increase: float
+        allow this percentage of variation within iteration_stop_count.
+        Early stop will be triggered if the data didn't change for more than this number
+        during iteration_stop_count rounds
+    """
+    def stop_fn(trials, best_loss=None, iteration_no_progress=0):
+        new_loss = trials.trials[len(trials.trials)-1]['result']['loss']
+        if best_loss == None:
+            return False, [new_loss, iteration_no_progress+1]
+        best_loss_threshold = best_loss - abs(best_loss * (percent_increase/100.0))
+        if new_loss < best_loss_threshold:
+            best_loss = new_loss
+            iteration_no_progress = 0
+        else:
+            iteration_no_progress += 1
+            logger.debug("No progress made: %d iteration on %d. best_loss=%.2f, best_loss_threshold=%.2f, new_loss=%.2f"
+                         % (iteration_no_progress, iteration_stop_count, best_loss, best_loss_threshold, new_loss))
+
+        return iteration_no_progress >= iteration_stop_count, [best_loss, iteration_no_progress]
+
+    return stop_fn

--- a/hyperopt/early_stop.py
+++ b/hyperopt/early_stop.py
@@ -1,5 +1,4 @@
 import logging
-import math
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +18,7 @@ def no_progress_loss(iteration_stop_count=20, percent_increase=0.0):
     """
     def stop_fn(trials, best_loss=None, iteration_no_progress=0):
         new_loss = trials.trials[len(trials.trials)-1]['result']['loss']
-        if best_loss == None:
+        if best_loss is None:
             return False, [new_loss, iteration_no_progress+1]
         best_loss_threshold = best_loss - abs(best_loss * (percent_increase/100.0))
         if new_loss < best_loss_threshold:

--- a/hyperopt/early_stop.py
+++ b/hyperopt/early_stop.py
@@ -14,7 +14,7 @@ def no_progress_loss(iteration_stop_count=20, percent_increase=0.0):
     percent_increase: float
         allow this percentage of variation within iteration_stop_count.
         Early stop will be triggered if the data didn't change for more than this number
-        during iteration_stop_count rounds
+        after iteration_stop_count rounds
     """
     def stop_fn(trials, best_loss=None, iteration_no_progress=0):
         new_loss = trials.trials[len(trials.trials)-1]['result']['loss']

--- a/hyperopt/fmin.py
+++ b/hyperopt/fmin.py
@@ -121,7 +121,7 @@ class FMinIter(object):
         loss_threshold=None,
         verbose=False,
         show_progressbar=True,
-        early_stop=None
+        early_stop_fn=None
     ):
         self.algo = algo
         self.domain = domain
@@ -139,7 +139,7 @@ class FMinIter(object):
         self.poll_interval_secs = poll_interval_secs
         self.max_queue_len = max_queue_len
         self.max_evals = max_evals
-        self.early_stop = early_stop
+        self.early_stop_fn = early_stop_fn
         self.early_stop_args = []
         self.timeout = timeout
         self.loss_threshold = loss_threshold
@@ -290,8 +290,8 @@ class FMinIter(object):
                     self.serial_evaluate()
 
                 self.trials.refresh()
-                if self.early_stop:
-                    stop, kwargs = self.early_stop(self.trials, *self.early_stop_args)
+                if self.early_stop_fn is not None:
+                    stop, kwargs = self.early_stop_fn(self.trials, *self.early_stop_args)
                     self.early_stop_args = kwargs
                     if stop:
                         logger.info("Early stop triggered. Stopping iterations as condition is reach.")
@@ -330,8 +330,8 @@ class FMinIter(object):
 
     def __next__(self):
         self.run(1, block_until_done=self.asynchronous)
-        if self.early_stop:
-            stop, kwargs = self.early_stop(self.trials, *self.early_stop_args)
+        if self.early_stop_fn is not None:
+            stop, kwargs = self.early_stop_fn(self.trials, *self.early_stop_args)
             self.early_stop_args = kwargs
             if stop:
                 raise StopIteration()
@@ -363,7 +363,7 @@ def fmin(
     points_to_evaluate=None,
     max_queue_len=1,
     show_progressbar=True,
-    early_stop=None,
+    early_stop_fn=None,
 ):
     """Minimize a function over a hyperparameter space.
 
@@ -461,7 +461,7 @@ def fmin(
     show_progressbar : bool or context manager, default True (or False is verbose is False).
         Show a progressbar. See `hyperopt.progress` for customizing progress reporting.
 
-    early_stop: callable ((result, **args) -> (Boolean, **args)).
+    early_stop_fn: callable ((result, *args) -> (Boolean, *args)).
         Called after every run with the result of the run and the values returned by the function previously.
         Stop the search if the function return true.
         Default None.
@@ -500,7 +500,7 @@ def fmin(
             catch_eval_exceptions=catch_eval_exceptions,
             return_argmin=return_argmin,
             show_progressbar=show_progressbar,
-            early_stop=early_stop,
+            early_stop_fn=early_stop_fn,
         )
 
     if trials is None:
@@ -523,7 +523,7 @@ def fmin(
         verbose=verbose,
         max_queue_len=max_queue_len,
         show_progressbar=show_progressbar,
-        early_stop=early_stop,
+        early_stop_fn=early_stop_fn,
     )
     rval.catch_eval_exceptions = catch_eval_exceptions
 

--- a/hyperopt/fmin.py
+++ b/hyperopt/fmin.py
@@ -121,6 +121,7 @@ class FMinIter(object):
         loss_threshold=None,
         verbose=False,
         show_progressbar=True,
+        early_stop=None
     ):
         self.algo = algo
         self.domain = domain
@@ -138,6 +139,8 @@ class FMinIter(object):
         self.poll_interval_secs = poll_interval_secs
         self.max_queue_len = max_queue_len
         self.max_evals = max_evals
+        self.early_stop = early_stop
+        self.early_stop_args = []
         self.timeout = timeout
         self.loss_threshold = loss_threshold
         self.start_time = timer()
@@ -266,6 +269,7 @@ class FMinIter(object):
                         new_ids, self.domain, trials, self.rstate.randint(2 ** 31 - 1)
                     )
                     assert len(new_ids) >= len(new_trials)
+
                     if len(new_trials):
                         self.trials.insert_trial_docs(new_trials)
                         self.trials.refresh()
@@ -286,7 +290,12 @@ class FMinIter(object):
                     self.serial_evaluate()
 
                 self.trials.refresh()
-
+                if self.early_stop:
+                    stop, kwargs = self.early_stop(self.trials, *self.early_stop_args)
+                    self.early_stop_args = kwargs
+                    if stop:
+                        logger.info("Early stop triggered. Stopping iterations as condition is reach.")
+                        stopped = True
                 # update progress bar with the min loss among trials with status ok
                 losses = [loss for loss in self.trials.losses() if loss is not None]
                 if losses:
@@ -321,6 +330,11 @@ class FMinIter(object):
 
     def __next__(self):
         self.run(1, block_until_done=self.asynchronous)
+        if self.early_stop:
+            stop, kwargs = self.early_stop(self.trials, *self.early_stop_args)
+            self.early_stop_args = kwargs
+            if stop:
+                raise StopIteration()
         if len(self.trials) >= self.max_evals:
             raise StopIteration()
         return self.trials
@@ -349,6 +363,7 @@ def fmin(
     points_to_evaluate=None,
     max_queue_len=1,
     show_progressbar=True,
+    early_stop=None,
 ):
     """Minimize a function over a hyperparameter space.
 
@@ -446,6 +461,11 @@ def fmin(
     show_progressbar : bool or context manager, default True (or False is verbose is False).
         Show a progressbar. See `hyperopt.progress` for customizing progress reporting.
 
+    early_stop: callable ((result, **args) -> (Boolean, **args)).
+        Called after every run with the result of the run and the values returned by the function previously.
+        Stop the search if the function return true.
+        Default None.
+
     Returns
     -------
 
@@ -480,6 +500,7 @@ def fmin(
             catch_eval_exceptions=catch_eval_exceptions,
             return_argmin=return_argmin,
             show_progressbar=show_progressbar,
+            early_stop=early_stop,
         )
 
     if trials is None:
@@ -502,6 +523,7 @@ def fmin(
         verbose=verbose,
         max_queue_len=max_queue_len,
         show_progressbar=show_progressbar,
+        early_stop=early_stop,
     )
     rval.catch_eval_exceptions = catch_eval_exceptions
 

--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -215,7 +215,7 @@ class SparkTrials(Trials):
         catch_eval_exceptions,
         return_argmin,
         show_progressbar,
-        early_stop,
+        early_stop_fn,
     ):
         """
         This should not be called directly but is called via :func:`hyperopt.fmin`
@@ -265,6 +265,7 @@ class SparkTrials(Trials):
                 return_argmin=return_argmin,
                 points_to_evaluate=None,  # not support
                 show_progressbar=show_progressbar,
+                early_stop_fn=early_stop_fn,
             )
         except BaseException as e:
             logger.debug("fmin thread exits with an exception raised.")

--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -215,6 +215,7 @@ class SparkTrials(Trials):
         catch_eval_exceptions,
         return_argmin,
         show_progressbar,
+        early_stop,
     ):
         """
         This should not be called directly but is called via :func:`hyperopt.fmin`

--- a/hyperopt/tests/test_fmin.py
+++ b/hyperopt/tests/test_fmin.py
@@ -4,6 +4,8 @@ import numpy as np
 import nose.tools
 from timeit import default_timer as timer
 import time
+from hyperopt.early_stop import no_progress_loss
+from hyperopt.fmin import generate_trials_to_calculate
 
 from hyperopt import (
     fmin,
@@ -330,3 +332,34 @@ def test_invalid_loss_threshold():
             )
         except Exception as e:
             assert str(e) == expected_message
+
+def test_early_stop():
+    trials = Trials()
+
+    #basic stop after 100 trials
+    def stop(trial, count=0):
+        return count+1 >= 100, [count+1]
+
+    fmin(
+        fn = lambda x: x,
+        space=hp.uniform("x", -5, 5),
+        algo=rand.suggest,
+        max_evals=500,
+        trials=trials,
+        early_stop=stop
+    )
+
+    assert len(trials) == 100
+
+def test_early_stop_no_progress_loss():
+    trials = generate_trials_to_calculate([{'x': -100}])
+    fmin(
+        fn = lambda x: x,
+        space=hp.uniform("x", -5, 5),
+        algo=rand.suggest,
+        max_evals=500,
+        trials=trials,
+        early_stop=no_progress_loss(10)
+    )
+
+    assert len(trials) == 10

--- a/hyperopt/tests/test_fmin.py
+++ b/hyperopt/tests/test_fmin.py
@@ -346,7 +346,7 @@ def test_early_stop():
         algo=rand.suggest,
         max_evals=500,
         trials=trials,
-        early_stop=stop
+        early_stop_fn=stop
     )
 
     assert len(trials) == 100
@@ -359,7 +359,7 @@ def test_early_stop_no_progress_loss():
         algo=rand.suggest,
         max_evals=500,
         trials=trials,
-        early_stop=no_progress_loss(10)
+        early_stop_fn=no_progress_loss(10)
     )
 
     assert len(trials) == 10


### PR DESCRIPTION
this PR add support for an early_stop parameter in the fmin function.
Hyperopt will stop the run when this function returns True.

Default implementation allow to stop the search if the loss doesn't increase after X run by a percent of X.
Custom implementations can also be added as stop function