### PR TITLE
fix: honor explicit progress controls independently of verbose

### DIFF
--- a/hyperopt/base.py
+++ b/hyperopt/base.py
@@ -638,7 +638,7 @@ class Trials:
         pass_expr_memo_ctrl=None,
         catch_eval_exceptions=False,
         return_argmin=True,
-        show_progressbar=True,
+        show_progressbar=None,
         early_stop_fn=None,
         trials_save_file="",
     ):
@@ -656,8 +656,10 @@ class Trials:
             error jobs (JOB_STATE_ERROR).  If set to False, such exceptions
             will not be caught, and so they will propagate to calling code.
 
-        show_progressbar : bool or context manager, default True.
-            Show a progressbar. See `hyperopt.progress` for customizing progress reporting.
+        show_progressbar : None, bool or context-manager factory, default None
+            Show a progress bar. When None, this follows the value of `verbose`.
+            A custom factory must accept `initial` and `total` keyword arguments.
+            See `hyperopt.progress` for customizing progress reporting.
 
         """
         # -- Stop-gap implementation!

--- a/hyperopt/fmin.py
+++ b/hyperopt/fmin.py
@@ -124,14 +124,16 @@ class FMinIter:
         timeout=None,
         loss_threshold=None,
         verbose=False,
-        show_progressbar=True,
+        show_progressbar=None,
         early_stop_fn=None,
         trials_save_file="",
     ):
         self.algo = algo
         self.domain = domain
         self.trials = trials
-        if not show_progressbar or not verbose:
+        if show_progressbar is None:
+            show_progressbar = verbose
+        if not show_progressbar:
             self.progress_callback = progress.no_progress_callback
         elif show_progressbar is True:
             self.progress_callback = progress.default_callback
@@ -377,7 +379,7 @@ def fmin(
     return_argmin=True,
     points_to_evaluate=None,
     max_queue_len=1,
-    show_progressbar=True,
+    show_progressbar=None,
     early_stop_fn=None,
     trials_save_file="",
 ):
@@ -445,8 +447,8 @@ def fmin(
         string, otherwise np.random is used in whatever state it is in.
 
     verbose : bool
-        Print out some information to stdout during search. If False, disable
-            progress bar irrespectively of show_progressbar argument
+        Print out some information to stdout during search. By default, setting
+        this to False also disables the progress bar.
 
     allow_trials_fmin : bool, default True
         If the `trials` argument
@@ -476,8 +478,10 @@ def fmin(
         value helps to slightly speed up parallel simulatulations which sometimes lag
         on suggesting a new trial.
 
-    show_progressbar : bool or context manager, default True (or False if verbose is False).
-        Show a progressbar. See `hyperopt.progress` for customizing progress reporting.
+    show_progressbar : None, bool or context-manager factory, default None
+        Show a progress bar. When None, this follows the value of `verbose`.
+        A custom factory must accept `initial` and `total` keyword arguments.
+        See `hyperopt.progress` for customizing progress reporting.
 
     early_stop_fn: callable ((result, *args) -> (Boolean, *args)).
         Called after every run with the result of the run and the values returned by the function previously.
@@ -530,6 +534,9 @@ def fmin(
 
         # Change fn to accept a dict-like argument
         fn = __objective_fmin_wrapper(fn)
+
+    if show_progressbar is None:
+        show_progressbar = verbose
 
     if allow_trials_fmin and hasattr(trials, "fmin"):
         return trials.fmin(

--- a/hyperopt/tests/unit/test_progress.py
+++ b/hyperopt/tests/unit/test_progress.py
@@ -1,5 +1,10 @@
+import contextlib
 import sys
 
+import numpy as np
+
+from hyperopt import Trials, fmin, hp, progress, rand
+from hyperopt.fmin import FMinIter
 from hyperopt.progress import tqdm_progress_callback
 
 
@@ -10,3 +15,148 @@ def test_tqdm_progress_callback_restores_stdout():
         ctx.postfix = "best loss: 4711"
         ctx.update(42)
     assert sys.stdout == real_stdout
+
+
+def test_fmin_iter_progress_callback_selection():
+    @contextlib.contextmanager
+    def custom_progress_callback(initial, total):
+        yield
+
+    def make_fmin_iter(*, verbose=False, **kwargs):
+        return FMinIter(
+            algo=None,
+            domain=None,
+            trials=Trials(),
+            rstate=np.random.default_rng(0),
+            verbose=verbose,
+            **kwargs,
+        )
+
+    assert make_fmin_iter().progress_callback is progress.no_progress_callback
+    assert make_fmin_iter(verbose=True).progress_callback is progress.default_callback
+
+    cases = [
+        (None, progress.no_progress_callback),
+        (False, progress.no_progress_callback),
+        (True, progress.default_callback),
+        (custom_progress_callback, custom_progress_callback),
+    ]
+    for show_progressbar, expected_callback in cases:
+        assert (
+            make_fmin_iter(show_progressbar=show_progressbar).progress_callback
+            is expected_callback
+        )
+
+
+def test_trials_progress_callback_selection(monkeypatch):
+    calls = []
+    omitted = object()
+
+    def make_progress_callback(name):
+        @contextlib.contextmanager
+        def progress_callback(initial, total):
+            calls.append(name)
+            yield
+
+        return progress_callback
+
+    default_progress_callback = make_progress_callback("default")
+    no_progress_callback = make_progress_callback("disabled")
+    custom_progress_callback = make_progress_callback("custom")
+    monkeypatch.setattr(progress, "default_callback", default_progress_callback)
+    monkeypatch.setattr(progress, "no_progress_callback", no_progress_callback)
+
+    def run_trials(*, verbose=False, show_progressbar=omitted):
+        calls.clear()
+        progress_kwargs = {}
+        if show_progressbar is not omitted:
+            progress_kwargs["show_progressbar"] = show_progressbar
+        Trials().fmin(
+            fn=lambda value: value,
+            space=hp.uniform("value", 0, 1),
+            algo=rand.suggest,
+            max_evals=0,
+            return_argmin=False,
+            verbose=verbose,
+            **progress_kwargs,
+        )
+        return list(calls)
+
+    assert run_trials() == ["disabled"]
+    assert run_trials(show_progressbar=None) == ["disabled"]
+    assert run_trials(verbose=True, show_progressbar=None) == ["default"]
+    assert run_trials(show_progressbar=False) == ["disabled"]
+    assert run_trials(show_progressbar=True) == ["default"]
+    assert run_trials(show_progressbar=custom_progress_callback) == ["custom"]
+
+
+def test_custom_progress_callback_contract():
+    events = []
+
+    class ProgressContext:
+        @property
+        def postfix(self):
+            raise AssertionError("postfix is write-only in this test")
+
+        @postfix.setter
+        def postfix(self, value):
+            events.append(("postfix", value))
+
+        def update(self, value):
+            events.append(("update", value))
+
+    @contextlib.contextmanager
+    def custom_progress_callback(initial, total):
+        events.append(("enter", initial, total))
+        try:
+            yield ProgressContext()
+        finally:
+            events.append(("exit",))
+
+    fmin(
+        fn=lambda value: 0.0,
+        space=hp.uniform("value", 0, 1),
+        algo=rand.suggest,
+        max_evals=1,
+        rstate=np.random.default_rng(0),
+        verbose=False,
+        show_progressbar=custom_progress_callback,
+    )
+
+    assert events == [
+        ("enter", 0, 1),
+        ("postfix", "best loss: 0.0"),
+        ("update", 1),
+        ("exit",),
+    ]
+
+
+def test_fmin_resolves_progress_before_custom_trials_dispatch():
+    class CustomTrials:
+        def fmin(self, *args, **kwargs):
+            self.show_progressbar = kwargs["show_progressbar"]
+
+    @contextlib.contextmanager
+    def custom_progress_callback(initial, total):
+        yield
+
+    def dispatch(*, verbose, **kwargs):
+        trials = CustomTrials()
+        fmin(
+            fn=lambda value: value,
+            space=hp.uniform("value", 0, 1),
+            trials=trials,
+            verbose=verbose,
+            **kwargs,
+        )
+        return trials.show_progressbar
+
+    assert dispatch(verbose=False) is False
+    assert dispatch(verbose=True) is True
+    assert dispatch(verbose=False, show_progressbar=None) is False
+    assert dispatch(verbose=False, show_progressbar=False) is False
+    assert dispatch(verbose=False, show_progressbar=True) is True
+    assert (
+        dispatch(verbose=False, show_progressbar=custom_progress_callback)
+        is custom_progress_callback
+    )


### PR DESCRIPTION
Fixes #937

## The problem

`verbose` and `show_progressbar` are documented as separate controls, but `FMinIter` combined them:

```python
if not show_progressbar or not verbose:
    self.progress_callback = progress.no_progress_callback
```

Because `show_progressbar` defaulted to `True`, `verbose=False` won that `and` every time. Anyone who asked for a progress bar explicitly — or supplied a custom callback factory — got silence, with nothing in the output to explain why:

```python
# Before: no progress bar, despite asking for one.
fmin(objective, space, algo=tpe.suggest, max_evals=100,
     verbose=False, show_progressbar=True)

# Same for a custom reporter.
fmin(objective, space, algo=tpe.suggest, max_evals=100,
     verbose=False, show_progressbar=my_progress_factory)
```

The existing docstring already conceded the coupling ("If False, disable progress bar irrespectively of show_progressbar argument"), so the only way to combine quiet logging with a progress bar was to not use `verbose` at all.

## The fix

`show_progressbar` becomes tri-state, with `None` as the new default:

| value | behavior |
| --- | --- |
| `None` (default) | follows `verbose` — unchanged from today |
| `True` / `False` | authoritative, regardless of `verbose` |
| context-manager factory | authoritative, regardless of `verbose` |

`FMinIter` resolves `None` to `verbose` before the existing dispatch, so the only condition left to check is the caller's actual intent.

## Backward compatibility

The historical behavior is what `None` now means, so **no existing call changes**:

- `fmin(..., verbose=False)` → still no progress bar.
- `fmin(..., verbose=True)` → still a progress bar.
- Passing `show_progressbar` explicitly now does what its name says.

`None` is normalized in `fmin` *before* dispatching to a custom `Trials.fmin`, so the new sentinel never reaches duck-typed `Trials` implementations outside this repo that only understand a bool. That normalization is the reason the change touches `base.py` as well — `Trials.fmin`'s signature default had to move in step with the public one.

## Docs

`fmin`, `FMinIter`, and `Trials.fmin` now state the `None` default and spell out the `initial` / `total` keyword contract a custom factory has to satisfy, which was previously only discoverable by reading `hyperopt/progress.py`.

## Tests

`hyperopt/tests/unit/test_progress.py` gains coverage for the omitted default, explicit `True` under `verbose=False`, explicit `False` under `verbose=True`, a custom factory under `verbose=False`, and the custom-`Trials` dispatch path that must never see `None`.

## Verification

| check | result |
| --- | --- |
| `uv run pre-commit run --all-files` | pass |
| `uv run pytest hyperopt/tests/unit/test_fmin.py hyperopt/tests/unit/test_progress.py -q` | 24 passed |
| `PYSPARK_PIN_THREAD=true uv run pytest` | 343 passed, 36 skipped |
| `PYSPARK_PIN_THREAD=false uv run pytest hyperopt/tests/integration/test_spark.py -q` | 16 passed, 1 skipped |

Not covered locally: other Python versions and platform matrices — left to CI.
