### PR TITLE
Remove usage of deprecated np.int and np.float

### DIFF
--- a/hyperopt/base.py
+++ b/hyperopt/base.py
@@ -139,7 +139,7 @@ def SONify(arg, memo=None):
             rval = type(arg)([SONify(ai, memo) for ai in arg])
         elif isinstance(arg, dict):
             rval = {SONify(k, memo): SONify(v, memo) for k, v in list(arg.items())}
-        elif isinstance(arg, (basestring, float, int, int, type(None))):
+        elif isinstance(arg, (basestring, float, int, type(None))):
             rval = arg
         elif isinstance(arg, np.ndarray):
             if arg.ndim == 0:

--- a/hyperopt/plotting.py
+++ b/hyperopt/plotting.py
@@ -219,7 +219,7 @@ def main_plot_1D_attachment(
         plotted_trials = [
             trials_by_loss[i]
             for i in np.linspace(
-                0, len(trials_by_loss), num_trails, endpoint=False, dtype=np.int
+                0, len(trials_by_loss), num_trails, endpoint=False, dtype=int
             )
         ]
 

--- a/hyperopt/rdists.py
+++ b/hyperopt/rdists.py
@@ -54,9 +54,9 @@ class lognorm_gen(scipy_lognorm_gen):
 
 
 def qtable_pmf(x, q, qlow, xs, ps):
-    qx = np.round(old_div(np.atleast_1d(x).astype(np.float), q)) * q
+    qx = np.round(old_div(np.atleast_1d(x).astype(float), q)) * q
     is_multiple = np.isclose(qx, x)
-    ix = np.round(old_div((qx - qlow), q)).astype(np.int)
+    ix = np.round(old_div((qx - qlow), q)).astype(int)
     is_inbounds = np.logical_and(ix >= 0, ix < len(ps))
     oks = np.logical_and(is_multiple, is_inbounds)
     rval = np.zeros_like(qx)
@@ -195,7 +195,7 @@ class qnormal_gen:
     def logpmf(self, x):
         x1 = np.atleast_1d(x)
         in_domain = self.in_domain(x1)
-        rval = np.zeros_like(x1, dtype=np.float) - np.inf
+        rval = np.zeros_like(x1, dtype=float) - np.inf
         x_in_domain = x1[in_domain]
 
         ubound = x_in_domain + self.q * 0.5
@@ -240,7 +240,7 @@ class qlognormal_gen:
         x1 = np.atleast_1d(x)
         in_domain = self.in_domain(x1)
         x1_in_domain = x1[in_domain]
-        rval = np.zeros_like(x1, dtype=np.float)
+        rval = np.zeros_like(x1, dtype=float)
         rval_in_domain = self._norm_cdf(np.log(x1_in_domain + 0.5 * self.q))
         rval_in_domain[x1_in_domain != 0] -= self._norm_cdf(
             np.log(x1_in_domain[x1_in_domain != 0] - 0.5 * self.q)

--- a/hyperopt/tests/test_base.py
+++ b/hyperopt/tests/test_base.py
@@ -233,12 +233,6 @@ class TestSONify(unittest.TestCase):
     def test_float(self):
         assert self.SONify(1.1) == 1.1
 
-    def test_np_int(self):
-        assert self.SONify(np.int(1)) == 1
-
-    def test_np_float(self):
-        assert self.SONify(np.float(1.1)) == 1.1
-
     def test_np_1d_int(self):
         assert np.all(self.SONify(np.asarray([1, 2, 3])) == [1, 2, 3])
 
@@ -255,5 +249,5 @@ class TestSONify(unittest.TestCase):
         assert np.all(self.SONify(np.asarray([[1, 2], [3, 4.5]])) == [[1, 2], [3, 4.5]])
 
     def test_nested_w_bool(self):
-        thing = dict(a=1, b="2", c=True, d=False, e=np.int(3), f=[1])
+        thing = dict(a=1, b="2", c=True, d=False, e=int(3), f=[1])
         assert thing == SONify(thing)


### PR DESCRIPTION
These are just references to the standard Python `int` and `float` types and are deprecated in newer numpy versions.