### PR TITLE
Travis CI: Add Python 3.9 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
       python: 3.8
     - name: "Run tests on python 3.9"
       python: 3.9
-      env: NUMPY_VERSION=1.19.2
+      env: NUMPY_VERSION=1.19.3
   allow_failures:
     - name: "Run tests on python 3.9"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ jobs:
     - name: "Run tests on python 3.9"
       python: 3.9
       env: NUMPY_VERSION=1.19.4
-  allow_failures: 
-    - name: "Run tests on python 3.9"
 
 install:
   - sudo apt-get remove ipython || true  # ipython is not pre-installed in Focal

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
   - mongo mydb_test --eval 'db.createUser({user:"travis",pwd:"test",roles:["readWrite"]});'
 
 install:
-  - sudo apt-get remove ipython
+  - sudo apt-get remove ipython || true  # ipython is not pre-installed in Focal
   - pip install --upgrade pip setuptools wheel
   - pip install $IPYTHON
   - pip install --only-binary=numpy,scipy numpy==$NUMPY_VERSION scipy

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,18 +30,15 @@ jobs:
       python: 3.8
     - name: "Run tests on python 3.9"
       python: 3.9
-      env: NUMPY_VERSION=1.19.3
+      env: NUMPY_VERSION=1.19.4
   allow_failures:
     - name: "Run tests on python 3.9"
 
 install:
   - sudo apt-get remove ipython || true  # ipython is not pre-installed in Focal
   - pip install --upgrade pip setuptools wheel
-  - pip install $IPYTHON
-  - pip install --only-binary=numpy,scipy numpy==$NUMPY_VERSION scipy
+  - pip install $IPYTHON numpy==$NUMPY_VERSION nose pyspark==$SPARK_VERSION scipy
   - pip install -e '.[MongoTrials, SparkTrials, ATPE, dev]'
-  - pip install nose
-  - pip install pyspark==$SPARK_VERSION
 
 before_script:
   - sleep 15 # mongo takes time to start

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
     - name: "Run tests on python 3.9"
       python: 3.9
       env: NUMPY_VERSION=1.19.4
-  allow_failures:
+  allow_failures: 
     - name: "Run tests on python 3.9"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-dist: bionic
+os: linux
+
+dist: focal
 
 language: python
 
@@ -31,18 +33,19 @@ install:
 
 jobs:
   include:
-    - stage: "lint"
-      name: "Run Linter (black)"
-      python: 3.8
+    - name: "Run Linter (black)"
+      python: 3.9
       script: black .
-    - stage: "test python 3.7"
-      name: "Run tests on python 3.7"
-      script: pytest
+    - name: "Run tests on python 3.7"
       python: 3.7
-    - stage: "test python 3.8"
-      name: "Run tests on python 3.8"
-      script: pytest
+    - name: "Run tests on python 3.8"
       python: 3.8
+    - name: "Run tests on python 3.9"
+      python: 3.9
+  allow_failures:
+    - name: "Run tests on python 3.9"
+
+script: pytest
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,21 @@ env:
 services:
   - mongodb
 
-before_script:
-  - sleep 15 # mongo takes time to start
-  - mongo mydb_test --eval 'db.createUser({user:"travis",pwd:"test",roles:["readWrite"]});'
+jobs:
+  include:
+    - name: "Run Linter (black)"
+      python: 3.9
+      install: pip install --upgrade black
+      script: black .
+    - name: "Run tests on python 3.7"
+      python: 3.7
+    - name: "Run tests on python 3.8"
+      python: 3.8
+    - name: "Run tests on python 3.9"
+      python: 3.9
+      env: NUMPY_VERSION=1.19.2
+  allow_failures:
+    - name: "Run tests on python 3.9"
 
 install:
   - sudo apt-get remove ipython || true  # ipython is not pre-installed in Focal
@@ -31,19 +43,9 @@ install:
   - pip install nose
   - pip install pyspark==$SPARK_VERSION
 
-jobs:
-  include:
-    - name: "Run Linter (black)"
-      python: 3.9
-      script: black .
-    - name: "Run tests on python 3.7"
-      python: 3.7
-    - name: "Run tests on python 3.8"
-      python: 3.8
-    - name: "Run tests on python 3.9"
-      python: 3.9
-  allow_failures:
-    - name: "Run tests on python 3.9"
+before_script:
+  - sleep 15 # mongo takes time to start
+  - mongo mydb_test --eval 'db.createUser({user:"travis",pwd:"test",roles:["readWrite"]});'
 
 script: pytest
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import re
 
 import setuptools
 
-with open("hyperopt/__init__.py", "rt", encoding="utf8") as f:
+with open("hyperopt/__init__.py", encoding="utf8") as f:
     version = re.search(r"__version__ = \"(.*?)\"", f.read()).group(1)
     if version is None:
         raise ImportError("Could not find __version__ in hyperopt/__init__.py")


### PR DESCRIPTION
Removes the stages to allow all four jobs can run in parallel.

~Scipy is not yet compatible with Python 3.9 so run that job in `allow_failures` mode.~