### PR TITLE
Update search_spaces.md `hp.uniformint` docs

### DIFF
--- a/docs/templates/getting-started/search_spaces.md
+++ b/docs/templates/getting-started/search_spaces.md
@@ -83,10 +83,10 @@ The stochastic expressions currently recognized by hyperopt's optimization algor
   * Returns a value like round(uniform(low, high) / q) * q
   * Suitable for a discrete value with respect to which the objective is still somewhat "smooth", but which should be bounded both above and below.
 
-* `hp.quniformint(label, low, high)` or `hp.uniformint(label, low, high, q)`
-  * Returns a value like round(uniform(low, high) / q) * q
-  * The parameter `q` will always be set to `1.0`  
-  * Suitable for a discrete value with respect to which the objective is still somewhat "smooth", but which should be bounded both above and below.
+* `hp.uniformint(label, low, high)`
+  * Returns a integer value uniformly between `low` and `high`
+  * Equivalent to `hp.quniform(label, low, high, 1.0)`
+  * Suitable for a discrete integer value with respect to which the objective is still somewhat "smooth", but which should be bounded both above and below.
 
 * `hp.loguniform(label, low, high)`
   * Returns a value drawn according to exp(uniform(low, high)) so that the logarithm of the return value is uniformly distributed.


### PR DESCRIPTION
**Problem**
- `hp.quniformint` is not a function so should not be in the docs
- `hp.uniformint` signature in the docs is incorrect

**Solution**
Per this [PR](https://github.com/hyperopt/hyperopt/pull/260) which added `hp.uniformint` and the current [signature](https://github.com/hyperopt/hyperopt/blob/d8515263a3168ba8f111179d29e74ffb09670610/hyperopt/pyll_utils.py#L86), update the docs to reflect this and remove the non-existent `hp.quniformint`
