### PR TITLE
Remove call to numpy.warnings.filterwarnings

### DIFF
--- a/hyperopt/atpe.py
+++ b/hyperopt/atpe.py
@@ -1271,8 +1271,6 @@ class ATPEOptimizer:
         percentile75Loss = 0
         statistics = {}
 
-        numpy.warnings.filterwarnings("ignore")
-
         if len(set(losses)) > 1:
             bestLoss = numpy.percentile(losses, 0)
             percentile5Loss = numpy.percentile(losses, 5)


### PR DESCRIPTION
That shouldn't happen as a side effect, not to mention it doesn't work with NumPy 1.24 anyway.