### PR TITLE
Unify __version__ in __init__.py and setup.py

### DIFF
--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -1,6 +1,5 @@
 
-1. Update the version number in setup.py
-1.5 Update the version in hyperopt/__init__.py
+1. Update the version number in hyperopt/__init__.py
 2. python setup.py sdist
 3. git tag -s <version> # TODO: determine annotated vs. signed [1]
 4. git push origin <version>

--- a/hyperopt/__init__.py
+++ b/hyperopt/__init__.py
@@ -40,4 +40,4 @@ from . import anneal
 # -- spark extension
 from .spark import SparkTrials
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,16 @@
+import io
+import re
+
 import setuptools
+
+with io.open('hyperopt/__init__.py', 'rt', encoding='utf8') as f:
+    version = re.search(r'__version__ = \"(.*?)\"', f.read()).group(1)
+    if version is None:
+        raise ImportError('Could not find __version__ in hyperopt/__init__.py')
 
 setuptools.setup(
     name="hyperopt",
-    version="0.2.4",
+    version=version,
     packages=setuptools.find_packages(include=["hyperopt*"]),
     entry_points={"console_scripts": ["hyperopt-mongo-worker=hyperopt.mongoexp:main"]},
     url="http://hyperopt.github.com/hyperopt/",


### PR DESCRIPTION
This PR fixes issue https://github.com/hyperopt/hyperopt/issues/657.

In future releases, we just need to update the __version__ variable in hyperopt/__init__.py and setup.py will pick up the version number from there. I also updated the RELEASE.txt.