### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -7,6 +7,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - run: pip install black==20.8b1 codespell flake8
-      - run: black --check . || true
+      - run: black --check .
       - run: codespell --ignore-words-list="hist,optionn" --quiet-level=2  # --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,12 @@
+name: lint_python
+on: push
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install black==20.8b1 codespell flake8
+      - run: black --check . || true
+      - run: codespell --quiet-level=2  # --ignore-words-list="" --skip=""
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -8,5 +8,5 @@ jobs:
       - uses: actions/setup-python@v2
       - run: pip install black==20.8b1 codespell flake8
       - run: black --check . || true
-      - run: codespell --quiet-level=2  # --ignore-words-list="" --skip=""
+      - run: codespell --ignore-words-list="hist,optionn" --quiet-level=2  # --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -10,15 +10,7 @@ import inspect
 import os
 import shutil
 
-import sys
-
-if sys.version[0] == "2":
-    reload(sys)
-    sys.setdefaultencoding("utf8")
-
-
 EXCLUDE = {}
-
 
 PAGES = [
     # {

--- a/hyperopt/fmin.py
+++ b/hyperopt/fmin.py
@@ -490,8 +490,8 @@ def fmin(
     argmin : dictionary
         If return_argmin is True returns `trials.argmin` which is a dictionary.  Otherwise
         this function  returns the result of `hyperopt.space_eval(space, trails.argmin)` if there
-        were successfull trails. This object shares the same structure as the space passed.
-        If there were no successfull trails, it returns None.
+        were successful trails. This object shares the same structure as the space passed.
+        If there were no successful trails, it returns None.
     """
     if algo is None:
         algo = tpe.suggest

--- a/hyperopt/pyll/base.py
+++ b/hyperopt/pyll/base.py
@@ -364,7 +364,7 @@ class Apply(object):
         if extra_args_ok:
             # XXX: THIS IS NOT BEING TESTED AND IS OBVIOUSLY BROKEN
             # TODO: 'args' does not even exist at this point
-            binding[args_param].extend(args[code.co_argcount :])
+            binding[args_param].extend(args[code.co_argcount :])  # noqa: F821
 
         # -- bind keyword arguments
         for aname, aval in self.named_args:
@@ -729,8 +729,8 @@ def clone_merge(expr, memo=None, merge_literals=False):
     #    XXX node.arg does not always work (builtins, weird co_flags)
     node_args = [(node.pos_args, node.named_args) for node in nodes]
     try:
-        del node
-    except:
+        del node  # noqa: F821
+    except NameError:
         pass
     for ii, node_ii in enumerate(nodes):
         if node_ii in memo:


### PR DESCRIPTION
Output: https://github.com/cclauss/hyperopt/actions 

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.