### PR TITLE
Patch `hp_randint()` to give an option to return an `int` instance

### DIFF
--- a/hyperopt/pyll_utils.py
+++ b/hyperopt/pyll_utils.py
@@ -73,7 +73,7 @@ def hp_choice(label, options):
 
 @validate_label
 def hp_randint(label, *args, **kwargs):
-    return scope.hyperopt_param(label, scope.randint(*args, **kwargs))
+    return scope.int(scope.hyperopt_param(label, scope.randint(*args, **kwargs)))
 
 
 @validate_label

--- a/hyperopt/pyll_utils.py
+++ b/hyperopt/pyll_utils.py
@@ -71,7 +71,7 @@ def hp_choice(label, options):
     return scope.switch(ch, *options)
 
 
-class _HyperoptRandintPatched:
+class _RandintPatched:
     def __call__(self, label, *args, **kwargs):
         return validate_label(scope.hyperopt_param)(
             label, scope.randint(*args, **kwargs)
@@ -81,7 +81,7 @@ class _HyperoptRandintPatched:
         return scope.int(self(label, *args, **kwargs))
 
 
-hp_randint = _HyperoptRandintPatched()
+hp_randint = _RandintPatched()
 
 
 @validate_label

--- a/hyperopt/pyll_utils.py
+++ b/hyperopt/pyll_utils.py
@@ -71,9 +71,15 @@ def hp_choice(label, options):
     return scope.switch(ch, *options)
 
 
-@validate_label
-def hp_randint(label, *args, **kwargs):
-    return scope.int(scope.hyperopt_param(label, scope.randint(*args, **kwargs)))
+class _HyperoptRandintPatched:
+    def __call__(self, label, *args, **kwargs):
+        return validate_label(scope.hyperopt_param)(label, scope.randint(*args, **kwargs))
+
+    def patched(self, label, *args, **kwargs):
+        return scope.int(self(label, *args, **kwargs))
+
+
+hp_randint = _HyperoptRandintPatched()
 
 
 @validate_label
@@ -244,6 +250,5 @@ def _remove_allpaths(hps, conditions):
                 if frozenset(conds) == potential_conds[depvar]:
                     v["conditions"] = {conditions}
                     continue
-
 
 # -- eof

--- a/hyperopt/pyll_utils.py
+++ b/hyperopt/pyll_utils.py
@@ -73,7 +73,9 @@ def hp_choice(label, options):
 
 class _HyperoptRandintPatched:
     def __call__(self, label, *args, **kwargs):
-        return validate_label(scope.hyperopt_param)(label, scope.randint(*args, **kwargs))
+        return validate_label(scope.hyperopt_param)(
+            label, scope.randint(*args, **kwargs)
+        )
 
     def patched(self, label, *args, **kwargs):
         return scope.int(self(label, *args, **kwargs))
@@ -250,5 +252,6 @@ def _remove_allpaths(hps, conditions):
                 if frozenset(conds) == potential_conds[depvar]:
                     v["conditions"] = {conditions}
                     continue
+
 
 # -- eof

--- a/hyperopt/tests/unit/test_pyll_utils.py
+++ b/hyperopt/tests/unit/test_pyll_utils.py
@@ -1,12 +1,12 @@
-from hyperopt import pyll_utils
-from hyperopt.pyll_utils import EQ
-from hyperopt.pyll_utils import expr_to_config
-from hyperopt import hp
-from hyperopt.pyll import as_apply
-from hyperopt.pyll.stochastic import sample
 import unittest
+
 import numpy as np
 import pytest
+
+from hyperopt import hp, pyll_utils
+from hyperopt.pyll import as_apply
+from hyperopt.pyll.stochastic import sample
+from hyperopt.pyll_utils import EQ, expr_to_config
 
 
 def test_expr_to_config():
@@ -107,6 +107,23 @@ def test_uniformint_arguments(arguments):
     rng = np.random.default_rng(np.random.PCG64(123))
     values = [sample(space, rng=rng) for _ in range(10)]
     assert values == [7, 1, 2, 2, 2, 8, 9, 3, 8, 9]
+
+
+@pytest.mark.parametrize(
+    "arguments", [["z", 0, 10], {"label": "z", "low": 0, "high": 10}]
+)
+def test_randint_patched_returns_int(arguments):
+    """
+    Test whether ``randint.patched`` returns an integer instead of numpy array.
+    Related to issue #437.
+    """
+    if isinstance(arguments, list):
+        space = hp.randint.patched(*arguments)
+    elif isinstance(arguments, dict):
+        space = hp.randint.patched(**arguments)
+    else:
+        raise ValueError("Unexpected type of 'arguments'.")
+    assert isinstance(sample(space), int)
 
 
 class TestValidateDistributionRange(unittest.TestCase):


### PR DESCRIPTION
Closes #437.

May be merged later, if a major release is required for this change.

Upd.: I addressed the backward compatibility issue, mentioned in #437, by doing such:

- Defined a class that copies an old `hp_randint` behaviour by its `__call__` method.
- Defined its instance that mimics `hp_randint` in `pyll_utils`.
- Added a method `patched` to the class that wraps `self.__call__` into `scope.int()`. The expected usage is: `hp.randint.patched(...)`
- Added a unit test for `hp.randint.patched` to return an integer