### PR TITLE
Use numpy.random's Generator instead of legacy RandomState

### DIFF
--- a/docs/templates/getting-started/minimizing_functions.md
+++ b/docs/templates/getting-started/minimizing_functions.md
@@ -84,7 +84,7 @@ date-times, you'll be fine.
 them as attachments.
 
 **HINT:** If you need to replicate the results of the stochastic search (e.g. for a demonstration),
-pass an object of type `np.random.RandomState` into the `fmin` function, using the `rstate` optional parameter.
+pass an object of type `np.random.Generator` into the `fmin` function, using the `rstate` optional parameter.
 
 Writing the function above in dictionary-returning style, it
 would look like this:

--- a/hyperopt/algobase.py
+++ b/hyperopt/algobase.py
@@ -223,10 +223,10 @@ class SuggestAlgo(ExprEvaluator):
             n: l for l, n in list(self.domain.vh.vals_by_label().items())
         }
         self._seed = seed
-        self.rng = np.random.RandomState(seed)
+        self.rng = np.random.default_rng(seed)
 
     def __call__(self, new_id):
-        self.rng.seed(self._seed + new_id)
+        self.rng = np.random.default_rng(self._seed + new_id)
         memo = self.eval_nodes(
             memo={self.domain.s_new_ids: [new_id], self.domain.s_rng: self.rng}
         )
@@ -246,7 +246,7 @@ class SuggestAlgo(ExprEvaluator):
 
     def batch(self, new_ids):
         new_ids = list(new_ids)
-        self.rng.seed([self._seed] + new_ids)
+        self.rng = np.random.default_rng([self._seed] + new_ids)
         memo = self.eval_nodes(
             memo={self.domain.s_new_ids: new_ids, self.domain.s_rng: self.rng}
         )

--- a/hyperopt/atpe.py
+++ b/hyperopt/atpe.py
@@ -698,7 +698,7 @@ class ATPEOptimizer:
     def recommendNextParameters(
         self, hyperparameterSpace, results, currentTrials, lockedValues=None
     ):
-        rstate = numpy.random.RandomState(seed=int(random.randint(1, 2 ** 32 - 1)))
+        rstate = numpy.random.default_rng(seed=int(random.randint(1, 2 ** 32 - 1)))
 
         params = {"param": {}}
 

--- a/hyperopt/criteria.py
+++ b/hyperopt/criteria.py
@@ -19,7 +19,7 @@ def EI_gaussian_empirical(mean, var, thresh, rng, N):
 
     (estimated empirically)
     """
-    return EI_empirical(rng.randn(N) * np.sqrt(var) + mean, thresh)
+    return EI_empirical(rng.standard_normal(N) * np.sqrt(var) + mean, thresh)
 
 
 def EI_gaussian(mean, var, thresh):

--- a/hyperopt/fmin.py
+++ b/hyperopt/fmin.py
@@ -276,7 +276,7 @@ class FMinIter:
                     # `new_trials`. This is the core of `run`, all the rest is just
                     # processes orchestration
                     new_trials = algo(
-                        new_ids, self.domain, trials, self.rstate.randint(2 ** 31 - 1)
+                        new_ids, self.domain, trials, self.rstate.integers(2 ** 31 - 1)
                     )
                     assert len(new_ids) >= len(new_trials)
 
@@ -441,11 +441,11 @@ def fmin(
         a trials object, then that trials object will be affected by
         side-effect of this call.
 
-    rstate : numpy.RandomState, default numpy.random or `$HYPEROPT_FMIN_SEED`
+    rstate : numpy.random.Generator, default numpy.random or `$HYPEROPT_FMIN_SEED`
         Each call to `algo` requires a seed value, which should be different
         on each call. This object is used to draw these seeds via `randint`.
         The default rstate is
-        `numpy.random.RandomState(int(env['HYPEROPT_FMIN_SEED']))`
+        `numpy.random.default_rng(int(env['HYPEROPT_FMIN_SEED']))`
         if the `HYPEROPT_FMIN_SEED` environment variable is set to a non-empty
         string, otherwise np.random is used in whatever state it is in.
 
@@ -513,9 +513,9 @@ def fmin(
     if rstate is None:
         env_rseed = os.environ.get("HYPEROPT_FMIN_SEED", "")
         if env_rseed:
-            rstate = np.random.RandomState(int(env_rseed))
+            rstate = np.random.default_rng(int(env_rseed))
         else:
-            rstate = np.random.RandomState()
+            rstate = np.random.default_rng()
 
     validate_timeout(timeout)
     validate_loss_threshold(loss_threshold)

--- a/hyperopt/ipy.py
+++ b/hyperopt/ipy.py
@@ -136,7 +136,7 @@ class IPythonTrials(Trials):
 
             if idles:
                 new_ids = self.new_trial_ids(len(idles))
-                new_trials = algo(new_ids, domain, self, rstate.randint(2 ** 31 - 1))
+                new_trials = algo(new_ids, domain, self, rstate.integers(2 ** 31 - 1))
                 if len(new_trials) == 0:
                     break
                 assert len(idles) >= len(new_trials)

--- a/hyperopt/mix.py
+++ b/hyperopt/mix.py
@@ -25,10 +25,10 @@ def suggest(new_ids, domain, trials, seed, p_suggest):
         sum(probabilities) must be [close to] 1.0
 
     """
