### PR TITLE
fix for issue 565: list index out of range

### DIFF
--- a/hyperopt/atpe.py
+++ b/hyperopt/atpe.py
@@ -1255,7 +1255,8 @@ class ATPEOptimizer:
         elif parameter.config.get("mode", "uniform") == "randint":
             min = parameter.config["min"]
             max = parameter.config["max"]
-            value = random.randint(min, max)
+            # `max` should be reduced by one, as native randint includes `max`, while numpy randint excludes it
+            value = random.randint(min, max - 1)
 
         return value
 


### PR DESCRIPTION
fix for issue #565 IndexError in ATPE
ATPE optimizer uses native random module instead of numpy random and there is a difference in `randint` function logic.
Native random [includes](https://docs.python.org/3/library/random.html#random.randint) upper boundary, while numpy [excludes](https://numpy.org/doc/stable/reference/random/generated/numpy.random.randint.html) it.
