### PR TITLE
fix crash while saving attachments in MongoTrials

### DIFF
--- a/hyperopt/mongoexp.py
+++ b/hyperopt/mongoexp.py
@@ -911,6 +911,9 @@ class MongoTrials(Trials):
 
         # don't offer more here than in MongoCtrl
         class Attachments:
+            def __init__(self, handle):
+                self.handle = handle
+
             def __contains__(self, name):
                 return name in self.handle.attachment_names(doc=trial)
 
@@ -943,7 +946,7 @@ class MongoTrials(Trials):
             def items(self):
                 return [(k, self[k]) for k in self]
 
-        return Attachments()
+        return Attachments(self.handle)
 
     @property
     def attachments(self):

--- a/hyperopt/tests/test_mongoexp.py
+++ b/hyperopt/tests/test_mongoexp.py
@@ -305,9 +305,9 @@ class TestExperimentWithThreads(unittest.TestCase):
         while n_jobs:
             try:
                 mw.run_one(host_id, timeout, erase_created_workdir=True)
-                print("worker: %s ran job" % str(host_id))
+                print("worker: {} ran job".format(str(host_id)))
             except Exception as exc:
-                print("worker: %s failed :: %s" % (str(host_id), str(exc)))
+                print("worker: {} failed :: {}".format(str(host_id), str(exc)))
                 traceback.print_exc()
             n_jobs -= 1
 


### PR DESCRIPTION
fixes #624 

The "Trials object" example @  https://hyperopt.github.io/hyperopt/getting-started/minimizing_functions/#the-trials-object fails with `MongoTrials` since `Attachments` has no access to `MongoTrials.handle`

fixes the issue (#624) and also updates a test case to demonstrate the issue. 