-    rng = np.random.RandomState(seed)
+    rng = np.random.default_rng(seed)
     ps, suggests = list(zip(*p_suggest))
     assert len(ps) == len(suggests) == len(p_suggest)
     if not np.isclose(sum(ps), 1.0):
         raise ValueError("Probabilities should sum to 1", ps)
     idx = rng.multinomial(n=1, pvals=ps).argmax()
-    return suggests[idx](new_ids, domain, trials, seed=rng.randint(2 ** 31))
+    return suggests[idx](new_ids, domain, trials, seed=rng.integers(2 ** 31))

--- a/hyperopt/pyll/stochastic.py
+++ b/hyperopt/pyll/stochastic.py
@@ -24,7 +24,7 @@ def implicit_stochastic(f):
 
 @scope.define
 def rng_from_seed(seed):
-    return np.random.RandomState(seed)
+    return np.random.default_rng(seed)
 
 
 # -- UNIFORM
@@ -95,9 +95,9 @@ def qlognormal(mu, sigma, q, rng=None, size=()):
 def randint(low, high=None, rng=None, size=()):
     """
     See np.random.randint documentation.
-    rng = random number generator, typically equals np.random.mtrand.RandomState
+    rng = random number generator, typically equals np.random.Generator
     """
-    return rng.randint(low, high, size)
+    return rng.integers(low, high, size)
 
 
 @implicit_stochastic
@@ -107,7 +107,7 @@ def randint_via_categorical(p, rng=None, size=()):
     Only used in tpe because of the chaotic API based on names.
     # ideally we would just use randint above, but to use priors this is a wrapper of
     categorical
-    rng = random number generator, typically equals np.random.mtrand.RandomState
+    rng = random number generator, typically equals np.random.Generator
     """
 
     return scope.categorical(p, rng, size)
@@ -177,7 +177,7 @@ def recursive_set_rng_kwarg(expr, rng=None):
     uniform(0, 1) -> uniform(0, 1, rng=rng)
     """
     if rng is None:
-        rng = np.random.RandomState()
+        rng = np.random.default_rng()
     lrng = as_apply(rng)
     for node in dfs(expr):
         if node.name in implicit_stochastic_symbols:
@@ -195,14 +195,14 @@ def sample(expr, rng=None, **kwargs):
     Parameters:
     expr - a pyll expression to be evaluated
 
