### PR TITLE
Remove `future` dependency

### DIFF
--- a/hyperopt/base.py
+++ b/hyperopt/base.py
@@ -22,7 +22,6 @@ The design is that there are three components fitting together in this project:
 """
 
 import numbers
-from past.builtins import basestring
 import logging
 import datetime
 import sys
@@ -139,7 +138,7 @@ def SONify(arg, memo=None):
             rval = type(arg)([SONify(ai, memo) for ai in arg])
         elif isinstance(arg, dict):
             rval = {SONify(k, memo): SONify(v, memo) for k, v in list(arg.items())}
-        elif isinstance(arg, (basestring, float, int, type(None))):
+        elif isinstance(arg, (str, bytes, float, int, type(None))):
             rval = arg
         elif isinstance(arg, np.ndarray):
             if arg.ndim == 0:

--- a/hyperopt/criteria.py
+++ b/hyperopt/criteria.py
@@ -1,6 +1,5 @@
 """Criteria for Bayesian optimization
 """
-from past.utils import old_div
 import numpy as np
 import scipy.stats
 
@@ -28,7 +27,7 @@ def EI_gaussian(mean, var, thresh):
     (estimated analytically)
     """
     sigma = np.sqrt(var)
-    score = old_div((mean - thresh), sigma)
+    score = (mean - thresh) / sigma
     n = scipy.stats.norm
     return sigma * (score * n.cdf(score) + n.pdf(score))
 
@@ -42,7 +41,7 @@ def logEI_gaussian(mean, var, thresh):
     """
     assert np.asarray(var).min() >= 0
     sigma = np.sqrt(var)
-    score = old_div((mean - thresh), sigma)
+    score = (mean - thresh) / sigma
     n = scipy.stats.norm
     try:
         float(mean)

--- a/hyperopt/fmin.py
+++ b/hyperopt/fmin.py
@@ -1,5 +1,3 @@
-from future import standard_library
-
 import functools
 import inspect
 import logging
@@ -17,7 +15,6 @@ from .utils import coarse_utcnow
 from . import base
 from . import progress
 
-standard_library.install_aliases()
 logger = logging.getLogger(__name__)
 
 

--- a/hyperopt/graph_viz.py
+++ b/hyperopt/graph_viz.py
@@ -3,12 +3,8 @@ Use graphviz's dot language to express the relationship between hyperparamters
 in a search space.
 
 """
-from future import standard_library
-
 import io
 from .pyll_utils import expr_to_config
-
-standard_library.install_aliases()
 
 
 def dot_hyperparameters(expr):

--- a/hyperopt/main.py
+++ b/hyperopt/main.py
@@ -3,14 +3,12 @@
 """
 Entry point for bin/* scripts
 """
-from future import standard_library
 import logging
 import os
 from . import utils
 from .base import SerialExperiment
 import sys
 
-standard_library.install_aliases()
 logger = logging.getLogger(__name__)
 
 

