### PR TITLE
docs: fix simple typo, fagile -> fragile

### DIFF
--- a/hyperopt/pyll/tests/test_stochastic.py
+++ b/hyperopt/pyll/tests/test_stochastic.py
@@ -39,7 +39,7 @@ def test_lnorm():
     print(lnorm)
     print(("len", len(str(lnorm))))
     # not sure what to assert
-    # ... this is too fagile
+    # ... this is too fragile
     # assert len(str(lnorm)) == 980
 
 


### PR DESCRIPTION
There is a small typo in hyperopt/pyll/tests/test_stochastic.py.

Should read `fragile` rather than `fagile`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md