-    rng - a np.random.RandomState instance
-          default: `np.random.RandomState()`
+    rng - a np.random.Generator instance
+          default: `np.random.default_rng()`
 
     **kwargs - optional arguments passed along to
                `hyperopt.pyll.rec_eval`
 
     """
     if rng is None:
-        rng = np.random.RandomState()
+        rng = np.random.default_rng()
     foo = recursive_set_rng_kwarg(clone(as_apply(expr)), as_apply(rng))
     return rec_eval(foo, **kwargs)

--- a/hyperopt/pyll/tests/test_stochastic.py
+++ b/hyperopt/pyll/tests/test_stochastic.py
@@ -7,7 +7,7 @@ from hyperopt.pyll.stochastic import recursive_set_rng_kwarg, sample
 def test_recursive_set_rng_kwarg():
     uniform = scope.uniform
     a = as_apply([uniform(0, 1), uniform(2, 3)])
-    rng = np.random.RandomState(234)
+    rng = np.random.default_rng(234)
     recursive_set_rng_kwarg(a, rng)
     print(a)
     val_a = rec_eval(a)
@@ -46,16 +46,16 @@ def test_lnorm():
 def test_sample_deterministic():
     aa = as_apply([0, 1])
     print(aa)
-    dd = sample(aa, np.random.RandomState(3))
+    dd = sample(aa, np.random.default_rng(3))
     assert dd == (0, 1)
 
 
 def test_repeatable():
     u = scope.uniform(0, 1)
     aa = as_apply(dict(u=u, n=scope.normal(5, 0.1), l=[0, 1, scope.one_of(2, 3), u]))
-    dd1 = sample(aa, np.random.RandomState(3))
-    dd2 = sample(aa, np.random.RandomState(3))
-    dd3 = sample(aa, np.random.RandomState(4))
+    dd1 = sample(aa, np.random.default_rng(3))
+    dd2 = sample(aa, np.random.default_rng(3))
+    dd3 = sample(aa, np.random.default_rng(4))
     assert dd1 == dd2
     assert dd1 != dd3
 
@@ -64,7 +64,7 @@ def test_sample():
     u = scope.uniform(0, 1)
     aa = as_apply(dict(u=u, n=scope.normal(5, 0.1), l=[0, 1, scope.one_of(2, 3), u]))
     print(aa)
-    dd = sample(aa, np.random.RandomState(3))
+    dd = sample(aa, np.random.default_rng(3))
     assert 0 < dd["u"] < 1
     assert 4 < dd["n"] < 6
     assert dd["u"] == dd["l"][3]

--- a/hyperopt/rand.py
+++ b/hyperopt/rand.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 def suggest(new_ids, domain, trials, seed):
-    rng = np.random.RandomState(seed)
+    rng = np.random.default_rng(seed)
     rval = []
     for ii, new_id in enumerate(new_ids):
         # -- sample new specs, idxs, vals
@@ -28,7 +28,7 @@ def suggest(new_ids, domain, trials, seed):
 
 def suggest_batch(new_ids, domain, trials, seed):
 
-    rng = np.random.RandomState(seed)
+    rng = np.random.default_rng(seed)
     # -- sample new specs, idxs, vals
     idxs, vals = pyll.rec_eval(
         domain.s_idxs_vals, memo={domain.s_new_ids: new_ids, domain.s_rng: rng}

--- a/hyperopt/tests/test_anneal.py
+++ b/hyperopt/tests/test_anneal.py
@@ -74,7 +74,7 @@ class TestItAtLeastSortOfWorks(unittest.TestCase, CasePerDomain):
             trials=trials,
             algo=algo,
             max_evals=iters_thresholds,
-            rstate=np.random.RandomState(8),
+            rstate=np.random.default_rng(8),
         )
         assert len(trials) == iters_thresholds
 
@@ -85,7 +85,7 @@ class TestItAtLeastSortOfWorks(unittest.TestCase, CasePerDomain):
             trials=rtrials,
             algo=rand.suggest,
             max_evals=iters_thresholds,
-            rstate=np.random.RandomState(8),
+            rstate=np.random.default_rng(8),
         )
 
         thresh = self.thresholds[bandit.name]

--- a/hyperopt/tests/test_atpe_basic.py
+++ b/hyperopt/tests/test_atpe_basic.py
@@ -30,7 +30,7 @@ def test_run_basic_search():
         space,
         algo=atpe.suggest,
         max_evals=20,
-        rstate=np.random.RandomState(1),
+        rstate=np.random.default_rng(1),
     )
 
     assert best["a"] == 1

--- a/hyperopt/tests/test_criteria.py
+++ b/hyperopt/tests/test_criteria.py
@@ -4,7 +4,7 @@ import hyperopt.criteria as crit
 
 
 def test_ei():
-    rng = np.random.RandomState(123)
+    rng = np.random.default_rng(123)
     for mean, var in [(0, 1), (-4, 9)]:
         thresholds = np.arange(-5, 5, 0.25) * np.sqrt(var) + mean
 

--- a/hyperopt/tests/test_domains.py
+++ b/hyperopt/tests/test_domains.py
@@ -82,7 +82,7 @@ def n_arms(N=2):
     The correct arm is arm 0.
 
     """
-    rng = np.random.RandomState(123)
+    rng = np.random.default_rng(123)
     x = hp.choice("x", [0, 1])
     reward_mus = as_apply([-1] + [0] * (N - 1))
     reward_sigmas = as_apply([1] * N)