--- a/hyperopt/mongoexp.py
+++ b/hyperopt/mongoexp.py
@@ -89,7 +89,6 @@ bandit.evaluate function has returned before setting the state to 2 or 3 to
 finalize the job in the database.
 
 """
-from future import standard_library
 import copy
 
 # import hashlib
@@ -134,7 +133,6 @@ __authors__ = ["James Bergstra", "Dan Yamins"]
 __license__ = "3-clause BSD License"
 __contact__ = "github.com/hyperopt/hyperopt"
 
-standard_library.install_aliases()
 logger = logging.getLogger(__name__)
 
 try:

--- a/hyperopt/plotting.py
+++ b/hyperopt/plotting.py
@@ -5,12 +5,6 @@ Functions to visualize an Experiment.
 
 import pickle
 
-try:
-    unicode = unicode
-except NameError:
-    basestring = (str, bytes)
-else:
-    basestring = basestring
 # -- don't import this here because it locks in the backend
 #    and we want the unittests to be able to set the backend
 # TODO: this is really bad style, create a backend plotting

--- a/hyperopt/pyll/base.py
+++ b/hyperopt/pyll/base.py
@@ -2,7 +2,6 @@
 #
 # It provides types to build ASTs in a simple lambda-notation style
 #
-from future import standard_library
 import copy
 import logging
 import operator
@@ -16,7 +15,6 @@ import networkx as nx
 import numpy as np
 from io import StringIO
 
-standard_library.install_aliases()
 logger = logging.getLogger(__name__)
 np_versions = list(map(int, np.__version__.split(".")[:2]))
 

--- a/hyperopt/pyll/stochastic.py
+++ b/hyperopt/pyll/stochastic.py
@@ -1,7 +1,6 @@
 """
 Constructs for annotating base graphs.
 """
-from past.utils import old_div
 import sys
 import numpy as np
 from .base import scope, as_apply, dfs, rec_eval, clone
@@ -47,14 +46,14 @@ def loguniform(low, high, rng=None, size=()):
 @scope.define
 def quniform(low, high, q, rng=None, size=()):
     draw = rng.uniform(low, high, size=size)
-    return np.round(old_div(draw, q)) * q
+    return np.round(draw / q) * q
 
 
 @implicit_stochastic
 @scope.define
 def qloguniform(low, high, q, rng=None, size=()):
     draw = np.exp(rng.uniform(low, high, size=size))
-    return np.round(old_div(draw, q)) * q
+    return np.round(draw / q) * q
 
 
 # -- NORMAL
@@ -70,7 +69,7 @@ def normal(mu, sigma, rng=None, size=()):
 @scope.define
 def qnormal(mu, sigma, q, rng=None, size=()):
     draw = rng.normal(mu, sigma, size=size)
-    return np.round(old_div(draw, q)) * q
+    return np.round(draw / q) * q
 
 
 @implicit_stochastic
@@ -84,7 +83,7 @@ def lognormal(mu, sigma, rng=None, size=()):
 @scope.define
 def qlognormal(mu, sigma, q, rng=None, size=()):
     draw = np.exp(rng.normal(mu, sigma, size=size))
-    return np.round(old_div(draw, q)) * q
+    return np.round(draw / q) * q
 
 
 # -- CATEGORICAL

--- a/hyperopt/pyll/tests/test_stochastic.py
+++ b/hyperopt/pyll/tests/test_stochastic.py
@@ -1,4 +1,3 @@
-from past.utils import old_div
 import numpy as np
 from hyperopt.pyll import scope, as_apply, rec_eval
 from hyperopt.pyll.stochastic import recursive_set_rng_kwarg, sample
@@ -30,9 +29,7 @@ def test_lnorm():
                 "outker_shape": (inker_size, inker_size),
                 "remove_mean": choice([0, 1]),
                 "stretch": uniform(low=0, high=10),
-                "threshold": uniform(
-                    low=old_div(0.1, np.sqrt(10.0)), high=10 * np.sqrt(10)
-                ),
+                "threshold": uniform(low=0.1 / np.sqrt(10), high=10 * np.sqrt(10)),
             }
         }
     )

--- a/hyperopt/pyll_utils.py
+++ b/hyperopt/pyll_utils.py
@@ -1,4 +1,3 @@
-from past.builtins import basestring
 from functools import partial, wraps
 from .base import DuplicateLabel
 from .pyll.base import Apply, Literal, MissingArgument
@@ -9,9 +8,9 @@ from .pyll import as_apply
 def validate_label(f):
     @wraps(f)
     def wrapper(label, *args, **kwargs):
-        is_real_string = isinstance(label, basestring)
+        is_real_string = isinstance(label, (str, bytes))
         is_literal_string = isinstance(label, Literal) and isinstance(
-            label.obj, basestring
+            label.obj, (str, bytes)
         )
         if not is_real_string and not is_literal_string:
             raise TypeError("require string label")

--- a/hyperopt/rdists.py
+++ b/hyperopt/rdists.py
@@ -23,13 +23,13 @@ class loguniform_gen(rv_continuous):
         return rval
 
     def _pdf(self, x):
-        return old_div(1.0, (x * (self._high - self._low)))
+        return 1 / (x * (self._high - self._low))
 
     def _logpdf(self, x):
         return -np.log(x) - np.log(self._high - self._low)
 
     def _cdf(self, x):
-        return old_div((np.log(x) - self._low), (self._high - self._low))
+        return (np.log(x) - self._low) / (self._high - self._low)
 
 
 class lognorm_gen(scipy_lognorm_gen):
@@ -54,9 +54,9 @@ class lognorm_gen(scipy_lognorm_gen):
 
 
 def qtable_pmf(x, q, qlow, xs, ps):
-    qx = np.round(old_div(np.atleast_1d(x).astype(float), q)) * q
+    qx = np.round(np.atleast_1d(x).astype(float) / q) * q
     is_multiple = np.isclose(qx, x)
-    ix = np.round(old_div((qx - qlow), q)).astype(int)
+    ix = np.round((qx - qlow) / q).astype(int)
     is_inbounds = np.logical_and(ix >= 0, ix < len(ps))
     oks = np.logical_and(is_multiple, is_inbounds)
     rval = np.zeros_like(qx)
@@ -84,15 +84,15 @@ class quniform_gen:
 
     def __init__(self, low, high, q):
         low, high = list(map(float, (low, high)))
-        qlow = safe_int_cast(np.round(old_div(low, q))) * q
-        qhigh = safe_int_cast(np.round(old_div(high, q))) * q
+        qlow = safe_int_cast(np.round(low / q)) * q
+        qhigh = safe_int_cast(np.round(high / q)) * q
         if qlow == qhigh:
             xs = [qlow]
             ps = [1.0]
         else:
-            lowmass = 1 - (old_div((low - qlow + 0.5 * q), q))
+            lowmass = 1 - ((low - qlow + 0.5 * q) / q)
             assert 0 <= lowmass <= 1.0, (lowmass, low, qlow, q)
-            highmass = old_div((high - qhigh + 0.5 * q), q)
+            highmass = (high - qhigh + 0.5 * q) / q
             assert 0 <= highmass <= 1.0, (highmass, high, qhigh, q)
             # -- xs: qlow to qhigh inclusive
             xs = np.arange(qlow, qhigh + 0.5 * q, q)
@@ -117,7 +117,7 @@ class quniform_gen:
 
     def rvs(self, size=()):
         rval = mtrand.uniform(low=self.low, high=self.high, size=size)
-        rval = safe_int_cast(np.round(old_div(rval, self.q))) * self.q
+        rval = safe_int_cast(np.round(rval / self.q)) * self.q
         return rval
 
 
@@ -131,8 +131,8 @@ class qloguniform_gen(quniform_gen):
         low, high = list(map(float, (low, high)))
         elow = np.exp(low)
         ehigh = np.exp(high)
-        qlow = safe_int_cast(np.round(old_div(elow, q))) * q
-        qhigh = safe_int_cast(np.round(old_div(ehigh, q))) * q
+        qlow = safe_int_cast(np.round(elow / q)) * q
+        qhigh = safe_int_cast(np.round(ehigh / q)) * q
 
         # -- loguniform for using the CDF
         lu = loguniform_gen(low=low, high=high)
@@ -173,7 +173,7 @@ class qloguniform_gen(quniform_gen):
 
     def rvs(self, size=()):
         x = mtrand.uniform(low=self.low, high=self.high, size=size)
-        rval = safe_int_cast(np.round(old_div(np.exp(x), self.q))) * self.q
+        rval = safe_int_cast(np.round(np.exp(x) / self.q)) * self.q
         return rval
 
 
@@ -217,7 +217,7 @@ class qnormal_gen:
 
     def rvs(self, size=()):
         x = mtrand.normal(loc=self.mu, scale=self.sigma, size=size)
-        rval = safe_int_cast(np.round(old_div(x, self.q))) * self.q
+        rval = safe_int_cast(np.round(x / self.q)) * self.q
         return rval
 
 
@@ -261,7 +261,7 @@ class qlognormal_gen:
 
     def rvs(self, size=()):
         x = mtrand.normal(loc=self.mu, scale=self.sigma, size=size)
-        rval = safe_int_cast(np.round(old_div(np.exp(x), self.q))) * self.q
+        rval = safe_int_cast(np.round(np.exp(x) / self.q)) * self.q
         return rval
 
 

--- a/hyperopt/rdists.py
+++ b/hyperopt/rdists.py
@@ -2,7 +2,6 @@
 Extra distributions to complement scipy.stats
 
 """
