### PR TITLE
Correct a mistake in README step 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ If you're a developer and wish to contribute, please follow these steps:
 
 
 ### Formatting
-10. We recommend to use [Black](https://github.com/psf/black) to format your code before submitting a PR which is installed automatically in step 4.
+10. We recommend to use [Black](https://github.com/psf/black) to format your code before submitting a PR which is installed automatically in step 6.
 
 11. Then, once you commit ensure that git hooks are activated (Pycharm for example has the option to omit them). This will run black automatically on all files you modified, failing if there are any files requiring to be blacked. In case black does not run execute the following:
 


### PR DESCRIPTION
See title. Step 10 currently indicates that Black is installed in step 4. This is wrong since step 4 creates a virtual environment, which does not involve installing Black. This PR changes it to say that Black is installed in step 6 which is the correct step number.