### PR TITLE
Fix broken spark plugin test

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -33,6 +33,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e '.[MongoTrials, SparkTrials, ATPE, dev]'
+          pip install pyspark==3.2.0
       - name: Test with pytest - Unit tests
         run: |
           python -m pytest ./hyperopt/tests/unit
+      - name: Test spark plugin - pin thread mode
+        run: |
+          PYSPARK_PIN_THREAD=true pytest hyperopt/tests/integration/test_spark.py
+      - name: Test spark plugin - non pin thread mode
+        run: |
+          PYSPARK_PIN_THREAD=false pytest hyperopt/tests/integration/test_spark.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,14 +38,14 @@ jobs:
         - NUMPY_VERSION=1.19.4
         - SPARK_VERSION=3.2.0
         - PYSPARK_PIN_THREAD=true
-      script: pytest hyperopt/tests/test_spark.py
+      script: pytest hyperopt/tests/integration/test_spark.py
     - name: "Run tests on python 3.9 with spark 3.2 and pinned threads off"
       python: 3.9
       env:
         - NUMPY_VERSION=1.19.4
         - SPARK_VERSION=3.2.0
         - PYSPARK_PIN_THREAD=false
-      script: pytest hyperopt/tests/test_spark.py
+      script: pytest hyperopt/tests/integration/test_spark.py
 
 install:
   - sudo apt-get remove ipython || true  # ipython is not pre-installed in Focal

--- a/hyperopt/tests/integration/test_spark.py
+++ b/hyperopt/tests/integration/test_spark.py
@@ -411,12 +411,12 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
             self.assert_task_succeeded(log_output, 0)
 
     def test_timeout_without_job_cancellation_fmin_timeout(self):
-        timeout = 4
+        timeout = 5
         spark_trials = SparkTrials(parallelism=1)
         spark_trials._spark_supports_job_cancelling = False
 
         def fn(x):
-            time.sleep(0.5)
+            time.sleep(1)
             return x
 
         with patch_logger("hyperopt-spark", logging.DEBUG) as output:

--- a/hyperopt/tests/integration/test_spark.py
+++ b/hyperopt/tests/integration/test_spark.py
@@ -211,7 +211,7 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
                 rstate=np.random.default_rng(99),
             )
             self.check_run_status(
-                spark_trials, output, num_total=8, num_success=7, num_failure=1
+                spark_trials, output, num_total=8, num_success=6, num_failure=2
             )
 
         expected_result = {"loss": 1.0, "status": "ok"}
@@ -240,17 +240,17 @@ class FMinTestCase(unittest.TestCase, BaseSparkContext):
         num_success = spark_trials.count_by_state_unsynced(base.JOB_STATE_DONE)
         self.assertEqual(
             num_success,
-            7,
+            6,
             "Wrong number of successful trial runs: Expected {e} but got {r}.".format(
-                e=7, r=num_success
+                e=6, r=num_success
             ),
         )
         num_failure = spark_trials.count_by_state_unsynced(base.JOB_STATE_ERROR)
         self.assertEqual(
             num_failure,
-            1,
+            2,
             "Wrong number of failed trial runs: Expected {e} but got {r}.".format(
-                e=1, r=num_failure
+                e=2, r=num_failure
             ),
         )
 


### PR DESCRIPTION
Fix broken spark plugin test:

* Fix CI command for spark test
* Fix a failure spark test `test_trial_run_info` broken by https://github.com/hyperopt/hyperopt/pull/821