### PR TITLE
fix: handle numpy.int64 scalar in switch node eval (fixes #949)

### DIFF
--- a/hyperopt/pyll/base.py
+++ b/hyperopt/pyll/base.py
@@ -856,6 +856,8 @@ def rec_eval(
                 switch_i = memo[switch_i_var]
                 if isinstance(switch_i, np.ndarray):
                     switch_i = switch_i.item()
+                if isinstance(switch_i, np.integer):
+                    switch_i = int(switch_i)
                 if isinstance(switch_i, int):
                     if switch_i < 0:
                         raise ValueError("switch pos must be positive int", switch_i)


### PR DESCRIPTION
## Summary

Fixes #949.

`numpy.int64` is not a subclass of Python `int` since numpy 1.20 ([numpy 1.20 release notes](https://numpy.org/doc/stable/release/1.20.0-notes.html#deprecations)), so the bare `isinstance(switch_i, int)` check in the `switch` node evaluator raises `TypeError` when the sampled index is a bare numpy integer scalar:

```
TypeError: ('switch argument was', 0)
  File "hyperopt/pyll/base.py", line 863, in rec_eval
    raise TypeError("switch argument was", switch_i)
```

The existing `np.ndarray` guard only handles zero-dimensional arrays via `.item()`. Bare `np.integer` scalars (which is what the TPE sampler returns) bypass it entirely.

## Fix

Add an explicit `np.integer` guard immediately after the `np.ndarray` check, coercing the scalar to a Python `int` before the existing `isinstance(switch_i, int)` check:

```python
# Before:
if isinstance(switch_i, np.ndarray):
    switch_i = switch_i.item()
if isinstance(switch_i, int):

# After:
if isinstance(switch_i, np.ndarray):
    switch_i = switch_i.item()
if isinstance(switch_i, np.integer):
    switch_i = int(switch_i)
if isinstance(switch_i, int):
```

`np.integer` is the stable abstract base class for all numpy integer scalar types (`np.int64`, `np.int32`, etc.) and has been available across all numpy versions. No behavioral change for environments where this bug is not triggered.