### PR TITLE
Fix for issue 833: incorrect handling of status failed jobs that don't throw an exception

### DIFF
--- a/hyperopt/spark.py
+++ b/hyperopt/spark.py
@@ -5,7 +5,7 @@ import timeit
 import traceback
 
 from hyperopt import base, fmin, Trials
-from hyperopt.base import validate_timeout, validate_loss_threshold, STATUS_OK
+from hyperopt.base import STATUS_OK, validate_loss_threshold, validate_timeout
 from hyperopt.utils import coarse_utcnow, _get_logger, _get_random_id
 
 from py4j.clientserver import ClientServer


### PR DESCRIPTION
Issue 833 describes the problem of jobs failing gracefully: not throwing an exception but instead returning a dict with a key status with value STATUS_FAIL. Those spark jobs would be marked as successful instead of error.

This PR fixes those cases and adds a test.

Closes #833 