### PR TITLE
option to automatically save trials to a file each iteration

### DIFF
--- a/hyperopt/base.py
+++ b/hyperopt/base.py
@@ -654,6 +654,7 @@ class Trials(object):
         return_argmin=True,
         show_progressbar=True,
         early_stop_fn=None,
+        trials_save_file="",
     ):
         """Minimize a function over a hyperparameter space.
 
@@ -695,6 +696,7 @@ class Trials(object):
             return_argmin=return_argmin,
             show_progressbar=show_progressbar,
             early_stop_fn=early_stop_fn,
+            trials_save_file=trials_save_file,
         )
 
 

--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -217,6 +217,7 @@ class SparkTrials(Trials):
         return_argmin,
         show_progressbar,
         early_stop_fn,
+        trials_save_file="",
     ):
         """
         This should not be called directly but is called via :func:`hyperopt.fmin`
@@ -260,13 +261,14 @@ class SparkTrials(Trials):
                 trials=self,
                 allow_trials_fmin=False,  # -- prevent recursion
                 rstate=rstate,
-                pass_expr_memo_ctrl=None,  # not support
+                pass_expr_memo_ctrl=None,  # not supported
                 catch_eval_exceptions=catch_eval_exceptions,
                 verbose=verbose,
                 return_argmin=return_argmin,
-                points_to_evaluate=None,  # not support
+                points_to_evaluate=None,  # not supported
                 show_progressbar=show_progressbar,
                 early_stop_fn=early_stop_fn,
+                trials_save_file="",  # not supported
             )
         except BaseException as e:
             logger.debug("fmin thread exits with an exception raised.")


### PR DESCRIPTION
The user can give a filename to `fmin` where the `Trials` object will be saved to each iteration using pickle. This allows the optimization to be easily continued from where it left off if interrupted. If no trials argument is given to `fmin` it will load from this file if it exists instead of creating a new empty `Trials`. If a trials argument is given, it will use that one instead. Either way it will overwrite the file given to `trials_save_file` each iteration with the most up to date trials object it is using.

Simple example of usage:

```python
from hyperopt import Trials, tpe, hp, fmin

def objective(x):
    return {'loss':x**2,'status':hyperopt.STATUS_OK}

space = hp.uniform('x', -10, 10)

trials_fname = 'my_trials.pkl'

best = fmin(fn=objective, space=space, algo=tpe.suggest, trials_save_file=trials_fname, max_evals=100)
```