### PR TITLE
Faster GMM1_lpdf

### DIFF
--- a/hyperopt/tpe.py
+++ b/hyperopt/tpe.py
@@ -159,8 +159,7 @@ def GMM1_lpdf(samples, weights, mus, sigmas, low=None, high=None, q=None):
         else:
             lbound = np.maximum(samples[..., None] - q / 2, low)
 
-        # ubound/lbound: (N, D, 1), mus/sigmas: (D,)
-        # Broadcast to (N, D, D)
+        # ubound/lbound: (N, D, 1), mus/sigmas: (D,), broadcast to (N, D, D)
         cdf_ub = normal_cdf(ubound, mus, sigmas)
         cdf_lb = normal_cdf(lbound, mus, sigmas)
         inc_amt = weights * (cdf_ub - cdf_lb)  # (N, D, D)

--- a/hyperopt/tpe.py
+++ b/hyperopt/tpe.py
@@ -98,6 +98,7 @@ def GMM1(weights, mus, sigmas, low=None, high=None, q=None, rng=None, size=()):
 
 
 @scope.define
+
 def normal_cdf(x, mu, sigma):
     top = x - mu
     bottom = np.maximum(np.sqrt(2) * sigma, EPS)
@@ -151,19 +152,19 @@ def GMM1_lpdf(samples, weights, mus, sigmas, low=None, high=None, q=None):
         rval = logsum_rows(-0.5 * mahal + np.log(coef))
     else:
         if high is None:
-            ubound = samples[..., None] + q / 2
+            ubound = samples[..., np.newaxis] + q / 2
         else:
-            ubound = np.minimum(samples[..., None] + q / 2, high)
+            ubound = np.minimum(samples[..., np.newaxis] + q / 2, high)
         if low is None:
-            lbound = samples[..., None] - q / 2
+            lbound = samples[..., np.newaxis] - q / 2
         else:
-            lbound = np.maximum(samples[..., None] - q / 2, low)
+            lbound = np.maximum(samples[..., np.newaxis] - q / 2, low)
 
         # ubound/lbound: (N, D, 1), mus/sigmas: (D,), broadcast to (N, D, D)
         cdf_ub = normal_cdf(ubound, mus, sigmas)
         cdf_lb = normal_cdf(lbound, mus, sigmas)
         inc_amt = weights * (cdf_ub - cdf_lb)  # (N, D, D)
-        # Sum over last axis (mixture components)
+
         prob = np.sum(inc_amt, axis=-1)
         rval = np.log(prob) - np.log(p_accept)
 

--- a/hyperopt/tpe.py
+++ b/hyperopt/tpe.py
@@ -98,7 +98,6 @@ def GMM1(weights, mus, sigmas, low=None, high=None, q=None, rng=None, size=()):
 
 
 @scope.define
-
 def normal_cdf(x, mu, sigma):
     top = x - mu
     bottom = np.maximum(np.sqrt(2) * sigma, EPS)


### PR DESCRIPTION
Hi there,

While running hyperopt in Ray Tune with large number of samples, I noticed that performance was dropping quite fast after a few hundreds of them.

I did some profiling using `cProfile` and noticed that `GMM1_lpdf` had a important total time of execution. See below an example of profiling results sorted by total time

![image](https://github.com/user-attachments/assets/caae6550-241d-4d18-b39d-be2547de54fb)

2 things to notice:
- `GMM1_lpdf` total time is large
- `normal_cdf` total time is large too, and its number of calls is quite important.

Looking at `GMM1_lpdf` code, the code block that calls `normal_cdf` most is the following: 

https://github.com/hyperopt/hyperopt/blob/0658f680c84a313eaffe1771a20dfe2ebabd7fd4/hyperopt/tpe.py#L153-L166

Several observations here:
- variables `lbound` and `ubound` don't depend on for loop parameters
- calls to `normal_cdf` depends on length of given arrays, which grows with number of samples.

After analyzing the impact, I drafted a "vectorized" version of the code, which doesn't rely on for loop anymore but executes the computation in one pass.

Tests are passing, and I've been able to validate the results with in-house experiments too. 

Feedback appreciated!