### PR TITLE
Fix the links for articles describing ATPE

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Currently three algorithms are implemented in hyperopt:
 
 - [Random Search](http://www.jmlr.org/papers/v13/bergstra12a.html?source=post_page---------------------------)
 - [Tree of Parzen Estimators (TPE)](https://papers.nips.cc/paper/4443-algorithms-for-hyper-parameter-optimization.pdf)
-- [Adaptive TPE](https://www.electricbrain.io/blog/learning-to-optimize)
+- [Adaptive TPE](https://articulon.bradleyarsenault.me/article/learning-to-optimize)
 
 Hyperopt has been designed to accommodate Bayesian optimization algorithms based on Gaussian processes and regression trees, but these are not currently implemented.
 

--- a/hyperopt/atpe.py
+++ b/hyperopt/atpe.py
@@ -1,8 +1,8 @@
 """
     Implements the ATPE algorithm. See
-    https://www.electricbrain.io/blog/learning-to-optimize
+    https://articulon.bradleyarsenault.me/article/learning-to-optimize
     and
-    https://www.electricbrain.io/blog/optimizing-optimization to learn more
+    https://articulon.bradleyarsenault.me/article/optimizing-optimization to learn more
 """
 
 __authors__ = "Bradley Arsenault"


### PR DESCRIPTION
After much haggling with the company that acquired Electric Brain, I was finally able to recover the articles that describe the research behind ATPE. And these are the final edited versions of the articles, not the crappy drafts that I had before.

Updating the links in the documentation.