### PR TITLE
Bump numpy to earliest version that supports Generator

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
     keywords="Bayesian optimization hyperparameter model selection",
     include_package_data=True,
     install_requires=[
-        "numpy",
+        "numpy>=1.17",
         "scipy",
         "six",
         "networkx>=2.2",


### PR DESCRIPTION
This is in reference to [this comment](https://github.com/hyperopt/hyperopt/issues/829#issuecomment-978914377) on #829:

> Hi. I just had the same problem.
> Wouldn't pinning or giving a range of the numpy version in `setup.py` prevent this? In a sense that contributors would not accidentally use an old numpy version.

_Originally posted by @alexandschaefer in https://github.com/hyperopt/hyperopt/issues/829#issuecomment-978914377_