### PR TITLE
Travis CI: Add Python 3.8 to tests in allow_failures mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: xenial
+dist: trusty
 language: python
 
 cache:
@@ -26,17 +26,22 @@ jobs:
     - python: 3.6
       env:
         - IPYTHON=ipython[all]
-    - python: 3.7
+    - python: 3.6
+      dist: xenial
       env:
         - IPYTHON=ipython[all]
+    #- python: 3.7
+    #  dist: xenial
+    #  env:
+    #    - IPYTHON=ipython[all]
+    #    - NUMPY_VERSION=1.14.6
+    #- python: 3.8
+    #  dist: xenial
+    #  env:
+    #    - IPYTHON=ipython[all]
     #    - NUMPY_VERSION=1.19.0
-    - python: 3.8
-      env:
-        - IPYTHON=ipython[all]
-        - NUMPY_VERSION=1.19.0
   allow_failures:
-    - python: 3.7
-    - python: 3.8
+    - dist: xenial
 
 services:
   - mongodb
@@ -59,8 +64,7 @@ install:
   - pip install .[SparkTrials]
   - pip install .[ATPE]
   - pip install pytest>=3.6
-  - pip install pytest-cov pep8 pytest-pep8
-  - pip install wrapt
+  - pip install pytest-cov pep8 pytest-pep8 wrapt
 script:
   - ./run_tests.sh
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: xenial
+dist: trusty
 
 language: python
 
@@ -33,6 +33,7 @@ jobs:
     - python: 3.8
       env:
         - IPYTHON=ipython[all]
+        - NUMPY_VERSION=1.19.0
 
 services:
   - mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,12 @@ jobs:
       env:
         - IPYTHON=ipython[all]
     #- python: 3.7
+    #  dist: xenial
     #  env:
     #    - IPYTHON=ipython[all]
+    #    - NUMPY_VERSION=1.19.0
     - python: 3.8
+      dist: xenial
       env:
         - IPYTHON=ipython[all]
         - NUMPY_VERSION=1.19.0
@@ -55,7 +58,9 @@ install:
   - pip install .[MongoTrials]
   - pip install .[SparkTrials]
   - pip install .[ATPE]
-  - pip install pytest>=3.6 pytest-cov pep8 pytest-pep8 wrapt
+  - pip install pytest>=3.6
+  - pip install pytest-cov pep8 pytest-pep8
+  - pip install wrapt
 script:
   - ./run_tests.sh
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os: linux
-dist: trusty
-
+dist: xenial
 language: python
 
 cache:
@@ -27,18 +26,17 @@ jobs:
     - python: 3.6
       env:
         - IPYTHON=ipython[all]
-    #- python: 3.7
-    #  dist: xenial
-    #  env:
-    #    - IPYTHON=ipython[all]
+    - python: 3.7
+      env:
+        - IPYTHON=ipython[all]
     #    - NUMPY_VERSION=1.19.0
     - python: 3.8
-      dist: xenial
       env:
         - IPYTHON=ipython[all]
         - NUMPY_VERSION=1.19.0
   allow_failures:
-    - dist: xenial
+    - python: 3.7
+    - python: 3.8
 
 services:
   - mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ jobs:
       env:
         - IPYTHON=ipython[all]
         - NUMPY_VERSION=1.19.0
+  allow_failures:
+    - dist: xenial
 
 services:
   - mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,11 @@ jobs:
     #  env:
     #    - IPYTHON=ipython[all]
     #    - NUMPY_VERSION=1.14.6
-    #- python: 3.8
-    #  dist: xenial
-    #  env:
-    #    - IPYTHON=ipython[all]
-    #    - NUMPY_VERSION=1.19.0
+    - python: 3.8
+      dist: xenial
+      env:
+        - IPYTHON=ipython[all]
+        - NUMPY_VERSION=1.19.0
   allow_failures:
     - dist: xenial
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-dist: trusty
+os: linux
+dist: xenial
 
 language: python
 
@@ -15,7 +16,7 @@ env:
     - SPARK_HOME=$HOME/.cache/spark-versions/${SPARK_BUILD}
     - RUN_ONLY_LIGHT_TESTS=True
     - NUMPY_VERSION=1.14.3
-matrix:
+jobs:
   include:
     - python: 2.7
       env:
@@ -24,6 +25,12 @@ matrix:
       env:
         - IPYTHON=ipython[all]
     - python: 3.6
+      env:
+        - IPYTHON=ipython[all]
+    #- python: 3.7
+    #  env:
+    #    - IPYTHON=ipython[all]
+    - python: 3.8
       env:
         - IPYTHON=ipython[all]
 
@@ -47,9 +54,7 @@ install:
   - pip install .[MongoTrials]
   - pip install .[SparkTrials]
   - pip install .[ATPE]
-  - pip install pytest>=3.6
-  - pip install pytest-cov pep8 pytest-pep8
-  - pip install wrapt
+  - pip install pytest>=3.6 pytest-cov pep8 pytest-pep8 wrapt
 script:
   - ./run_tests.sh
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,11 @@ jobs:
     #  env:
     #    - IPYTHON=ipython[all]
     #    - NUMPY_VERSION=1.14.6
-    - python: 3.8
-      dist: xenial
-      env:
-        - IPYTHON=ipython[all]
-        - NUMPY_VERSION=1.19.0
+    #- python: 3.8
+    #  dist: xenial
+    #  env:
+    #    - IPYTHON=ipython[all]
+    #    - NUMPY_VERSION=1.19.0
   allow_failures:
     - dist: xenial
 


### PR DESCRIPTION
[Ubuntu Trusty is End of Life](https://releases.ubuntu.com) but when we try to upgrade to Xenial our Travis CI tests fail.

This PR creates adds Python 3.6 on Xenial run in __allow_failures__ mode so we can work to make the code compatible without breaking the build.  Once the tests pass on Xenial, we can remove allow_failures and add Python 3.7 and 3.8 to the testing.