-from past.utils import old_div
 import numpy as np
 import numpy.random as mtrand
 import scipy.stats
@@ -187,7 +186,7 @@ class qnormal_gen:
         self._norm_logcdf = scipy.stats.norm(loc=mu, scale=sigma).logcdf
 
     def in_domain(self, x):
-        return np.isclose(x, safe_int_cast(np.round(old_div(x, self.q))) * self.q)
+        return np.isclose(x, safe_int_cast(np.round(x / self.q)) * self.q)
 
     def pmf(self, x):
         return np.exp(self.logpmf(x))
@@ -233,7 +232,7 @@ class qlognormal_gen:
     def in_domain(self, x):
         return np.logical_and(
             (x >= 0),
-            np.isclose(x, safe_int_cast(np.round(old_div(x, self.q))) * self.q),
+            np.isclose(x, safe_int_cast(np.round(x / self.q)) * self.q),
         )
 
     def pmf(self, x):

--- a/hyperopt/tests/unit/test_criteria.py
+++ b/hyperopt/tests/unit/test_criteria.py
@@ -1,4 +1,3 @@
-from past.utils import old_div
 import numpy as np
 import hyperopt.criteria as crit
 
@@ -21,7 +20,7 @@ def test_ei():
 
         if not np.allclose(v_n, v_a, atol=0.03, rtol=0.03):
             for t, n, a in zip(thresholds, v_n, v_a):
