### PR TITLE
Converting randint in native integer (as it's already done with uniform and native float)

### DIFF
--- a/hyperopt/pyll_utils.py
+++ b/hyperopt/pyll_utils.py
@@ -73,7 +73,7 @@ def hp_choice(label, options):
 
 @validate_label
 def hp_randint(label, *args, **kwargs):
-    return scope.hyperopt_param(label, scope.randint(*args, **kwargs))
+    return scope.int(scope.hyperopt_param(label, scope.randint(*args, **kwargs)))
 
 
 @validate_label


### PR DESCRIPTION
While saving the generated parameters of my optimization in a json I was getting:  
>  UserWarning: Object of type int64 is not JSON serializable

I saw it was from a parameter generated using `randint`.
In the sources, I noticed that the result of `uniform` has a final `scope.float` to convert the resulting np.float64 into native float. So I said "hey let's do the same with `randint`" !

And that's what's this PR is all about :-) 