### PR TITLE
Make hyperopt SparkTrials support pyspark 3.2 which pin thread mode enabled by default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: stable
     hooks:
     - id: black
-      args: [--check]
+      args: [--check, --diff]
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.7.3
     hooks:

--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -87,10 +87,14 @@ class SparkTrials(Trials):
         )
         self._spark_context = self._spark.sparkContext
         # The feature to support controlling jobGroupIds is in SPARK-22340
-        self._spark_supports_job_cancelling = _spark_major_minor_version >= (
-            3,
-            2,
-        ) or hasattr(self._spark_context.parallelize([1]), "collectWithJobGroup")
+        self._spark_supports_job_cancelling = (
+            _spark_major_minor_version
+            >= (
+                3,
+                2,
+            )
+            or hasattr(self._spark_context.parallelize([1]), "collectWithJobGroup")
+        )
         spark_default_parallelism = self._spark_context.defaultParallelism
         self.parallelism = self._decide_parallelism(
             requested_parallelism=parallelism,

--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -491,7 +491,7 @@ class _SparkFMinState:
                         )
                         spark_context.setLocalProperty(
                             "spark.job.interruptOnCancel",
-                            str(self._job_interrupt_on_cancel).lower()
+                            str(self._job_interrupt_on_cancel).lower(),
                         )
                         result_or_e = worker_rdd.mapPartitions(
                             run_task_on_executor

--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -490,7 +490,7 @@ class _SparkFMinState:
                             "spark.job.description", self._job_desc
                         )
                         spark_context.setLocalProperty(
-                            "spark.job.interruptOnCancel", self._job_interrupt_on_cancel
+                            "spark.job.interruptOnCancel", str(self._job_interrupt_on_cancel).lower()
                         )
                         result_or_e = worker_rdd.mapPartitions(
                             run_task_on_executor

--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -490,7 +490,8 @@ class _SparkFMinState:
                             "spark.job.description", self._job_desc
                         )
                         spark_context.setLocalProperty(
-                            "spark.job.interruptOnCancel", str(self._job_interrupt_on_cancel).lower()
+                            "spark.job.interruptOnCancel",
+                            str(self._job_interrupt_on_cancel).lower()
                         )
                         result_or_e = worker_rdd.mapPartitions(
                             run_task_on_executor

--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -12,6 +12,7 @@ try:
     from pyspark.sql import SparkSession
     from pyspark.util import VersionUtils
     import pyspark
+
     _have_spark = True
     _spark_major_minor_version = VersionUtils.majorMinorVersion(pyspark.__version__)
 except ImportError as e:
@@ -86,8 +87,10 @@ class SparkTrials(Trials):
         )
         self._spark_context = self._spark.sparkContext
         # The feature to support controlling jobGroupIds is in SPARK-22340
-        self._spark_supports_job_cancelling = _spark_major_minor_version >= (3, 2) or \
-            hasattr(self._spark_context.parallelize([1]), "collectWithJobGroup")
+        self._spark_supports_job_cancelling = _spark_major_minor_version >= (
+            3,
+            2,
+        ) or hasattr(self._spark_context.parallelize([1]), "collectWithJobGroup")
         spark_default_parallelism = self._spark_context.defaultParallelism
         self.parallelism = self._decide_parallelism(
             requested_parallelism=parallelism,
@@ -516,6 +519,7 @@ class _SparkFMinState:
 
         if _spark_major_minor_version >= (3, 2):
             from pyspark import inheritable_thread_target
+
             run_task_thread = inheritable_thread_target(run_task_thread)
 
         task_thread = threading.Thread(target=run_task_thread)

--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -10,10 +10,13 @@ from hyperopt.utils import coarse_utcnow, _get_logger, _get_random_id
 
 try:
     from pyspark.sql import SparkSession
-
+    from pyspark.util import VersionUtils
+    import pyspark
     _have_spark = True
+    _spark_major_minor_version = VersionUtils.majorMinorVersion(pyspark.__version__)
 except ImportError as e:
     _have_spark = False
+    _spark_major_minor_version = None
 
 logger = _get_logger("hyperopt-spark")
 
@@ -83,9 +86,8 @@ class SparkTrials(Trials):
         )
         self._spark_context = self._spark.sparkContext
         # The feature to support controlling jobGroupIds is in SPARK-22340
-        self._spark_supports_job_cancelling = hasattr(
-            self._spark_context.parallelize([1]), "collectWithJobGroup"
-        )
+        self._spark_supports_job_cancelling = _spark_major_minor_version >= (3, 2) or \
+            hasattr(self._spark_context.parallelize([1]), "collectWithJobGroup")
         spark_default_parallelism = self._spark_context.defaultParallelism
         self.parallelism = self._decide_parallelism(
             requested_parallelism=parallelism,
@@ -469,15 +471,33 @@ class _SparkFMinState:
             try:
                 worker_rdd = self.spark.sparkContext.parallelize([0], 1)
                 if self.trials._spark_supports_job_cancelling:
-                    result_or_e = worker_rdd.mapPartitions(
-                        run_task_on_executor
-                    ).collectWithJobGroup(
-                        self._job_group_id,
-                        self._job_desc,
-                        self._job_interrupt_on_cancel,
-                    )[
-                        0
-                    ]
+                    if _spark_major_minor_version >= (3, 2):
+                        self.spark.sparkContext.setLocalProperty(
+                            "spark.jobGroup.id", self._job_group_id
+                        )
+                        spark_context = self.spark.sparkContext
+                        self._job_group_id = spark_context.setLocalProperty(
+                            "spark.jobGroup.id", self._job_group_id
+                        )
+                        self._job_desc = spark_context.setLocalProperty(
+                            "spark.job.description", self._job_desc
+                        )
+                        spark_context.setLocalProperty(
+                            "spark.job.interruptOnCancel", self._job_interrupt_on_cancel
+                        )
+                        result_or_e = worker_rdd.mapPartitions(
+                            run_task_on_executor
+                        ).collect()[0]
+                    else:
+                        result_or_e = worker_rdd.mapPartitions(
+                            run_task_on_executor
+                        ).collectWithJobGroup(
+                            self._job_group_id,
+                            self._job_desc,
+                            self._job_interrupt_on_cancel,
+                        )[
+                            0
+                        ]
                 else:
                     result_or_e = worker_rdd.mapPartitions(
                         run_task_on_executor
@@ -493,6 +513,10 @@ class _SparkFMinState:
             else:
                 # The exceptions captured in run_task_on_executor would be returned in the result_or_e
                 finish_trial_run(result_or_e)
+
+        if _spark_major_minor_version >= (3, 2):
+            from pyspark import inheritable_thread_target
+            run_task_thread = inheritable_thread_target(run_task_thread)
 
         task_thread = threading.Thread(target=run_task_thread)
         task_thread.setDaemon(True)

--- a/hyperopt/tests/test_spark.py
+++ b/hyperopt/tests/test_spark.py
@@ -504,14 +504,6 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
                     log_output=log_output
                 ),
             )
-            self.assertNotIn(
-                "Task should have been cancelled",
-                log_output,
-                """ "Task should have been cancelled" should not in log:
-                              {log_output}""".format(
-                    log_output=log_output
-                ),
-            )
             self.assert_task_failed(log_output, 0)
 
         # Test mix of successful and cancelled trials.


### PR DESCRIPTION
Make hyperopt SparkTrials support pyspark 3.2 which pin thread mode enabled by default

See https://github.com/apache/spark/pull/32429 for details.