-                print((t, n, a, abs(n - a), old_div(abs(n - a), (abs(n) + abs(a)))))
+                print((t, n, a, abs(n - a), abs(n - a) / (abs(n) + abs(a))))
             assert 0
             # mean, var, thresh, v_n, v_a)
 

--- a/hyperopt/tests/unit/test_domains.py
+++ b/hyperopt/tests/unit/test_domains.py
@@ -1,4 +1,3 @@
-from past.utils import old_div
 import unittest
 
 import numpy as np
@@ -106,7 +105,7 @@ def distractor():
 
     x = hp.uniform("x", -15, 15)
     # climbs rightward from 0.0 to 1.0
-    f1 = old_div(1.0, (1.0 + scope.exp(-x)))
+    f1 = 1 / (1 + scope.exp(-x))
     f2 = 2 * scope.exp(-((x + 10) ** 2))  # bump with height 2 at (x=-10)
     return {"loss": -f1 - f2, "status": base.STATUS_OK}
 
@@ -127,7 +126,7 @@ def gauss_wave():
     x = hp.uniform("x", -20, 20)
     t = hp.choice("curve", [x, x + np.pi])
     f1 = scope.sin(t)
-    f2 = 2 * scope.exp(-((old_div(t, 5.0)) ** 2))
+    f2 = 2 * scope.exp(-((t / 5) ** 2))
     return {"loss": -(f1 + f2), "status": base.STATUS_OK}
 
 
@@ -147,7 +146,7 @@ def gauss_wave2():
     var = 0.1
     x = hp.uniform("x", -20, 20)
     amp = hp.uniform("amp", 0, 1)
