### PR TITLE
Avoid attachment in SparkTrials

### DIFF
--- a/hyperopt/fmin.py
+++ b/hyperopt/fmin.py
@@ -157,7 +157,7 @@ class FMinIter:
         self.rstate = rstate
         self.verbose = verbose
 
-        if self.asynchronous:
+        if self.asynchronous and not hasattr(self.trials, "_spark"):
             if "FMinIter_Domain" in trials.attachments:
                 logger.warning("over-writing old domain trials attachment")
             msg = pickler.dumps(domain)


### PR DESCRIPTION
Fix https://github.com/hyperopt/hyperopt/issues/669.

### Problem

The following code in https://github.com/hyperopt/hyperopt/blob/master/hyperopt/fmin.py#L160
```
        if self.asynchronous:
            if "FMinIter_Domain" in trials.attachments:
                logger.warning("over-writing old domain trials attachment")
            msg = pickler.dumps(domain)
            # -- sanity check for unpickling
            pickler.loads(msg)
            trials.attachments["FMinIter_Domain"] = msg
```
tries to add an attachment to Spark trials, since SparkTrials sets `self.asynchronous` to True (just like MongoTrials). The problem is that it relies on pickling `domain` and this is an issue if an object cannot be serialized by pickle (e.g. if we are using a Spark-broadcasted object).

Moreover, this code in https://github.com/hyperopt/hyperopt/blob/master/hyperopt/spark.py#L188
```
    def trial_attachments(self, trial):
        raise NotImplementedError("SparkTrials does not support trial attachments.")
```
seems to suggest that SparkTrials does not even support trial attachments. So why are we trying to add an attachment if SparkTrials does not support trial attachments?

### Solution

We add an additional `and not hasattr(self.trials, "_spark")` condition, so the current behavior doesn't change for MongoTrials, but we skip the problematic code for SparkTrials (`_spark` is an attribute within SparkTrials which stores the Spark session). This "hasattr" check is similar to other implemented checks such as this one: https://github.com/hyperopt/hyperopt/blob/master/hyperopt/fmin.py#L204
