### PR TITLE
Convert hp.choice to native integer.

### DIFF
--- a/hyperopt/pyll_utils.py
+++ b/hyperopt/pyll_utils.py
@@ -67,7 +67,7 @@ def hp_pchoice(label, p_options):
 
 @validate_label
 def hp_choice(label, options):
-    ch = scope.hyperopt_param(label, scope.randint(len(options)))
+    ch = scope.int(scope.hyperopt_param(label, scope.randint(len(options))))
     return scope.switch(ch, *options)
 
 


### PR DESCRIPTION
Similar to https://github.com/hyperopt/hyperopt/commit/0658f680c84a313eaffe1771a20dfe2ebabd7fd4,  before I got exceptions for switch getting np.uint(0).