-    t = scope.normal(0, var, rng=rng) + 2 * scope.exp(-((old_div(x, 5.0)) ** 2))
+    t = scope.normal(0, var, rng=rng) + 2 * scope.exp(-((x / 5) ** 2))
     return {
         "loss": -hp.choice("hf", [t, t + scope.sin(x) * amp]),
         "loss_variance": var,
@@ -200,8 +199,8 @@ def branin():
     y = hp.uniform("y", 0.0, 15.0)
     pi = float(np.pi)
     loss = (
-        (y - (old_div(5.1, (4 * pi**2))) * x**2 + 5 * x / pi - 6) ** 2
-        + 10 * (1 - old_div(1, (8 * pi))) * scope.cos(x)
+        (y - (5.1 / (4 * pi**2)) * x**2 + 5 * x / pi - 6) ** 2
+        + 10 * (1 - 1 / (8 * pi)) * scope.cos(x)
         + 10
     )
     return {"loss": loss, "loss_variance": 0, "status": base.STATUS_OK}

--- a/hyperopt/tests/unit/test_rdists.py
+++ b/hyperopt/tests/unit/test_rdists.py
@@ -1,4 +1,3 @@
-from past.utils import old_div
 from collections import defaultdict
 import unittest
 import numpy as np
@@ -92,7 +91,7 @@ class TestLogNormal(unittest.TestCase):
 def check_d_samples(dfn, n, rtol=1e-2, atol=1e-2):
     counts = defaultdict(lambda: 0)
     # print 'sample', dfn.rvs(size=n)
-    inc = old_div(1.0, n)
+    inc = 1 / n
     for s in dfn.rvs(size=n):
         counts[s] += inc
     for ii, p in sorted(counts.items()):

--- a/hyperopt/tests/unit/test_tpe.py
+++ b/hyperopt/tests/unit/test_tpe.py
@@ -1,4 +1,3 @@
-from past.utils import old_div
 from functools import partial
 import os
 import unittest
@@ -116,7 +115,7 @@ class TestGMM1(unittest.TestCase):
         # x  # weights  # mu  # sigma
         llval = GMM1_lpdf(1.0, [1.0], [1.0], [2.0])
         assert llval.shape == ()
-        assert np.allclose(llval, np.log(old_div(1.0, np.sqrt(2 * np.pi * 2.0**2))))
+        assert np.allclose(llval, np.log(1 / np.sqrt(2 * np.pi * 2.0**2)))
 
     def test_lpdf_scalar_N_components(self):
         llval = GMM1_lpdf(
@@ -128,12 +127,8 @@ class TestGMM1(unittest.TestCase):
         print(llval)
 
         a = 0.25 / np.sqrt(2 * np.pi * 1.0**2) * np.exp(-0.5 * (1.0) ** 2)
-        a += old_div(0.25, np.sqrt(2 * np.pi * 2.0**2))
-        a += (
-            0.5
-            / np.sqrt(2 * np.pi * 5.0**2)
-            * np.exp(-0.5 * (old_div(1.0, 5.0)) ** 2)
-        )
+        a += 0.25 / np.sqrt(2 * np.pi * 2.0**2)
+        a += 0.5 / np.sqrt(2 * np.pi * 5.0**2) * np.exp(-0.5 * (0.2) ** 2)
 
     def test_lpdf_vector_N_components(self):
         llval = GMM1_lpdf(
@@ -145,28 +140,16 @@ class TestGMM1(unittest.TestCase):
 
         # case x = 1.0
         a = 0.25 / np.sqrt(2 * np.pi * 1.0**2) * np.exp(-0.5 * (1.0) ** 2)
-        a += old_div(0.25, np.sqrt(2 * np.pi * 2.0**2))
-        a += (
-            0.5
-            / np.sqrt(2 * np.pi * 5.0**2)
-            * np.exp(-0.5 * (old_div(1.0, 5.0)) ** 2)
-        )
+        a += 0.25 / np.sqrt(2 * np.pi * 2.0**2)
+        a += 0.5 / np.sqrt(2 * np.pi * 5.0**2) * np.exp(-0.5 * (0.2) ** 2)
 
         assert llval.shape == (2,)
         assert np.allclose(llval[0], np.log(a))
 
         # case x = 0.0
-        a = old_div(0.25, np.sqrt(2 * np.pi * 1.0**2))
-        a += (
-            0.25
-            / np.sqrt(2 * np.pi * 2.0**2)
-            * np.exp(-0.5 * (old_div(1.0, 2.0)) ** 2)
-        )
-        a += (
-            0.5
-            / np.sqrt(2 * np.pi * 5.0**2)
-            * np.exp(-0.5 * (old_div(2.0, 5.0)) ** 2)
-        )
+        a = 0.25 / np.sqrt(2 * np.pi * 1.0**2)
+        a += 0.25 / np.sqrt(2 * np.pi * 2.0**2) * np.exp(-0.5 * (0.5) ** 2)
+        a += 0.5 / np.sqrt(2 * np.pi * 5.0**2) * np.exp(-0.5 * (0.4) ** 2)
         assert np.allclose(llval[1], np.log(a))
 
     def test_lpdf_matrix_N_components(self):
@@ -180,28 +163,16 @@ class TestGMM1(unittest.TestCase):
         assert llval.shape == (3, 3)
 
         a = 0.25 / np.sqrt(2 * np.pi * 1.0**2) * np.exp(-0.5 * (1.0) ** 2)
-        a += old_div(0.25, np.sqrt(2 * np.pi * 2.0**2))
-        a += (
-            0.5
-            / np.sqrt(2 * np.pi * 5.0**2)
-            * np.exp(-0.5 * (old_div(1.0, 5.0)) ** 2)
-        )
+        a += 0.25 / np.sqrt(2 * np.pi * 2.0**2)
+        a += 0.5 / np.sqrt(2 * np.pi * 5.0**2) * np.exp(-0.5 * (0.2) ** 2)
 
         assert np.allclose(llval[0, 0], np.log(a))
         assert np.allclose(llval[1, 2], np.log(a))
 
         # case x = 0.0
-        a = old_div(0.25, np.sqrt(2 * np.pi * 1.0**2))
-        a += (
-            0.25
-            / np.sqrt(2 * np.pi * 2.0**2)
-            * np.exp(-0.5 * (old_div(1.0, 2.0)) ** 2)
-        )
-        a += (
-            0.5
-            / np.sqrt(2 * np.pi * 5.0**2)
-            * np.exp(-0.5 * (old_div(2.0, 5.0)) ** 2)
-        )
+        a = 0.25 / np.sqrt(2 * np.pi * 1.0**2)
+        a += 0.25 / np.sqrt(2 * np.pi * 2.0**2) * np.exp(-0.5 * (0.5) ** 2)
+        a += 0.5 / np.sqrt(2 * np.pi * 5.0**2) * np.exp(-0.5 * (0.4) ** 2)
 
         assert np.allclose(llval[0, 1], np.log(a))
         assert np.allclose(llval[0, 2], np.log(a))
@@ -300,7 +271,7 @@ class TestQGMM1Math(unittest.TestCase):
             high=self.high,
             q=self.q,
         )
-        samples = old_div(GMM1(rng=self.rng, size=(self.n_samples,), **gkwargs), self.q)
+        samples = GMM1(rng=self.rng, size=(self.n_samples,), **gkwargs) / self.q
         print("drew", len(samples), "samples")
         assert np.all(samples == samples.astype("int"))
         min_max = int(samples.min()), int(samples.max())
@@ -310,7 +281,7 @@ class TestQGMM1Math(unittest.TestCase):
         xcoords = np.arange(min_max[0], min_max[1] + 1) * self.q
         prob = np.exp(GMM1_lpdf(xcoords, **gkwargs))
         assert counts.sum() == self.n_samples
-        y = old_div(counts, float(self.n_samples))
+        y = counts / float(self.n_samples)
 
         if self.show:
             plt.scatter(xcoords, y, c="r", label="empirical")
@@ -471,9 +442,7 @@ class TestQLGMM1Math(unittest.TestCase):
     def work(self, **kwargs):
         self.__dict__.update(kwargs)
         self.worked = True
-        samples = old_div(
-            LGMM1(rng=self.rng, size=(self.n_samples,), **self.kwargs), self.q
-        )
+        samples = LGMM1(rng=self.rng, size=(self.n_samples,), **self.kwargs) / self.q
         # -- we've divided the LGMM1 by self.q to get ints here
         assert np.all(samples == samples.astype("int"))
         min_max = int(samples.min()), int(samples.max())
@@ -487,7 +456,7 @@ class TestQLGMM1Math(unittest.TestCase):
         print(xcoords)
         print(prob)
         assert counts.sum() == self.n_samples
-        y = old_div(counts, float(self.n_samples))
+        y = counts / float(self.n_samples)
 
         if self.show:
             plt.scatter(xcoords, y, c="r", label="empirical")

--- a/hyperopt/tpe.py
+++ b/hyperopt/tpe.py
@@ -1,7 +1,6 @@
 """
 Graphical model (GM)-based optimization algorithm using Theano
 """
-from past.utils import old_div
 import logging
 import time
 
@@ -580,7 +579,7 @@ def ap_randint_sampler(
     # -- add in some prior pseudocounts
     pseudocounts = counts + prior_weight
     random_variable = scope.randint_via_categorical(
-        old_div(pseudocounts, scope.sum(pseudocounts)), size=size, rng=rng
+        pseudocounts / scope.sum(pseudocounts), size=size, rng=rng
     )
     return random_variable
 
@@ -593,7 +592,7 @@ def tpe_cat_pseudocounts(counts, prior_weight, p, size):
         assert np.all(p == p[0])
         p = p[0]
     pseudocounts = counts + p.size * (prior_weight * p)
-    return old_div(pseudocounts, np.sum(pseudocounts))
+    return pseudocounts / np.sum(pseudocounts)
 
 
 @adaptive_parzen_sampler("categorical")

--- a/hyperopt/utils.py
+++ b/hyperopt/utils.py
@@ -1,4 +1,3 @@
-from past.builtins import basestring
 import datetime
 import numpy as np
 import logging
@@ -86,7 +85,7 @@ def json_call(json, args=(), kwargs=None):
     """
     if kwargs is None:
         kwargs = {}
-    if isinstance(json, basestring):
+    if isinstance(json, (str, bytes)):
         symbol = json_lookup(json)
         return symbol(*args, **kwargs)
     elif isinstance(json, dict):

--- a/hyperopt/utils.py
+++ b/hyperopt/utils.py
@@ -1,5 +1,4 @@
 from past.builtins import basestring
-from past.utils import old_div
 import datetime
 import numpy as np
 import logging
@@ -132,7 +131,7 @@ def pmin_sampled(mean, var, n_samples=1000, rng=None):
     winners = (samples.T == samples.min(axis=1)).T
     wincounts = winners.sum(axis=0)
     assert wincounts.shape == mean.shape
-    return old_div(wincounts.astype("float64"), wincounts.sum())
+    return wincounts.astype("float64") / wincounts.sum()
 
 
 def fast_isin(X, Y):

--- a/hyperopt/utils.py
+++ b/hyperopt/utils.py
@@ -1,4 +1,3 @@
-from future import standard_library
 from past.builtins import basestring
 from past.utils import old_div
 import datetime
@@ -11,8 +10,6 @@ import uuid
 import numpy
 from . import pyll
 from contextlib import contextmanager
-
-standard_library.install_aliases()
 
 
 def _get_random_id():

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setuptools.setup(
         "numpy>=1.17",
         "scipy",
         "networkx>=2.2",
-        "future",
         "tqdm",
         "cloudpickle",
     ],


### PR DESCRIPTION
Closes #897

Most of the instances of `old_div` clearly involved floats anyway so the `old_div` was not doing anything. There's a few instances (see https://github.com/hyperopt/hyperopt/commit/8e16cf2ffd7849f672a890163198e239ce4eca3b) where I'm guessing it's correct to replace `old_div` with `/` but I'm less confident so would be good if someone more familiar with the codebase could double check.

I've replaced `basestring` with `(str, bytes)` since that's the direct replacement but maybe some of these should be just `str`.