### PR TITLE
Travis CI: pip now has a real dependency resolver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,9 @@ before_script:
 
 install:
   - sudo apt-get remove ipython
-  - pip install --upgrade pip
-  - pip install --upgrade setuptools
-  - pip install --upgrade wheel
-  - pip install $IPYTHON
-  - pip install --only-binary=numpy,scipy numpy==$NUMPY_VERSION scipy
+  - pip install --upgrade pip setuptools wheel
+  - pip install --only-binary=numpy,scipy numpy==$NUMPY_VERSION scipy $IPYTHON nose wrapt pyspark==$SPARK_VERSION
   - pip install -e '.[MongoTrials, SparkTrials, ATPE, dev]'
-  - pip install nose
-  - pip install wrapt
-  - pip install pyspark==$SPARK_VERSION
 script:
   - pytest
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ before_script:
 
 install:
   - sudo apt-get remove ipython
-  - pip install --upgrade pip setuptools wheel pytest
-  - pip install --only-binary=numpy,scipy numpy==$NUMPY_VERSION scipy $IPYTHON nose wrapt pyspark==$SPARK_VERSION
+  - pip install --upgrade pip setuptools wheel coveralls pytest
+  - pip install --only-binary=numpy,scipy numpy==$NUMPY_VERSION scipy $IPYTHON wrapt pyspark==$SPARK_VERSION
   - pip install -e '.[MongoTrials, SparkTrials, ATPE, dev]'
 script:
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
 
 install:
   - sudo apt-get remove ipython
-  - pip install --upgrade pip setuptools wheel
+  - pip install --upgrade pip setuptools wheel pytools
   - pip install --only-binary=numpy,scipy numpy==$NUMPY_VERSION scipy $IPYTHON nose wrapt pyspark==$SPARK_VERSION
   - pip install -e '.[MongoTrials, SparkTrials, ATPE, dev]'
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
 
 install:
   - sudo apt-get remove ipython
-  - pip install --upgrade pip setuptools wheel pytools
+  - pip install --upgrade pip setuptools wheel pytest
   - pip install --only-binary=numpy,scipy numpy==$NUMPY_VERSION scipy $IPYTHON nose wrapt pyspark==$SPARK_VERSION
   - pip install -e '.[MongoTrials, SparkTrials, ATPE, dev]'
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
 install:
   - sudo apt-get remove ipython
   - pip install --upgrade pip setuptools wheel coveralls pytest
-  - pip install --only-binary=numpy,scipy numpy==$NUMPY_VERSION scipy $IPYTHON wrapt pyspark==$SPARK_VERSION
+  - pip install --only-binary=numpy,scipy numpy==$NUMPY_VERSION scipy $IPYTHON pyspark==$SPARK_VERSION
   - pip install -e '.[MongoTrials, SparkTrials, ATPE, dev]'
 script:
   - pytest


### PR DESCRIPTION
Let’s allow pip to properly resolve dependencies by providing them together, not in separate commands.