@@ -143,7 +143,7 @@ def gauss_wave2():
     up the amp to 1.
     """
 
-    rng = np.random.RandomState(123)
+    rng = np.random.default_rng(123)
     var = 0.1
     x = hp.uniform("x", -20, 20)
     amp = hp.uniform("amp", 0, 1)
@@ -218,7 +218,7 @@ class DomainExperimentMixin:
             domain.expr,
             trials=trials,
             algo=suggest,
-            rstate=np.random.RandomState(4),
+            rstate=np.random.default_rng(4),
             max_evals=self._n_steps,
         )
         assert trials.average_best_error(domain) - domain.loss_target < 0.2

--- a/hyperopt/tests/test_fmin.py
+++ b/hyperopt/tests/test_fmin.py
@@ -29,6 +29,7 @@ def test_quadratic1_rand():
         algo=rand.suggest,
         max_evals=500,
         trials=trials,
+        rstate=np.random.default_rng(np.random.PCG64(123)),
     )
 
     assert len(trials) == 500
@@ -43,6 +44,7 @@ def test_quadratic1_tpe(trials=Trials()):
         algo=tpe.suggest,
         max_evals=50,
         trials=trials,
+        rstate=np.random.default_rng(np.random.PCG64(123)),
     )
 
     assert len(trials) == 50, len(trials)
@@ -64,6 +66,7 @@ def test_quadratic1_anneal():
         algo=hyperopt.anneal.suggest,
         max_evals=N,
         trials=trials,
+        rstate=np.random.default_rng(np.random.PCG64(123)),
     )
 
     print(argmin)
@@ -86,6 +89,7 @@ def test_duplicate_label_is_error():
             algo=rand.suggest,
             max_evals=500,
             trials=trials,
+            rstate=np.random.default_rng(0),
         )
 
 
@@ -113,7 +117,7 @@ def test_set_fmin_rstate():
         algo=rand.suggest,
         max_evals=1,
         trials=trials_seed0,
-        rstate=np.random.RandomState(0),
+        rstate=np.random.default_rng(0),
     )
     assert len(trials_seed0) == 1
     trials_seed1 = Trials()
@@ -123,7 +127,7 @@ def test_set_fmin_rstate():
         algo=rand.suggest,
         max_evals=1,
         trials=trials_seed1,
-        rstate=np.random.RandomState(1),
+        rstate=np.random.default_rng(1),
     )
     assert len(trials_seed1) == 1
     assert argmin_seed0 != argmin_seed1
@@ -142,7 +146,7 @@ def test_fmin_return_argmin():
         max_evals=10,
         algo=rand.suggest,
         return_argmin=False,
-        rstate=np.random.RandomState(0),
+        rstate=np.random.default_rng(0),
     )
     assert best_parameter == 5
 
@@ -154,7 +158,7 @@ def test_fmin_return_argmin():
         max_evals=10,
         algo=rand.suggest,
         return_argmin=True,
-        rstate=np.random.RandomState(0),
+        rstate=np.random.default_rng(0),
     )
     assert best_args["x"] == 1
 
@@ -255,7 +259,7 @@ def test_timeout():
         timeout=1,
         algo=rand.suggest,
         return_argmin=False,
-        rstate=np.random.RandomState(0),
+        rstate=np.random.default_rng(0),
     )
     end_time_1 = timer()
     assert (end_time_1 - start_time_1) < 2
@@ -269,7 +273,7 @@ def test_timeout():
         timeout=5,
         algo=rand.suggest,
         return_argmin=False,
-        rstate=np.random.RandomState(0),
+        rstate=np.random.default_rng(0),
     )
     end_time_5 = timer()
     assert (end_time_5 - start_time_5) < 6
@@ -294,7 +298,7 @@ def test_invalid_timeout():
                 timeout=wrong_timeout,
                 algo=rand.suggest,
                 return_argmin=False,
-                rstate=np.random.RandomState(0),
+                rstate=np.random.default_rng(0),
             )
         except Exception as e:
             assert str(e) == expected_message
@@ -309,7 +313,7 @@ def test_loss_threshold():
         loss_threshold=loss_threshold,
         algo=rand.suggest,
         trials=hypopt_trials,
-        rstate=np.random.RandomState(0),
+        rstate=np.random.default_rng(0),
     )
     best_loss = hypopt_trials.best_trial["result"]["loss"]
     assert best_loss <= loss_threshold
@@ -335,7 +339,7 @@ def test_invalid_loss_threshold():
                 loss_threshold=wrong_loss_threshold,
                 algo=rand.suggest,
                 return_argmin=False,
-                rstate=np.random.RandomState(0),
+                rstate=np.random.default_rng(0),
             )
         except Exception as e:
             assert str(e) == expected_message

--- a/hyperopt/tests/test_mongoexp.py
+++ b/hyperopt/tests/test_mongoexp.py
@@ -307,7 +307,7 @@ class TestExperimentWithThreads(unittest.TestCase):
             space=space,
             algo=rand.suggest,
             trials=trials,
-            rstate=np.random.RandomState(seed),
+            rstate=np.random.default_rng(seed),
             max_evals=max_evals,
             return_argmin=False,
         )
@@ -409,7 +409,7 @@ def fmin_thread_fn(space, mongo_trials: MongoTrials, max_evals: int):
         space=space,
         algo=rand.suggest,
         trials=mongo_trials,
-        rstate=np.random.RandomState(),
+        rstate=np.random.default_rng(),
         max_evals=max_evals,
         return_argmin=False,
     )

--- a/hyperopt/tests/test_pchoice.py
+++ b/hyperopt/tests/test_pchoice.py
@@ -13,7 +13,7 @@ class TestPChoice(unittest.TestCase):
             [(0.14, "gaussian"), (0.02, "multinomial"), (0.84, "bernoulli")],
         )
         a, b, c = 0, 0, 0
-        rng = np.random.RandomState(123)
+        rng = np.random.default_rng(123)
         for i in range(0, 1000):
             nesto = hyperopt.pyll.stochastic.sample(space, rng=rng)
             if nesto == "gaussian":
@@ -37,7 +37,7 @@ class TestPChoice(unittest.TestCase):
             ],
         )
         a, b, c = 0, 0, 0
-        rng = np.random.RandomState(123)
+        rng = np.random.default_rng(123)
         for i in range(0, 1000):
             nesto = hyperopt.pyll.stochastic.sample(space, rng=rng)
             if nesto == "first":
@@ -63,7 +63,7 @@ class TestPChoice(unittest.TestCase):
             ],
         )
         a, b, c, d = 0, 0, 0, 0
-        rng = np.random.RandomState(123)
+        rng = np.random.default_rng(123)
         for i in range(0, 2000):
             nesto = hyperopt.pyll.stochastic.sample(space, rng=rng)
             if nesto == 2:
@@ -105,7 +105,7 @@ class TestSimpleFMin(unittest.TestCase):
             space=self.space,
             trials=self.trials,
             algo=rand.suggest,
-            rstate=np.random.RandomState(4),
+            rstate=np.random.default_rng(4),
             max_evals=max_evals,
         )
 
@@ -121,7 +121,7 @@ class TestSimpleFMin(unittest.TestCase):
             space=self.space,
             trials=self.trials,
             algo=partial(tpe.suggest, n_startup_jobs=10),
-            rstate=np.random.RandomState(4),
+            rstate=np.random.default_rng(4),
             max_evals=max_evals,
         )
 
@@ -136,7 +136,7 @@ class TestSimpleFMin(unittest.TestCase):
             space=self.space,
             trials=self.trials,
             algo=partial(anneal.suggest),
-            rstate=np.random.RandomState(4),
+            rstate=np.random.default_rng(4),
             max_evals=max_evals,
         )
 
@@ -171,7 +171,7 @@ def test_constant_fn_tpe():
         space=space,
         algo=tpe.suggest,
         max_evals=50,
-        rstate=np.random.RandomState(44),
+        rstate=np.random.default_rng(44),
     )
 
 

--- a/hyperopt/tests/test_pyll_utils.py
+++ b/hyperopt/tests/test_pyll_utils.py
@@ -104,9 +104,9 @@ def test_uniformint_arguments(arguments):
         space = hp.uniformint(*arguments)
     if isinstance(arguments, dict):
         space = hp.uniformint(**arguments)
-    rng = np.random.RandomState(123)
+    rng = np.random.default_rng(np.random.PCG64(123))
     values = [sample(space, rng=rng) for _ in range(10)]
-    assert values == [7, 3, 2, 6, 7, 4, 10, 7, 5, 4]
+    assert values == [7, 1, 2, 2, 2, 8, 9, 3, 8, 9]
 
 
 class TestValidateDistributionRange(unittest.TestCase):

--- a/hyperopt/tests/test_rand.py
+++ b/hyperopt/tests/test_rand.py
@@ -3,6 +3,7 @@ from hyperopt.base import Trials, trials_from_docs, miscs_to_idxs_vals
 from hyperopt import rand
 from hyperopt.tests.test_base import Suggest_API
 from .test_domains import gauss_wave2, coin_flip
+import numpy as np
 
 TestRand = Suggest_API.make_tst_class(rand.suggest, gauss_wave2(), "TestRand")
 
@@ -12,13 +13,15 @@ class TestRand(unittest.TestCase):
         # -- assert that the seeding works a particular way
 
         domain = coin_flip()
-        docs = rand.suggest(list(range(10)), domain, Trials(), seed=123)
+        docs = rand.suggest(
+            list(range(10)), domain, Trials(), seed=np.random.PCG64(123)
+        )
         trials = trials_from_docs(docs)
         idxs, vals = miscs_to_idxs_vals(trials.miscs)
 
         # Passes Nov 8 / 2013
         self.assertEqual(list(idxs["flip"]), list(range(10)))
-        self.assertEqual(list(vals["flip"]), [0, 1, 0, 0, 0, 0, 0, 1, 1, 0])
+        self.assertEqual(list(vals["flip"]), [0, 1, 1, 0, 1, 0, 0, 0, 0, 0])
 
     # -- TODO: put in a test that guarantees that
     #          stochastic nodes are sampled in a particular order.

--- a/hyperopt/tests/test_randint.py
+++ b/hyperopt/tests/test_randint.py
@@ -10,7 +10,7 @@ def test_basic():
 
     space = hp.randint("a", 5)
     x = np.zeros(5)
-    rng = np.random.RandomState(123)
+    rng = np.random.default_rng(123)
     for i in range(0, 1000):
         nesto = hyperopt.pyll.stochastic.sample(space, rng=rng)
         x[nesto] += 1
@@ -24,7 +24,7 @@ def test_basic2():
 
     space = hp.randint("a", 5, 15)
     x = np.zeros(15)
-    rng = np.random.RandomState(123)
+    rng = np.random.default_rng(123)
     for i in range(0, 1000):
         nesto = hyperopt.pyll.stochastic.sample(space, rng=rng)
         x[nesto] += 1
@@ -58,7 +58,7 @@ class TestSimpleFMin(unittest.TestCase):
             space=self.space,
             trials=self.trials,
             algo=rand.suggest,
-            rstate=np.random.RandomState(4),
+            rstate=np.random.default_rng(4),
             max_evals=max_evals,
         )
 
@@ -73,7 +73,7 @@ class TestSimpleFMin(unittest.TestCase):
             space=self.space,
             trials=self.trials,
             algo=partial(tpe.suggest, n_startup_jobs=10),
-            rstate=np.random.RandomState(4),
+            rstate=np.random.default_rng(4),
             max_evals=max_evals,
         )
 
@@ -90,7 +90,7 @@ class TestSimpleFMin(unittest.TestCase):
                 self.objective,
                 space=hp.randint("t", lower, upper),
                 algo=rand.suggest,
-                rstate=np.random.RandomState(4),
+                rstate=np.random.default_rng(4),
                 max_evals=max_evals,
             )
             expected = [i for i in [3, 10, 50] if lower <= i < upper]
@@ -105,7 +105,7 @@ class TestSimpleFMin(unittest.TestCase):
                 self.objective,
                 space=hp.randint("t", lower, upper),
                 algo=tpe.suggest,
-                rstate=np.random.RandomState(4),
+                rstate=np.random.default_rng(4),
                 max_evals=max_evals,
             )
             expected = [i for i in [3, 10, 50] if lower <= i < upper]

--- a/hyperopt/tests/test_spark.py
+++ b/hyperopt/tests/test_spark.py
@@ -206,7 +206,7 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
                 max_evals=8,
                 return_argmin=False,
                 trials=spark_trials,
-                rstate=np.random.RandomState(99),
+                rstate=np.random.default_rng(99),
             )
             self.check_run_status(
                 spark_trials, output, num_total=8, num_success=7, num_failure=1
@@ -428,7 +428,7 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
                 max_queue_len=1,
                 show_progressbar=False,
                 return_argmin=False,
-                rstate=np.random.RandomState(99),
+                rstate=np.random.default_rng(99),
             )
             log_output = output.getvalue().strip()
 
@@ -483,7 +483,7 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
                 max_queue_len=1,
                 show_progressbar=False,
                 return_argmin=False,
-                rstate=np.random.RandomState(4),
+                rstate=np.random.default_rng(4),
             )
             log_output = output.getvalue().strip()
 
@@ -517,7 +517,7 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
             max_queue_len=1,
             show_progressbar=False,
             return_argmin=True,
-            rstate=np.random.RandomState(4),
+            rstate=np.random.default_rng(4),
         )
 
         time.sleep(2)

--- a/hyperopt/tests/test_tpe.py
+++ b/hyperopt/tests/test_tpe.py
@@ -42,11 +42,11 @@ def passthrough(x):
 
 
 def test_adaptive_parzen_normal_orig():
-    rng = np.random.RandomState(123)
+    rng = np.random.default_rng(123)
 
     prior_mu = 7
     prior_sigma = 2
-    mus = rng.randn(10) + 5
+    mus = rng.standard_normal(10) + 5
 
     weights2, mus2, sigmas2 = adaptive_parzen_normal_orig(
         mus, 3.3, prior_mu, prior_sigma
@@ -65,7 +65,7 @@ def test_adaptive_parzen_normal_orig():
 
 class TestGMM1(unittest.TestCase):
     def setUp(self):
-        self.rng = np.random.RandomState(234)
+        self.rng = np.random.default_rng(234)
 
     def test_mu_is_used_correctly(self):
         assert np.allclose(10, GMM1([1], [10.0], [0.0000001], rng=self.rng))
@@ -215,7 +215,7 @@ class TestGMM1(unittest.TestCase):
 
 class TestGMM1Math(unittest.TestCase):
     def setUp(self):
-        self.rng = np.random.RandomState(234)
+        self.rng = np.random.default_rng(234)
         self.weights = [0.1, 0.3, 0.4, 0.2]
         self.mus = [1.0, 2.0, 3.0, 4.0]
         self.sigmas = [0.1, 0.4, 0.8, 2.0]
@@ -274,7 +274,7 @@ class TestGMM1Math(unittest.TestCase):
 
 class TestQGMM1Math(unittest.TestCase):
     def setUp(self):
-        self.rng = np.random.RandomState(234)
+        self.rng = np.random.default_rng(234)
         self.weights = [0.1, 0.3, 0.4, 0.2]
         self.mus = [1.0, 2.0, 3.0, 4.0]
         self.sigmas = [0.1, 0.4, 0.8, 2.0]
@@ -377,7 +377,7 @@ class TestQGMM1Math(unittest.TestCase):
 
 class TestLGMM1Math(unittest.TestCase):
     def setUp(self):
-        self.rng = np.random.RandomState(234)
+        self.rng = np.random.default_rng(234)
         self.weights = [0.1, 0.3, 0.4, 0.2]
         self.mus = [-2.0, 1.0, 0.0, 3.0]
         self.sigmas = [0.1, 0.4, 0.8, 2.0]
@@ -440,7 +440,7 @@ class TestLGMM1Math(unittest.TestCase):
 
 class TestQLGMM1Math(unittest.TestCase):
     def setUp(self):
-        self.rng = np.random.RandomState(234)
+        self.rng = np.random.default_rng(234)
         self.weights = [0.1, 0.3, 0.4, 0.2]
         self.mus = [-2, 0.0, -3.0, 1.0]
         self.sigmas = [2.1, 0.4, 0.8, 2.1]
@@ -623,7 +623,7 @@ class TestOpt(unittest.TestCase, CasePerDomain):
             algo=algo,
             trials=trials,
             max_evals=LEN,
-            rstate=np.random.RandomState(123),
+            rstate=np.random.default_rng(np.random.PCG64(0)),
             catch_eval_exceptions=False,
         )
         assert len(trials) == LEN
@@ -664,7 +664,7 @@ class TestOpt(unittest.TestCase, CasePerDomain):
 
 @domain_constructor(loss_target=0)
 def opt_q_uniform(target):
-    rng = np.random.RandomState(123)
+    rng = np.random.default_rng(123)
     x = hp.quniform("x", 1.01, 10, 1)
     return {
         "loss": (x - target) ** 2 + scope.normal(0, 1, rng=rng),

--- a/hyperopt/tests/test_utils.py
+++ b/hyperopt/tests/test_utils.py
@@ -41,7 +41,7 @@ def test_get_most_recent_inds():
         for _ind in range(k):
             test_data.append({"_id": ind, "version": _ind})
         most_recent_data.append({"_id": ind, "version": _ind})
-    rng = np.random.RandomState(0)
+    rng = np.random.default_rng(0)
     p = rng.permutation(len(test_data))
     test_data_rearranged = [test_data[_p] for _p in p]
     rind = get_most_recent_inds(test_data_rearranged)

--- a/hyperopt/tests/test_vectorize.py
+++ b/hyperopt/tests/test_vectorize.py
@@ -56,7 +56,7 @@ def test_vectorize_trivial():
     full_output = as_apply([vloss, vh.idxs_by_label(), vh.vals_by_label()])
     fo2 = replace_repeat_stochastic(full_output)
 
-    new_vc = recursive_set_rng_kwarg(fo2, as_apply(np.random.RandomState(1)))
+    new_vc = recursive_set_rng_kwarg(fo2, as_apply(np.random.default_rng(1)))
 
     # print new_vc
     losses, idxs, vals = rec_eval(new_vc)
@@ -81,7 +81,7 @@ def test_vectorize_simple():
     full_output = as_apply([vloss, vh.idxs_by_label(), vh.vals_by_label()])
     fo2 = replace_repeat_stochastic(full_output)
 
-    new_vc = recursive_set_rng_kwarg(fo2, as_apply(np.random.RandomState(1)))
+    new_vc = recursive_set_rng_kwarg(fo2, as_apply(np.random.default_rng(1)))
 
     # print new_vc
     losses, idxs, vals = rec_eval(new_vc)
@@ -106,7 +106,7 @@ def test_vectorize_multipath():
 
     full_output = as_apply([vloss, vh.idxs_by_label(), vh.vals_by_label()])
 
-    new_vc = recursive_set_rng_kwarg(full_output, as_apply(np.random.RandomState(1)))
+    new_vc = recursive_set_rng_kwarg(full_output, as_apply(np.random.default_rng(1)))
 
     losses, idxs, vals = rec_eval(new_vc)
     print("losses", losses)
@@ -157,7 +157,7 @@ def test_vectorize_config0():
         print(fo2)
         print("\n" * 1)
 
-    new_vc = recursive_set_rng_kwarg(fo2, as_apply(np.random.RandomState(1)))
+    new_vc = recursive_set_rng_kwarg(fo2, as_apply(np.random.default_rng(1)))
     if 0:
         print("=" * 80)
         print("VECTORIZED STOCHASTIC WITH RNGS")
@@ -220,7 +220,7 @@ def test_distributions():
         algo=rand.suggest,
         trials=trials,
         max_evals=N,
-        rstate=np.random.RandomState(124),
+        rstate=np.random.default_rng(124),
         catch_eval_exceptions=False,
     )
     assert len(trials) == N

--- a/hyperopt/tpe.py
+++ b/hyperopt/tpe.py
@@ -919,7 +919,7 @@ def suggest(
 
     # -- this dictionary will map pyll nodes to the values
     #    they should take during the evaluation of the pyll program
-    memo = {domain.s_new_ids: fake_ids, domain.s_rng: np.random.RandomState(seed)}
+    memo = {domain.s_new_ids: fake_ids, domain.s_rng: np.random.default_rng(seed)}
 
     memo[observed_loss["idxs"]] = tids
     memo[observed_loss["vals"]] = losses

--- a/hyperopt/utils.py
+++ b/hyperopt/utils.py
@@ -129,9 +129,9 @@ def pmin_sampled(mean, var, n_samples=1000, rng=None):
 
     """
     if rng is None:
