### PR TITLE
Fixed python 3 incompatible code

### DIFF
--- a/hyperopt/early_stop.py
+++ b/hyperopt/early_stop.py
@@ -22,7 +22,7 @@ def no_progress_loss(iteration_stop_count=20, percent_increase=0.0):
         if best_loss is None:
             return False, [new_loss, iteration_no_progress + 1]
         best_loss_threshold = best_loss - abs(best_loss * (percent_increase / 100.0))
-        if new_loss < best_loss_threshold:
+        if new_loss is None or new_loss < best_loss_threshold:
             best_loss = new_loss
             iteration_no_progress = 0
         else:


### PR DESCRIPTION
`new_loss` can `None` in specific cases. On python 2 this results in the less-than comparison being True but on Python 3 it throws a type error.

Error message encountered:
```
TypeError: '<' not supported between instances of 'NoneType' and 'float'
  <snip>
  File "hyperopt/fmin.py", line 522, in fmin
    trials_save_file=trials_save_file,
  File "hyperopt/base.py", line 699, in fmin
    trials_save_file=trials_save_file,
  File "hyperopt/fmin.py", line 553, in fmin
    rval.exhaust()
  File "hyperopt/fmin.py", line 356, in exhaust
    self.run(self.max_evals - n_done, block_until_done=self.asyn)
  File "hyperopt/fmin.py", line 299, in run
    self.trials, *self.early_stop_args
  File "hyperopt/early_stop.py", line 25, in stop_fn
    if new_loss < best_loss_threshold:
```