### PR TITLE
Add action for closing stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,14 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-message: 'This issue has been marked as stale because it has been open 120 days with no activity. Remove the stale label or comment or this will be closed in 30 days.'
+          days-before-stale: 120
+          days-before-close: 30


### PR DESCRIPTION
Fix for #562. Currently set to mark as stale after 120 days and then close after an addition 30 days of no activity. @maxpumperla what do you think?