### PR TITLE
Deal with nan loss by replacing min->nanmin, argmin->nanargmin

### DIFF
--- a/hyperopt/base.py
+++ b/hyperopt/base.py
@@ -236,7 +236,8 @@ def validate_timeout(timeout):
             "The timeout argument should be None or a positive value. "
             "Given value: {timeout}".format(timeout=timeout)
         )
-        
+
+
 def validate_loss_threshold(loss_threshold):
     if loss_threshold is not None and (
         not isinstance(loss_threshold, numbers.Number)
@@ -465,8 +466,18 @@ class Trials(object):
         assert len(tids) == len(specs) == len(results) == len(miscs)
         trials_docs = []
         for tid, spec, result, misc in zip(tids, specs, results, miscs):
-            doc = {"state": JOB_STATE_NEW, "tid": tid, "spec": spec, "result": result, "misc": misc,
-                   "exp_key": self._exp_key, "owner": None, "version": 0, "book_time": None, "refresh_time": None}
+            doc = {
+                "state": JOB_STATE_NEW,
+                "tid": tid,
+                "spec": spec,
+                "result": result,
+                "misc": misc,
+                "exp_key": self._exp_key,
+                "owner": None,
+                "version": 0,
+                "book_time": None,
+                "refresh_time": None,
+            }
             trials_docs.append(doc)
         return trials_docs
 
@@ -614,7 +625,7 @@ class Trials(object):
         losses = [float(t["result"]["loss"]) for t in candidates]
         if len(losses) == 0:
             return None
-        best = np.argmin(losses)
+        best = np.nanargmin(losses)
         return candidates[best]
 
     @property

--- a/hyperopt/fmin.py
+++ b/hyperopt/fmin.py
@@ -288,7 +288,11 @@ class FMinIter(object):
                 self.trials.refresh()
 
                 # update progress bar with the min loss among trials with status ok
-                losses = [loss for loss in self.trials.losses() if loss is not None]
+                losses = [
+                    loss
+                    for loss in self.trials.losses()
+                    if loss is not None and not np.isnan(loss)
+                ]
                 if losses:
                     best_loss = min(losses)
                     progress_ctx.postfix = "best loss: " + str(best_loss)

--- a/hyperopt/tpe.py
+++ b/hyperopt/tpe.py
@@ -898,7 +898,11 @@ def suggest(
 
     if verbose:
         if docs:
-            s = "%i/%i trials with best loss %f" % (len(docs), len(trials), min(losses))
+            s = "%i/%i trials with best loss %f" % (
+                len(docs),
+                len(trials),
+                np.nanmin(losses),
+            )
         else:
             s = "0 trials"
         logger.info("TPE using %s" % s)


### PR DESCRIPTION
Closes issue #662: 
- Currently the best loss can be reported wrongly in the progress bar due to relying on min() which is not safe when nans can occur (see issue for detailed description)
- Deal with the above by replacing `min` -> `nanmin`, `argmin` -> `nanargmin`, `if loss is not None` -> `if loss is not None and not np.isnan(loss)`. 