### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,9 @@ setuptools.setup(
     packages=setuptools.find_packages(include=["hyperopt*"]),
     entry_points={"console_scripts": ["hyperopt-mongo-worker=hyperopt.mongoexp:main"]},
     url="https://hyperopt.github.io/hyperopt",
+    project_urls={
+        "Source": "https://github.com/hyperopt/hyperopt",
+    },
     author="James Bergstra",
     author_email="james.bergstra@gmail.com",
     description="Distributed Asynchronous Hyperparameter Optimization",


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)