### PR TITLE
Fix comparison glitch

### DIFF
--- a/hyperopt/atpe.py
+++ b/hyperopt/atpe.py
@@ -1540,7 +1540,7 @@ class ATPEOptimizer:
 
             for param in Hyperparameter(hyperparameterSpace).getFlatParameters():
                 value = result[param.name]
-                if value is not "" and value is not None:
+                if value != "" and value is not None:
                     if "enum" in param.config:
                         value = param.config["enum"].index(value)
 


### PR DESCRIPTION
`is not` should not be used for comparing strings, as it is an identity check and not an equality check.