### PR TITLE
fix crash while saving attachments in MongoTrials

### DIFF
--- a/hyperopt/mongoexp.py
+++ b/hyperopt/mongoexp.py
@@ -911,7 +911,7 @@ class MongoTrials(Trials):
 
         # don't offer more here than in MongoCtrl
         class Attachments:
-            def __init__(self, handle):
+            def __init__(self, handle: MongoJobs):
                 self.handle = handle
 
             def __contains__(self, name):

--- a/hyperopt/mongoexp.py
+++ b/hyperopt/mongoexp.py
@@ -911,6 +911,9 @@ class MongoTrials(Trials):
 
         # don't offer more here than in MongoCtrl
         class Attachments:
+            def __init__(self, handle):
+                self.handle = handle
+
             def __contains__(self, name):
                 return name in self.handle.attachment_names(doc=trial)
 
@@ -943,7 +946,7 @@ class MongoTrials(Trials):
             def items(self):
                 return [(k, self[k]) for k in self]
 
-        return Attachments()
+        return Attachments(self.handle)
 
     @property
     def attachments(self):

--- a/hyperopt/tests/test_mongoexp.py
+++ b/hyperopt/tests/test_mongoexp.py
@@ -3,6 +3,7 @@ import os
 import signal
 import subprocess
 import sys
+import traceback
 import threading
 import time
 import unittest
@@ -256,6 +257,48 @@ def test_attachments(trials):
     assert "aname" not in trials.attachments
 
 
+def test_trial_attachments():
+    def fmin_thread_fn(space, mongo_trials, evals):
+        fmin(
+            fn=passthrough_with_attachments,
+            space=space,
+            algo=rand.suggest,
+            trials=mongo_trials,
+            rstate=np.random.RandomState(),
+            max_evals=evals,
+            return_argmin=False,
+        )
+
+    exp_key = "A"
+    with TempMongo() as tm:
+        mj = tm.mongo_jobs("foo")
+        trials = MongoTrials(tm.connection_string("foo"), exp_key=exp_key)
+
+        domain = gauss_wave2()
+        max_evals = 3
+        fmin_thread = threading.Thread(
+            target=fmin_thread_fn, args=(domain.expr, trials, max_evals)
+        )
+        fmin_thread.start()
+
+        mw = MongoWorker(mj=mj, logfilename=None, workdir="mongoexp_test_dir")
+        n_jobs = max_evals
+        while n_jobs:
+            try:
+                mw.run_one("hostname", 10.0, erase_created_workdir=True)
+                print("worker: ran job")
+            except Exception as exc:
+                print(f"worker: encountered error : {str(exc)}")
+                traceback.print_exc()
+            n_jobs -= 1
+        fmin_thread.join()
+        all_trials = MongoTrials(tm.connection_string("foo"))
+
+        assert len(all_trials) == max_evals
+        assert trials.count_by_state_synced(JOB_STATE_DONE) == max_evals
+        assert trials.count_by_state_unsynced(JOB_STATE_DONE) == max_evals
+
+
 @with_mongo_trials
 def test_delete_all_on_attachments(trials):
     trials.attachments["aname"] = "a"
@@ -284,6 +327,13 @@ def passthrough(x):
         "cwd is %s" % os.getcwd()
     )
     return x
+
+
+def passthrough_with_attachments(x):
+    result = passthrough(x)
+    if isinstance(result, dict) and "attachments" not in result:
+        result["attachments"] = {"time": pickle.dumps(time.time())}
+    return result
 
 
 class TestExperimentWithThreads(unittest.TestCase):


### PR DESCRIPTION
fixes #624

The "Trials object" example @ https://hyperopt.github.io/hyperopt/getting-started/minimizing_functions/#the-trials-object fails with MongoTrials since Attachments has no access to MongoTrials.handle

fixes the issue (#624) and also updates a test case to demonstrate the issue.