### PR TITLE
Use ==/!= to compare constant literals (str, bytes, int, float, tuple)

### DIFF
--- a/hyperopt/atpe.py
+++ b/hyperopt/atpe.py
@@ -1528,7 +1528,7 @@ class ATPEOptimizer:
 
             for param in Hyperparameter(hyperparameterSpace).getFlatParameters():
                 value = result[param.name]
-                if value is not "" and value is not None:
+                if value not in ("", None):
                     if "enum" in param.config:
                         value = param.config["enum"].index(value)
 


### PR DESCRIPTION
Avoid [SyntaxWarnings on Python >= 3.8](https://docs.python.org/3/whatsnew/3.8.html#porting-to-python-3-8).

% `python3.8`
```
>>> "" is ""
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```