### PR TITLE
Make package formally Python 3.7+ only

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
-import io
 import re
 
 import setuptools
-
 
 with open("hyperopt/__init__.py", encoding="utf8") as f:
     version = re.search(r"__version__ = \"(.*?)\"", f.read()).group(1)
@@ -31,8 +29,9 @@ setuptools.setup(
         "Operating System :: POSIX",
         "Operating System :: Unix",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Scientific/Engineering",
         "Topic :: Software Development",
     ],
@@ -40,6 +39,7 @@ setuptools.setup(
     license="BSD",
     keywords="Bayesian optimization hyperparameter model selection",
     include_package_data=True,
+    requires_python=">=3.7",
     install_requires=[
         "numpy>=1.17",
         "scipy",


### PR DESCRIPTION
Python 2 support had been effectively dropped in #831 and https://github.com/hyperopt/hyperopt/commit/caa3c2425de055d885b59acf5bd921e5dae33eb0, so update metadata to reflect that.

