### PR TITLE
Fixed implementation of "last_job_timeout" option

### DIFF
--- a/hyperopt/mongoexp.py
+++ b/hyperopt/mongoexp.py
@@ -1222,11 +1222,14 @@ def main_worker_helper(options, args):
     if N > 1:
         proc = None
         cons_errs = 0
-        if last_job_timeout and time.time() > last_job_timeout:
-            logger.info("Exiting due to last_job_timeout")
-            return
 
         while N and cons_errs < int(options.max_consecutive_failures):
+            # exit due to time limit:
+            if last_job_timeout and time.time() > last_job_timeout:
+                logger.info("Exiting due to last_job_timeout")
+                return
+
+            # exit due to threshold on number of jobs:
             if (
                 options.max_jobs_in_db is not None
                 and options.max_jobs_in_db != sys.maxsize
@@ -1240,6 +1243,8 @@ def main_worker_helper(options, args):
                         + str(options.max_jobs_in_db)
                     )
                     return
+
+            # try to run one MongoWorker
             try:
                 if options.use_subprocesses:
                     # recursive Popen, dropping N from the argv

--- a/hyperopt/mongoexp.py
+++ b/hyperopt/mongoexp.py
@@ -1200,9 +1200,9 @@ def number_of_jobs_in_db(options):
 def main_worker_helper(options, args):
     N = int(options.max_jobs)
     if options.last_job_timeout is not None:
-        last_job_timeout = time.time() + float(options.last_job_timeout)
+        end_time = time.time() + float(options.last_job_timeout)
     else:
-        last_job_timeout = None
+        end_time = None
 
     def sighandler_shutdown(signum, frame):
         logger.info("Caught signal %i, shutting down." % signum)
@@ -1225,7 +1225,7 @@ def main_worker_helper(options, args):
 
         while N and cons_errs < int(options.max_consecutive_failures):
             # exit due to time limit:
-            if last_job_timeout and time.time() > last_job_timeout:
+            if end_time and time.time() > end_time:
                 logger.info("Exiting due to last_job_timeout")
                 return
 


### PR DESCRIPTION
Fixed implementation of "last_job_timeout" which is supposed to exit the mongo worker after some time has passed, but instead it was doing nothing.

Before, the condition in the if statement was impossible to evaluate to True. Now, the condition is evaluated every time a job is about to be reserved. 