-        rng = numpy.random.RandomState(232342)
+        rng = numpy.random.default_rng(232342)
 
-    samples = rng.randn(n_samples, len(mean)) * numpy.sqrt(var) + mean
+    samples = rng.standard_normal((n_samples, len(mean))) * numpy.sqrt(var) + mean
     winners = (samples.T == samples.min(axis=1)).T
     wincounts = winners.sum(axis=0)
     assert wincounts.shape == mean.shape


### PR DESCRIPTION
Numpy's `numpy.random.RandomState` is deprecated. According to [its documentation](https://numpy.org/doc/stable/reference/random/legacy.html):
> This generator is considered frozen and will have no further improvements. It is guaranteed to produce the same values as the final point release of NumPy v1.16.

I've updated the code to use instances of `numpy.random.Generator` instead.

**NOTE**: This will lead to an API breakage, since `numpy.random.Generator` is not backwards-compatible with `numpy.random.RandomState`.

I've also updated some tests to use fixed RNG algorithms where the seed is important. However, I may have missed some, so please let me know in your review. The reason is that `numpy.random.Generator` doesn't provide a compatibility guarantee, as written in [its documentation](https://numpy.org/doc/stable/reference/random/generator.html#numpy.random.Generator):
> **No Compatibility Guarantee**
>
> Generator does not provide a version compatibility guarantee. In particular, as better algorithms evolve the bit stream may change.