### PR TITLE
Update docs to match code

### DIFF
--- a/docs/templates/getting-started/minimizing_functions.md
+++ b/docs/templates/getting-started/minimizing_functions.md
@@ -200,7 +200,7 @@ which behaves like a string-to-string dictionary.
 ## The `Ctrl` Object for Realtime Communication with MongoDB
 
 It is possible for `fmin()` to give your objective function a handle to the mongodb used by a parallel experiment. This mechanism makes it possible to update the database with partial results, and to communicate with other concurrent processes that are evaluating different points.
-Your objective function can even add new search points, just like `random.suggest`.
+Your objective function can even add new search points, just like `rand.suggest`.
 
 The basic technique involves:
 

--- a/docs/templates/getting-started/overview.md
+++ b/docs/templates/getting-started/overview.md
@@ -14,7 +14,7 @@ The way to use hyperopt is to describe:
 * the search algorithm to use
 
 This (most basic) tutorial will walk through how to write functions and search spaces,
-using the default `Trials` database, and the dummy `random` search algorithm.
+using the default `Trials` database, and the dummy `rand` (random) search algorithm.
 Section (1) is about the different calling conventions for communication between an objective function and hyperopt.
 Section (2) is about describing search spaces.
 
@@ -22,7 +22,7 @@ Parallel search is possible when replacing the `Trials` database with
 a `MongoTrials` one;
 there is another wiki page on the subject of [using mongodb for parallel search](Parallelizing-Evaluations-During-Search-via-MongoDB).
 
-Choosing the search algorithm is as simple as passing `algo=hyperopt.tpe.suggest` instead of `algo=hyperopt.random.suggest`.
+Choosing the search algorithm is as simple as passing `algo=hyperopt.tpe.suggest` instead of `algo=hyperopt.rand.suggest`.
 The search algorithms are actually callable objects, whose constructors
 accept configuration arguments, but that's about all there is to say about the
 mechanics of choosing a search algorithm.

--- a/docs/templates/interfacing-languages.md
+++ b/docs/templates/interfacing-languages.md
@@ -24,9 +24,9 @@ def foo_wrapper(n):
 Of course, to optimize the `n` argument to `foo` you also need to call hyperopt.fmin, and define the search space. I can only imagine that you will want to do this part in Python.
 
 ```python
-from hyperopt import fmin, hp, random
+from hyperopt import fmin, hp, rand
 
-best_n = fmin(foo_wrapper, hp.quniform('n', 1, 100, 1), algo=random.suggest)
+best_n = fmin(foo_wrapper, hp.quniform('n', 1, 100, 1), algo=rand.suggest)
 
 print best_n
 ```


### PR DESCRIPTION
There was some confusion about module `random` not existing, solution being that it's name indeed is `rand`. This pr simply updates the docs to match that.

Could maintainers double-check that I understood the issue (mentioned below) correctly?

Fixes #247