### PR TITLE
Only use pinned thread mode in Spark 3.2 when explicitly enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,18 @@ jobs:
       script: black .
     - name: "Run tests on python 3.7"
       python: 3.7
-      env:
-        - SPARK_VERSION=3.0.1
+      env: SPARK_VERSION=3.0.1
     - name: "Run tests on python 3.8"
       python: 3.8
     - name: "Run tests on python 3.9"
       python: 3.9
       env: NUMPY_VERSION=1.19.4
+    - name: "Run tests on python 3.9 with spark 3.2 with pinned threads"
+      env:
+        - NUMPY_VERSION=1.19.4
+        - SPARK_VERSION=3.2.0
+        - PYSPARK_PIN_THREAD=true
+      script: pytest hyperopt/tests/test_spark.py -k test_pin_thread_on
 
 install:
   - sudo apt-get remove ipython || true  # ipython is not pre-installed in Focal

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
 env:
   global:
     - HYPEROPT_FMIN_SEED=3
-    - SPARK_VERSION=3.0.1
+    - SPARK_VERSION=3.2.0
     - NUMPY_VERSION=1.18.1
     - IPYTHON=ipython[all]
 
@@ -26,6 +26,8 @@ jobs:
       script: black .
     - name: "Run tests on python 3.7"
       python: 3.7
+      env:
+        - SPARK_VERSION=3.0.1
     - name: "Run tests on python 3.8"
       python: 3.8
     - name: "Run tests on python 3.9"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
     - name: "Run tests on python 3.9"
       python: 3.9
       env: NUMPY_VERSION=1.19.4
-    - name: "Run tests on python 3.9 with spark 3.2 with pinned threads"
+    - name: "Run tests on python 3.9 with spark 3.2 and pinned threads"
       env:
         - NUMPY_VERSION=1.19.4
         - SPARK_VERSION=3.2.0

--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -8,6 +8,8 @@ from hyperopt import base, fmin, Trials
 from hyperopt.base import validate_timeout, validate_loss_threshold
 from hyperopt.utils import coarse_utcnow, _get_logger, _get_random_id
 
+from py4j.clientserver import ClientServer
+
 try:
     from pyspark.sql import SparkSession
     from pyspark.util import VersionUtils
@@ -86,13 +88,12 @@ class SparkTrials(Trials):
             else spark_session
         )
         self._spark_context = self._spark.sparkContext
+        self._spark_pinned_threads_enabled = isinstance(
+            self._spark_context._gateway, ClientServer
+        )
         # The feature to support controlling jobGroupIds is in SPARK-22340
         self._spark_supports_job_cancelling = (
-            _spark_major_minor_version
-            >= (
-                3,
-                2,
-            )
+            self._spark_pinned_threads_enabled
             or hasattr(self._spark_context.parallelize([1]), "collectWithJobGroup")
         )
         spark_default_parallelism = self._spark_context.defaultParallelism
@@ -478,7 +479,7 @@ class _SparkFMinState:
             try:
                 worker_rdd = self.spark.sparkContext.parallelize([0], 1)
                 if self.trials._spark_supports_job_cancelling:
-                    if _spark_major_minor_version >= (3, 2):
+                    if self.trials._spark_pinned_threads_enabled:
                         spark_context = self.spark.sparkContext
                         spark_context.setLocalProperty(
                             "spark.jobGroup.id", self._job_group_id
@@ -519,7 +520,7 @@ class _SparkFMinState:
                 # The exceptions captured in run_task_on_executor would be returned in the result_or_e
                 finish_trial_run(result_or_e)
 
-        if _spark_major_minor_version >= (3, 2):
+        if self.trials._spark_pinned_threads_enabled:
             from pyspark import inheritable_thread_target
 
             run_task_thread = inheritable_thread_target(run_task_thread)

--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -521,9 +521,12 @@ class _SparkFMinState:
                 finish_trial_run(result_or_e)
 
         if self.trials._spark_pinned_threads_enabled:
-            from pyspark import inheritable_thread_target
-
-            run_task_thread = inheritable_thread_target(run_task_thread)
+            try:
+                # pylint: disable=no-name-in-module,import-outside-toplevel
+                from pyspark import inheritable_thread_target
+                run_task_thread = inheritable_thread_target(run_task_thread)
+            except ImportError:
+                pass
 
         task_thread = threading.Thread(target=run_task_thread)
         task_thread.setDaemon(True)

--- a/hyperopt/tests/test_spark.py
+++ b/hyperopt/tests/test_spark.py
@@ -16,6 +16,7 @@ from hyperopt import SparkTrials, anneal, base, fmin, hp, rand
 from .test_fmin import test_quadratic1_tpe
 from py4j.clientserver import ClientServer
 
+
 @contextlib.contextmanager
 def patch_logger(name, level=logging.INFO):
     """patch logger and give an output"""
@@ -61,9 +62,7 @@ class BaseSparkContext:
             .getOrCreate()
         )
         cls._sc = cls._spark.sparkContext
-        cls._pin_mode_enabled = isinstance(
-            cls._sc._gateway, ClientServer
-        )
+        cls._pin_mode_enabled = isinstance(cls._sc._gateway, ClientServer)
         cls.checkpointDir = tempfile.mkdtemp()
         cls._sc.setCheckpointDir(cls.checkpointDir)
         # Small tests run much faster with spark.sql.shuffle.partitions=4
@@ -593,7 +592,7 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
         self.assertEqual(NUM_TRIALS, call_count)
 
     def test_pin_thread_off(self):
-        if (self._pin_mode_enabled):
+        if self._pin_mode_enabled:
             raise unittest.SkipTest()
 
         spark_trials = SparkTrials(parallelism=2)
@@ -609,7 +608,7 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
         self.assertEqual(spark_trials.count_successful_trials(), 5)
 
     def test_pin_thread_on(self):
-        if (not self._pin_mode_enabled):
+        if not self._pin_mode_enabled:
             raise unittest.SkipTest()
 
         spark_trials = SparkTrials(parallelism=2)


### PR DESCRIPTION
This PR updates Hyperopt + Spark logic to adjust our assumptions / behavior related to pinned thread mode. Users of Spark 3.2 still have the option to disable pinned thread mode, in which case hyperopt should attempt to behave the way it did in Spark <= 3.1 with respect to pinned thread mode.