### PR TITLE
Cache dependencies pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/pre-commit
+            ~/.cache/pip
+          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - uses: actions/setup-python@v2
       - run: pip install pre-commit
       - run: pre-commit --version


### PR DESCRIPTION
Cache the `pip` and `pre-commit` downloads. This will also cache all environments that `pre-commit` initializes at the start of each run.